### PR TITLE
Add polygonal selector toolbar and persisted selector settings scaffold

### DIFF
--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -625,6 +625,16 @@ public:
 	ColorimetricFilterSettings m_settings;
 };
 
+class GuiDataRenderPolygonalSelector : public GuiDataActiveCamera
+{
+public:
+	GuiDataRenderPolygonalSelector(const PolygonalSelectorSettings& settings, const SafePtr<CameraNode>& camera);
+	~GuiDataRenderPolygonalSelector() {};
+	virtual guiDType getType() override;
+public:
+	PolygonalSelectorSettings m_settings;
+};
+
 class GuiDataColorimetricFilterPickValue : public IGuiData
 {
 public:

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -76,6 +76,7 @@ enum class guiDType
         renderDepthLining,
         renderRampScale,
         renderColorimetricFilter,
+        renderPolygonalSelector,
         renderDisplayParameters,
         renderUpdate,
         renderGuizmo,

--- a/include/gui/toolBars/ToolBarSelector.h
+++ b/include/gui/toolBars/ToolBarSelector.h
@@ -1,0 +1,47 @@
+#ifndef TOOLBAR_SELECTOR_H
+#define TOOLBAR_SELECTOR_H
+
+#include <QtWidgets/qwidget.h>
+#include "ui_toolbar_selector.h"
+#include "gui/IPanel.h"
+#include "gui/IDataDispatcher.h"
+#include "models/3d/DisplayParameters.h"
+
+#include <unordered_map>
+
+class ToolBarSelector : public QWidget, public IPanel
+{
+    Q_OBJECT
+
+public:
+    explicit ToolBarSelector(IDataDispatcher& dataDispatcher, QWidget* parent, float guiScale);
+    void informData(IGuiData* data) override;
+
+private:
+    ~ToolBarSelector();
+
+    void onProjectLoad(IGuiData* data);
+    void onFocusViewport(IGuiData* data);
+    void onActiveCamera(IGuiData* data);
+    void onRenderSelector(IGuiData* data);
+
+    void applySettings(bool enabled);
+    void resetSettings();
+    void refreshUiFromSettings();
+
+    typedef void (ToolBarSelector::*GuiDataFunction)(IGuiData*);
+    inline void registerGuiDataFunction(guiDType type, GuiDataFunction fct)
+    {
+        m_dataDispatcher.registerObserverOnKey(this, type);
+        m_methods.insert({ type, fct });
+    }
+
+private:
+    std::unordered_map<guiDType, GuiDataFunction> m_methods;
+    Ui::toolbar_selector m_ui;
+    IDataDispatcher& m_dataDispatcher;
+    SafePtr<CameraNode> m_focusCamera;
+    PolygonalSelectorSettings m_settings;
+};
+
+#endif

--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -248,6 +248,10 @@
 #define Key_Colorimetric_Filter_Tolerance	"ColorimetricFilterTolerance"
 #define Key_Colorimetric_Filter_Colors		"ColorimetricFilterColors"
 #define Key_Colorimetric_Filter_Colors_Enabled "ColorimetricFilterColorsEnabled"
+#define Key_Polygonal_Selector "PolygonalSelector"
+#define Key_Polygonal_Selector_Enabled "PolygonalSelectorEnabled"
+#define Key_Polygonal_Selector_Show_Inside "PolygonalSelectorShowInside"
+#define Key_Polygonal_Selector_Polygons "PolygonalSelectorPolygons"
 
 #define Key_Active_Scans				"ActiveScans"
 #define Key_Active_Clippings			"ActiveClippings"

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -9,6 +9,7 @@
 
 #include <glm/glm.hpp>
 #include <array>
+#include <vector>
 
 struct ColorimetricFilterSettings
 {
@@ -17,6 +18,13 @@ struct ColorimetricFilterSettings
     float tolerance = 5.0f;
     std::array<Color32, 4> colors = { Color32(0, 0, 0), Color32(0, 0, 0), Color32(0, 0, 0), Color32(0, 0, 0) };
     std::array<bool, 4> colorsEnabled = { false, false, false, false };
+};
+
+struct PolygonalSelectorSettings
+{
+    bool enabled = false;
+    bool showInside = true;
+    std::vector<std::vector<glm::vec2>> polygons = {};
 };
 
 class DisplayParameters
@@ -73,6 +81,7 @@ public:
     bool                    m_displayAllMarkersTexts = true;
     bool                    m_displayAllMeasures = true;
     ColorimetricFilterSettings m_colorimetricFilter = {};
+    PolygonalSelectorSettings m_polygonalSelector = {};
 
     //Ortho
     bool            m_orthoGridActive = false;

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -237,6 +237,7 @@ private:
     void onRenderDepthLining(IGuiData* data);
     void onRenderRampScale(IGuiData* data);
     void onRenderColorimetricFilter(IGuiData* data);
+    void onRenderPolygonalSelector(IGuiData* data);
     void onBackgroundColor(IGuiData* data);
     void onAdjustZoomToScene(IGuiData* data);
     void onRenderCameraMoveTo(IGuiData* data);

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -61,6 +61,7 @@
 #include "gui/toolBars/ToolBarRenderTransparency.h"
 #include "gui/toolBars/ToolBarRenderEnhance.h"
 #include "gui/toolBars/ToolBarClippingGroup.h"
+#include "gui/toolBars/ToolBarSelector.h"
 #include "gui/toolBars/ToolBarMeasureShowOptions.h"
 #include "gui/toolBars/ToolBarStructureAnalysis.h"
 #include "gui/toolBars/ToolBarOthersModelsGroup.h"
@@ -338,6 +339,7 @@ Gui::Gui(Controller& controller)
 	ribbonTabContent = new RibbonTabContent();
 	ribbonTabContent->addWidget(TEXT_ATTRIBUTE, new ToolBarAttributesGroup(controller, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_BOX, new ToolBarClippingGroup(m_dataDispatcher, this, m_guiScale));
+	ribbonTabContent->addWidget(tr("Selector"), new ToolBarSelector(m_dataDispatcher, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_CLIPPING_GROUP_NAME, new ToolBarClippingParameters(m_dataDispatcher, this, m_guiScale));
     m_ribbon->addTab(TEXT_CLIPPING, ribbonTabContent);
 

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -648,6 +648,17 @@ guiDType GuiDataRenderColorimetricFilter::getType()
 	return guiDType::renderColorimetricFilter;
 }
 
+
+GuiDataRenderPolygonalSelector::GuiDataRenderPolygonalSelector(const PolygonalSelectorSettings& settings, const SafePtr<CameraNode>& camera)
+	: GuiDataActiveCamera(camera)
+	, m_settings(settings)
+{}
+
+guiDType GuiDataRenderPolygonalSelector::getType()
+{
+	return guiDType::renderPolygonalSelector;
+}
+
 GuiDataColorimetricFilterPickValue::GuiDataColorimetricFilterPickValue(const Color32& color, uint8_t intensity)
 	: m_color(color)
 	, m_intensity(intensity)

--- a/src/gui/forms/toolbar_selector.ui
+++ b/src/gui/forms/toolbar_selector.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>toolbar_selector</class>
+ <widget class="QWidget" name="toolbar_selector">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>440</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin"><number>6</number></property>
+   <property name="topMargin"><number>6</number></property>
+   <property name="rightMargin"><number>6</number></property>
+   <property name="bottomMargin"><number>6</number></property>
+   <item row="0" column="0">
+    <widget class="QToolButton" name="toolButton_polygonalSelector">
+     <property name="text"><string>Polygonal selector</string></property>
+     <property name="checkable"><bool>true</bool></property>
+     <property name="toolButtonStyle"><enum>Qt::ToolButtonTextBesideIcon</enum></property>
+     <property name="autoRaise"><bool>true</bool></property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QRadioButton" name="radioButton_showInside">
+     <property name="text"><string>Show inside</string></property>
+     <property name="checked"><bool>true</bool></property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QRadioButton" name="radioButton_showOutside">
+     <property name="text"><string>Show outside</string></property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="labelPolygonText">
+     <property name="text"><string>Polygons:</string></property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QLabel" name="label_polygonCount">
+     <property name="text"><string>0</string></property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="pushButton_apply">
+     <property name="text"><string>Apply</string></property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QPushButton" name="pushButton_deactivate">
+     <property name="text"><string>Deactivate</string></property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QPushButton" name="pushButton_reset">
+     <property name="text"><string>Reset</string></property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/toolBars/ToolBarSelector.cpp
+++ b/src/gui/toolBars/ToolBarSelector.cpp
@@ -1,0 +1,122 @@
+#include "gui/toolBars/ToolBarSelector.h"
+
+#include "gui/GuiData/GuiDataGeneralProject.h"
+#include "gui/GuiData/GuiDataRendering.h"
+#include "models/graph/CameraNode.h"
+
+ToolBarSelector::ToolBarSelector(IDataDispatcher& dataDispatcher, QWidget* parent, float guiScale)
+    : QWidget(parent)
+    , m_dataDispatcher(dataDispatcher)
+{
+    m_ui.setupUi(this);
+    setEnabled(false);
+
+    m_ui.toolButton_polygonalSelector->setIconSize(QSize(20, 20) * guiScale);
+
+    connect(m_ui.toolButton_polygonalSelector, &QToolButton::clicked, [this]()
+    {
+        applySettings(m_ui.toolButton_polygonalSelector->isChecked());
+    });
+
+    connect(m_ui.radioButton_showInside, &QRadioButton::toggled, [this](bool)
+    {
+        if (m_settings.enabled)
+            applySettings(true);
+    });
+
+    connect(m_ui.radioButton_showOutside, &QRadioButton::toggled, [this](bool)
+    {
+        if (m_settings.enabled)
+            applySettings(true);
+    });
+
+    connect(m_ui.pushButton_apply, &QPushButton::clicked, [this]() { applySettings(true); });
+    connect(m_ui.pushButton_deactivate, &QPushButton::clicked, [this]() { applySettings(false); });
+    connect(m_ui.pushButton_reset, &QPushButton::clicked, [this]() { resetSettings(); });
+
+    registerGuiDataFunction(guiDType::projectLoaded, &ToolBarSelector::onProjectLoad);
+    registerGuiDataFunction(guiDType::focusViewport, &ToolBarSelector::onFocusViewport);
+    registerGuiDataFunction(guiDType::renderActiveCamera, &ToolBarSelector::onActiveCamera);
+    registerGuiDataFunction(guiDType::renderPolygonalSelector, &ToolBarSelector::onRenderSelector);
+
+    refreshUiFromSettings();
+}
+
+ToolBarSelector::~ToolBarSelector()
+{
+    m_dataDispatcher.unregisterObserver(this);
+}
+
+void ToolBarSelector::informData(IGuiData* data)
+{
+    if (m_methods.find(data->getType()) != m_methods.end())
+    {
+        GuiDataFunction method = m_methods.at(data->getType());
+        (this->*method)(data);
+    }
+}
+
+void ToolBarSelector::onProjectLoad(IGuiData* data)
+{
+    GuiDataProjectLoaded* projectData = static_cast<GuiDataProjectLoaded*>(data);
+    setEnabled(projectData->m_isProjectLoad);
+}
+
+void ToolBarSelector::onFocusViewport(IGuiData* data)
+{
+    GuiDataFocusViewport* castData = static_cast<GuiDataFocusViewport*>(data);
+    if (castData->m_forceFocus && castData->m_camera)
+        m_focusCamera = castData->m_camera;
+}
+
+void ToolBarSelector::onActiveCamera(IGuiData* data)
+{
+    auto infos = static_cast<GuiDataCameraInfo*>(data);
+    if (infos->m_camera && !(m_focusCamera == infos->m_camera))
+        return;
+
+    ReadPtr<CameraNode> rCam = m_focusCamera.cget();
+    if (!rCam)
+        return;
+
+    m_settings = rCam->getDisplayParameters().m_polygonalSelector;
+    refreshUiFromSettings();
+}
+
+void ToolBarSelector::onRenderSelector(IGuiData* data)
+{
+    auto* selectorData = static_cast<GuiDataRenderPolygonalSelector*>(data);
+    m_settings = selectorData->m_settings;
+    refreshUiFromSettings();
+}
+
+void ToolBarSelector::applySettings(bool enabled)
+{
+    m_settings.enabled = enabled;
+    m_settings.showInside = m_ui.radioButton_showInside->isChecked();
+    refreshUiFromSettings();
+    m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, m_focusCamera), this);
+}
+
+void ToolBarSelector::resetSettings()
+{
+    m_settings = PolygonalSelectorSettings{};
+    refreshUiFromSettings();
+    m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, m_focusCamera), this);
+}
+
+void ToolBarSelector::refreshUiFromSettings()
+{
+    m_ui.toolButton_polygonalSelector->blockSignals(true);
+    m_ui.radioButton_showInside->blockSignals(true);
+    m_ui.radioButton_showOutside->blockSignals(true);
+
+    m_ui.toolButton_polygonalSelector->setChecked(m_settings.enabled);
+    m_ui.radioButton_showInside->setChecked(m_settings.showInside);
+    m_ui.radioButton_showOutside->setChecked(!m_settings.showInside);
+    m_ui.label_polygonCount->setText(QString::number(m_settings.polygons.size()));
+
+    m_ui.toolButton_polygonalSelector->blockSignals(false);
+    m_ui.radioButton_showInside->blockSignals(false);
+    m_ui.radioButton_showOutside->blockSignals(false);
+}

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -402,6 +402,19 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 		} }
 	};
 
