### PR TITLE
Fix ReCap export transforms and add RCS import compatibility mode

### DIFF
--- a/include/io/imports/RcsFileReader.h
+++ b/include/io/imports/RcsFileReader.h
@@ -13,8 +13,14 @@ using Autodesk::RealityComputing::Data::RCScan;
 
 class RcsFileReader : public IScanFileReader
 {
-
 public:
+    enum class ImportTransformMode
+    {
+        Auto,
+        PointsAreGlobal,
+        PointsAreLocal,
+    };
+
     static bool getReader(const std::filesystem::path& filepath, std::wstring log, IScanFileReader** reader);
     RcsFileReader(RCSharedPtr<RCScan> rcScan);
     ~RcsFileReader();
@@ -44,6 +50,9 @@ private:
     tls::FileHeader m_fileHeader;
     tls::ScanHeader m_scanHeader;
     TransformationModule transfo_;
+
+    ImportTransformMode m_importTransformMode = ImportTransformMode::Auto;
+    bool m_applyInverseTransform = true;
 };
 
 #endif


### PR DESCRIPTION
### Motivation
- Ensure ReCap export preserves the scan pose in metadata rather than baking transforms into point coordinates, avoiding incorrect round-trip placement.
- Allow import to reliably handle ReCap files that store points either in local or already-global coordinates by providing an automatic compatibility mode and an override.
- Respect visibility settings and keep accurate point counts reported by readers/writers.

### Description
- RCP export: persist the destination scan transform passed to `appendPointCloud(...)`, mirror it into `m_scanHeader.transfo`, and initialize `total_point_count_` in the constructor; points are encoded in destination-local coordinates using `inv(scan_transfo) * src_transfo` in `mergePoints` so the scan pose is represented by metadata. (changes in `src/io/exports/RcpFileWriter.cpp`).
- RCP export: apply `post_translation_` to the metadata transform at finalize time and populate `RCScanMetadata::globalTransformation` from the effective transform so "restore original coordinates" behavior remains coherent. (changes in `src/io/exports/RcpFileWriter.cpp`).
- RCS import: add `ImportTransformMode` enum and runtime-configurable `m_importTransformMode` / `m_applyInverseTransform`, with parsing from environment variable `OPENSCANTOOLS_RCS_IMPORT_MODE` (`auto|global|local`). (changes in `include/io/imports/RcsFileReader.h` and `src/io/imports/RcsFileReader.cpp`).
- RCS import: implement `auto` compatibility mode that samples points (up to 128) to heuristically decide whether to apply the inverse transform, honor `m_visiblePointsOnly` when creating iterators, and set the stored TLS scan transform from the ReCap `RCTransform`. (changes in `src/io/imports/RcsFileReader.cpp`).

### Testing
- Ran `git diff --check` and no whitespace or diff-check issues were reported (success).
- Attempted an in-environment build with `if [ -d build ]; then cmake --build build -j2; else echo 'no build directory'; fi` which reported `no build directory`, so a full compile was not executed here (no build performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b29480990832fb13ab8acd2dc84d9)