### PR TITLE
Fix ReCap (.rcs/.rcp) import transforms and add compatibility mode

### DIFF
--- a/include/io/imports/RcsFileReader.h
+++ b/include/io/imports/RcsFileReader.h
@@ -13,8 +13,14 @@ using Autodesk::RealityComputing::Data::RCScan;
 
 class RcsFileReader : public IScanFileReader
 {
-
 public:
+    enum class ImportTransformMode
+    {
+        Auto,
+        PointsAreGlobal,
+        PointsAreLocal,
+    };
+
     static bool getReader(const std::filesystem::path& filepath, std::wstring log, IScanFileReader** reader);
     RcsFileReader(RCSharedPtr<RCScan> rcScan);
     ~RcsFileReader();
@@ -44,6 +50,9 @@ private:
     tls::FileHeader m_fileHeader;
     tls::ScanHeader m_scanHeader;
     TransformationModule transfo_;
+
+    ImportTransformMode m_importTransformMode = ImportTransformMode::Auto;
+    bool m_applyInverseTransform = true;
 };
 
 #endif


### PR DESCRIPTION
### Motivation
- ReCap imports could lose scan pose because transform metadata from the SDK was not propagated to the scan header, making scans appear at the origin.
- Different ReCap files may store point coordinates as either local or already-global, so imports need a way to handle both behaviors reliably.
- The importer should honor visibility settings and report the correct total point count.

### Description
- Add `ImportTransformMode` enum and fields `m_importTransformMode` / `m_applyInverseTransform` to `RcsFileReader` and expose configuration via the `OPENSCANTOOLS_RCS_IMPORT_MODE` environment variable (`auto|global|local`).
- Propagate the ReCap `RCTransform` into `m_scanHeader.transfo` (quaternion + translation) and set `m_pointCount` from the scan's reported point count.
- Replace the previous unconditional transform reset/assumption in `startReadingScan` with explicit logic that: honors the env override, or in `auto` mode samples points to heuristically decide whether to apply the inverse transform.
- Apply the inverse transform conditionally in `readPoints`, and use `m_visiblePointsOnly` when creating point iterators.

### Testing
- Ran `git diff --check` and no issues were reported.
- Attempted a build (`cmake --build`) but no build directory was present in this environment, so a full compile could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b29480990832fb13ab8acd2dc84d9)