### PR TITLE
Fix double-click finalization: add `Validate` action and ignore redundant left-release

### DIFF
--- a/include/gui/viewport/VulkanViewport.h
+++ b/include/gui/viewport/VulkanViewport.h
@@ -109,6 +109,7 @@ public:
         None,
         DoubleClick,
         Click,
+        Validate,
         Examine,
         BeginManipulation,
         EndManipulation
@@ -182,6 +183,7 @@ protected:
     void onQuitEvent(IGuiData* data);
     void onRenderDecimationOptions(IGuiData* data);
 	void onRenderOctreePrecision(IGuiData* data);
+    void onActivatedFunctions(IGuiData* data);
 
 private:
     void initSurface();
@@ -229,6 +231,8 @@ private:
     PickingManager m_pickingManager;
     Action m_actionToPull;
     bool m_forceObjectCenterOnExamine = false;
+    bool m_isDoubleClickExamineBlocked = false;
+    bool m_ignoreNextLeftReleaseClick = false;
 
     // Window state
     bool m_initialized;

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -1,5 +1,6 @@
 #include "gui/viewport/VulkanViewport.h"
 #include "controller/controls/ControlPicking.h"
+#include "controller/controls/ControlFunction.h"
 #include "controller/controls/ControlViewport.h"
 
 #include "gui/GuiData/GuiDataRendering.h"
@@ -22,6 +23,66 @@
 
 #include <QtGui/qevent.h>
 #include <QApplication.h>
+
+namespace
+{
+    bool blockExamineOnDoubleClick(ContextType contextType)
+    {
+        switch (contextType)
+        {
+        case ContextType::tagCreation:
+        case ContextType::tagDuplication:
+        case ContextType::tagMove:
+        case ContextType::tagDeletion:
+        case ContextType::beamBending:
+        case ContextType::columnTilt:
+        case ContextType::fitCylinder:
+        case ContextType::simpleMeasure:
+        case ContextType::pointsMeasure:
+        case ContextType::pointMeasure:
+        case ContextType::pointCreation:
+        case ContextType::Sphere:
+        case ContextType::Slab2Click:
+        case ContextType::Slab1Click:
+        case ContextType::ClicsSphere4:
+        case ContextType::pointToCylinder:
+        case ContextType::clippingBoxCreation:
+        case ContextType::clippingBoxAttached3Points:
+        case ContextType::clippingBoxAttached2Points:
+        case ContextType::boxDuplication:
+        case ContextType::pointCloudObjectCreation:
+        case ContextType::pointCloudObjectDuplication:
+        case ContextType::meshObjectCreation:
+        case ContextType::meshObjectDuplication:
+        case ContextType::meshDistance:
+        case ContextType::bigCylinderFit:
+        case ContextType::pointToPlane:
+        case ContextType::pointToPlane3:
+        case ContextType::cylinderToPlane:
+        case ContextType::cylinderToPlane3:
+        case ContextType::cylinderToCylinder:
+        case ContextType::experiment:
+        case ContextType::deletePoints:
+        case ContextType::multipleCylinders:
+        case ContextType::cylinder2ClickExtend:
+        case ContextType::testCylinder:
+        case ContextType::pipeDetectionConnexion:
+        case ContextType::pipePostConnexion:
+        case ContextType::beamDetection:
+        case ContextType::viewpointCreation:
+        case ContextType::viewpointUpdate:
+        case ContextType::planeConnexion:
+        case ContextType::planeDetection:
+        case ContextType::setOfPoints:
+        case ContextType::peopleRemover:
+        case ContextType::fitTorus:
+        case ContextType::trajectory:
+            return true;
+        default:
+            return false;
+        }
+    }
+}
 
 
 double calcTranslationSpeedFactor(NavigationParameters navParam)
@@ -64,6 +125,7 @@ VulkanViewport::VulkanViewport(IDataDispatcher& dataDispatcher, float guiScale)
     registerGuiDataFunction(guiDType::quitEvent, &VulkanViewport::onQuitEvent);
     registerGuiDataFunction(guiDType::renderDecimationOptions, &VulkanViewport::onRenderDecimationOptions);
 	registerGuiDataFunction(guiDType::renderOctreePrecision, &VulkanViewport::onRenderOctreePrecision);