+	json[Key_Polygonal_Selector] = {
+		{ Key_Polygonal_Selector_Enabled, params.m_polygonalSelector.enabled },
+		{ Key_Polygonal_Selector_Show_Inside, params.m_polygonalSelector.showInside },
+		{ Key_Polygonal_Selector_Polygons, nlohmann::json::array() }
+	};
+	for (const auto& polygon : params.m_polygonalSelector.polygons)
+	{
+		nlohmann::json polygonJson = nlohmann::json::array();
+		for (const auto& pt : polygon)
+			polygonJson.push_back({ pt.x, pt.y });
+		json[Key_Polygonal_Selector][Key_Polygonal_Selector_Polygons].push_back(polygonJson);
+	}
+
 	json[Key_Ortho_Grid_Active] = params.m_orthoGridActive;
 	json[Key_Ortho_Grid_Color] = { params.m_orthoGridColor.r, params.m_orthoGridColor.g, params.m_orthoGridColor.b, params.m_orthoGridColor.a };
 	json[Key_Ortho_Grid_Step] = params.m_orthoGridStep;

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -713,6 +713,31 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
         }
     }
 
+    if (json.find(Key_Polygonal_Selector) != json.end())
+    {
+        const auto& selectorJson = json.at(Key_Polygonal_Selector);
+        if (selectorJson.find(Key_Polygonal_Selector_Enabled) != selectorJson.end())
+            data.m_polygonalSelector.enabled = selectorJson.at(Key_Polygonal_Selector_Enabled).get<bool>();
+        if (selectorJson.find(Key_Polygonal_Selector_Show_Inside) != selectorJson.end())
+            data.m_polygonalSelector.showInside = selectorJson.at(Key_Polygonal_Selector_Show_Inside).get<bool>();
+        if (selectorJson.find(Key_Polygonal_Selector_Polygons) != selectorJson.end())
+        {
+            data.m_polygonalSelector.polygons.clear();
+            const auto& polygons = selectorJson.at(Key_Polygonal_Selector_Polygons);
+            for (const auto& polygon : polygons)
+            {
+                std::vector<glm::vec2> pts;
+                for (const auto& point : polygon)
+                {
+                    if (point.size() >= 2)
+                        pts.emplace_back(point.at(0).get<float>(), point.at(1).get<float>());
+                }
+                if (!pts.empty())
+                    data.m_polygonalSelector.polygons.push_back(std::move(pts));
+            }
+        }
+    }
+
     if (json.find(Key_Marker_Rendering_Parameters) != json.end())
     {
         nlohmann::json options = json.at(Key_Marker_Rendering_Parameters);

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -69,6 +69,7 @@ CameraNode::CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher
     registerGuiDataFunction(guiDType::renderDepthLining, &CameraNode::onRenderDepthLining);
     registerGuiDataFunction(guiDType::renderRampScale, &CameraNode::onRenderRampScale);
     registerGuiDataFunction(guiDType::renderColorimetricFilter, &CameraNode::onRenderColorimetricFilter);
+    registerGuiDataFunction(guiDType::renderPolygonalSelector, &CameraNode::onRenderPolygonalSelector);
     registerGuiDataFunction(guiDType::renderFovValueChanged, &CameraNode::onRenderFov);
     registerGuiDataFunction(guiDType::renderExamine, &CameraNode::onRenderExamine);
     registerGuiDataFunction(guiDType::examineOptions, &CameraNode::onExamineOptions);
@@ -1552,6 +1553,13 @@ void CameraNode::onRenderColorimetricFilter(IGuiData* data)
 {
     auto castData = static_cast<GuiDataRenderColorimetricFilter*>(data);
     m_colorimetricFilter = castData->m_settings;
+    sendNewUIViewPoint();
+}
+
+void CameraNode::onRenderPolygonalSelector(IGuiData* data)
+{
+    auto castData = static_cast<GuiDataRenderPolygonalSelector*>(data);
+    m_polygonalSelector = castData->m_settings;
     sendNewUIViewPoint();
 }
 


### PR DESCRIPTION
### Motivation

- Provide UI/data/persistence plumbing to allow storing and exchanging polygonal selector settings (enabled, showInside, polygons) with camera/viewpoint display parameters so a future polygon-drawing/clipping feature can persist and synchronize state.

### Description

- Add `PolygonalSelectorSettings` to `DisplayParameters` and expose it as `m_polygonalSelector` so selector state is part of rendering parameters (`include/models/3d/DisplayParameters.h`).
- Add serializer keys and persistence logic in `DataSerializer.cpp` and `DataDeserializer.cpp` so selector state is exported/imported per viewpoint (`include/io/SerializerKeys.h`, `src/io/exports/DataSerializer.cpp`, `src/io/imports/DataDeserializer.cpp`).
- Introduce a new GUI data channel `guiDType::renderPolygonalSelector` and message `GuiDataRenderPolygonalSelector` to propagate selector updates between UI and rendering (`include/gui/GuiData/IGuiData.h`, `include/gui/GuiData/GuiDataRendering.h`, `src/gui/GuiData/GuiDataRendering.cpp`).
- Wire `CameraNode` to observe and store incoming selector settings via `onRenderPolygonalSelector` and register the handler (`include/models/graph/CameraNode.h`, `src/models/graph/CameraNode.cpp`).
- Add a scaffold toolbar `ToolBarSelector` with UI form `toolbar_selector.ui` and implementation to control selector activation, inside/outside mode, apply/deactivate/reset and show polygon count, and integrate it into the Clipping ribbon (`include/gui/toolBars/ToolBarSelector.h`, `src/gui/toolBars/ToolBarSelector.cpp`, `src/gui/forms/toolbar_selector.ui`, `src/gui/Gui.cpp`).

### Testing

- Ran `git diff --check` and it returned no whitespace/format issues (success).  
- Ran `git status --short` to validate working tree state after changes and commit (success).  
- Searched repository with `rg -n "renderPolygonalSelector|GuiDataRenderPolygonalSelector|PolygonalSelector" include src` to verify new symbols and wiring are present (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de5f164ac832fbd52525258e2b9d6)