+    registerGuiDataFunction(guiDType::activatedFunctions, &VulkanViewport::onActivatedFunctions);
 }
 
 VulkanViewport::~VulkanViewport()
@@ -169,6 +231,12 @@ void VulkanViewport::onRenderOctreePrecision(IGuiData* data)
 {
 	m_octreePrecision = static_cast<GuiDataRenderOctreePrecision*>(data)->m_precision;
 	m_refreshViewport = true;
+}
+
+void VulkanViewport::onActivatedFunctions(IGuiData* data)
+{
+    auto* functionData = static_cast<GuiDataActivatedFunctions*>(data);
+    m_isDoubleClickExamineBlocked = blockExamineOnDoubleClick(functionData->type);
 }
 
 void VulkanViewport::initSurface()
@@ -381,6 +449,9 @@ void VulkanViewport::doAction(const WritePtr<CameraNode>& wCam, SafePtr<Manipula
         case VulkanViewport::Action::Click:
             m_dataDispatcher.sendControl(new control::picking::Click(click));
             break;
+        case VulkanViewport::Action::Validate:
+            m_dataDispatcher.sendControl(new control::function::Validate());
+            break;
         case VulkanViewport::Action::Examine:
         {
             ElementType hoverType = ElementType::None;
@@ -541,6 +612,11 @@ void VulkanViewport::mouseReleaseEvent(QMouseEvent *_event)
     case Qt::LeftButton:
     {
         m_MI.leftButtonPressed = false;
+        if (m_ignoreNextLeftReleaseClick)
+        {
+            m_ignoreNextLeftReleaseClick = false;
+            break;
+        }
         if (m_mouseInputEffect == MouseInputEffect::None)
         {
             m_actionToPull = Action::Click;
@@ -578,8 +654,16 @@ void VulkanViewport::mouseDoubleClickEvent(QMouseEvent* _event)
 
     if (_event->button() == Qt::LeftButton)
     {
-        m_forceObjectCenterOnExamine = true;
-        m_actionToPull = Action::Examine;
+        if (!m_isDoubleClickExamineBlocked)
+        {
+            m_forceObjectCenterOnExamine = true;
+            m_actionToPull = Action::Examine;
+        }
+        else
+        {
+            m_ignoreNextLeftReleaseClick = true;
+            m_actionToPull = Action::Validate;
+        }
     }
     else
         m_actionToPull = Action::DoubleClick;


### PR DESCRIPTION
### Motivation
- Prevent duplicate final element creation when a left double-click is used to finish "finalize-only" functions, because the extra left-button release in the double-click sequence was being interpreted as a second click. 
- Provide an explicit way to finish/validate active functions via the viewport input pipeline so double-click behavior matches the intent of pressing Enter/Return in finalize contexts.

### Description
- Added a new action `Action::Validate` to `VulkanViewport` and dispatched it to call `control::function::Validate()` when triggered. 
- Introduced a one-shot flag `m_ignoreNextLeftReleaseClick` to consume the spurious left-button release after a double-click, and updated `mouseReleaseEvent` to respect this flag. 
- Changed `mouseDoubleClickEvent` to set `m_actionToPull = Action::Validate` and arm the ignore flag when examine is blocked, otherwise preserve the original examine behavior. 
- Hooked `onActivatedFunctions` to update `m_isDoubleClickExamineBlocked` (via `blockExamineOnDoubleClick`) so contexts that must finalize on double-click are recognized.

### Testing
- Ran `git diff --check` which produced no issues. 
- Performed static inspection of the input event flow (`mouseReleaseEvent`, `mouseDoubleClickEvent`, `doAction`) to verify the new `Validate` path and the one-shot ignore flag integrate correctly. 
- Searched the modified files to confirm all new symbols (`Action::Validate`, `m_ignoreNextLeftReleaseClick`, `control::function::Validate`) are referenced consistently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698daee92354832f9c2b707ea0cfe2e0)