### PR TITLE
Register and integrate Polygonal Selector (context, toolbar, GUI data)

### DIFF
--- a/include/controller/controls/ControlFunctionClipping.h
+++ b/include/controller/controls/ControlFunctionClipping.h
@@ -99,6 +99,15 @@ namespace control::function::clipping
 		ControlType getType() const override;
 	};
 
+	class ActivatePolygonalSelector : public AControl
+	{
+	public:
+		ActivatePolygonalSelector();
+		~ActivatePolygonalSelector();
+		void doFunction(Controller& controller) override;
+		ControlType getType() const override;
+	};
+
 }
 
 #endif // !CONTROL_FUNCTION_TAG_H_

--- a/include/controller/controls/IControl.h
+++ b/include/controller/controls/IControl.h
@@ -211,6 +211,7 @@ enum class ControlType
 	setDefaultOffsetFunctionClipping,
 	activateDuplicateFunctionClipping,
 	setClippingAlignementValue,
+	activatePolygonalSelector,
 
 	// control::duplication
 	setDefaultDuplicationModeFunction,

--- a/include/controller/functionSystem/AContext.h
+++ b/include/controller/functionSystem/AContext.h
@@ -46,6 +46,7 @@ enum class ContextType
 	clippingBoxCreation,
 	clippingBoxAttached3Points,
 	clippingBoxAttached2Points,
+	polygonalSelector,
 	boxDuplication,
 	pointCloudObjectCreation,
 	pointCloudObjectDuplication,

--- a/include/controller/functionSystem/ContextPolygonalSelector.h
+++ b/include/controller/functionSystem/ContextPolygonalSelector.h
@@ -1,0 +1,27 @@
+#ifndef CONTEXT_POLYGONAL_SELECTOR_H
+#define CONTEXT_POLYGONAL_SELECTOR_H
+
+#include "controller/functionSystem/AContext.h"
+#include "models/3d/DisplayParameters.h"
+#include <vector>
+
+class ContextPolygonalSelector : public AContext
+{
+public:
+    ContextPolygonalSelector(const ContextId& id);
+    ~ContextPolygonalSelector();
+
+    ContextState start(Controller& controller) override;
+    ContextState feedMessage(IMessage* message, Controller& controller) override;
+    ContextState launch(Controller& controller) override;
+    ContextState abort(Controller& controller) override;
+    ContextState validate(Controller& controller) override;
+    bool canAutoRelaunch() const override;
+    ContextType getType() const override;
+
+private:
+    std::vector<glm::vec2> m_currentVertices;
+    PolygonalSelectorSettings m_settings;
+};
+
+#endif

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -625,6 +625,16 @@ public:
 	ColorimetricFilterSettings m_settings;
 };
 
+class GuiDataRenderPolygonalSelector : public GuiDataActiveCamera
+{
+public:
+	GuiDataRenderPolygonalSelector(const PolygonalSelectorSettings& settings, const SafePtr<CameraNode>& camera);
+	~GuiDataRenderPolygonalSelector() {};
+	virtual guiDType getType() override;
+public:
+	PolygonalSelectorSettings m_settings;
+};
+
 class GuiDataColorimetricFilterPickValue : public IGuiData
 {
 public:

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -76,6 +76,7 @@ enum class guiDType
         renderDepthLining,
         renderRampScale,
         renderColorimetricFilter,
+        renderPolygonalSelector,
         renderDisplayParameters,
         renderUpdate,
         renderGuizmo,

--- a/include/gui/toolBars/ToolBarPolygonalSelector.h
+++ b/include/gui/toolBars/ToolBarPolygonalSelector.h
@@ -1,0 +1,38 @@
+#ifndef TOOLBAR_POLYGONAL_SELECTOR_H
+#define TOOLBAR_POLYGONAL_SELECTOR_H
+
+#include "ui_toolbar_selector.h"
+#include "gui/IPanel.h"
+#include "gui/IDataDispatcher.h"
+#include "models/3d/DisplayParameters.h"
+
+#include <unordered_map>
+
+class ToolBarPolygonalSelector : public QWidget, public IPanel
+{
+    Q_OBJECT
+
+public:
+    explicit ToolBarPolygonalSelector(IDataDispatcher& dataDispatcher, QWidget* parent = nullptr, float guiScale = 1.f);
+    ~ToolBarPolygonalSelector();
+
+private:
+    void informData(IGuiData* data) override;
+    void onProjectLoad(IGuiData* data);
+    void onActivatedFunctions(IGuiData* data);
+    void onRenderSettings(IGuiData* data);
+
+    void activateSelector();
+    void applySettings(bool enabled);
+    void resetSettings();
+
+private:
+    typedef void (ToolBarPolygonalSelector::*GuiDataMethod)(IGuiData*);
+    std::unordered_map<guiDType, GuiDataMethod> m_methods;
+
+    Ui::toolbar_selector m_ui;
+    IDataDispatcher& m_dataDispatcher;
+    PolygonalSelectorSettings m_settings;
+};
+
+#endif

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -9,6 +9,30 @@
 
 #include <glm/glm.hpp>
 #include <array>
+#include <vector>
+
+struct PolygonalSelectorCameraSnapshot
+{
+    glm::dmat4 view = glm::dmat4(1.0);
+    glm::dmat4 proj = glm::dmat4(1.0);
+    uint32_t viewportWidth = 0;
+    uint32_t viewportHeight = 0;
+    bool perspective = true;
+};
+
+struct PolygonalSelectorPolygon
+{
+    std::vector<glm::vec2> normalizedVertices;
+    PolygonalSelectorCameraSnapshot camera;
+};
+
+struct PolygonalSelectorSettings
+{
+    bool enabled = false;
+    bool showSelected = true;
+    bool active = false;
+    std::vector<PolygonalSelectorPolygon> polygons;
+};
 
 struct ColorimetricFilterSettings
 {
@@ -73,6 +97,7 @@ public:
     bool                    m_displayAllMarkersTexts = true;
     bool                    m_displayAllMeasures = true;
     ColorimetricFilterSettings m_colorimetricFilter = {};
+    PolygonalSelectorSettings m_polygonalSelector = {};
 
     //Ortho
     bool            m_orthoGridActive = false;

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -237,6 +237,7 @@ private:
     void onRenderDepthLining(IGuiData* data);
     void onRenderRampScale(IGuiData* data);
     void onRenderColorimetricFilter(IGuiData* data);
+    void onRenderPolygonalSelector(IGuiData* data);
     void onBackgroundColor(IGuiData* data);
     void onAdjustZoomToScene(IGuiData* data);
     void onRenderCameraMoveTo(IGuiData* data);

--- a/projects/OpenScanTools/OpenScanTools.pro
+++ b/projects/OpenScanTools/OpenScanTools.pro
@@ -196,6 +196,7 @@ HEADERS += ../../ext/imgui/imconfig.h \
     ../../include/gui/toolBars/ToolBarAnimationGroup.h \
     ../../include/gui/toolBars/ToolBarMeasureShowOptions.h \
     ../../include/gui/toolBars/ToolBarClippingGroup.h \
+    ../../include/gui/toolBars/ToolBarPolygonalSelector.h \
     ../../include/gui/toolBars/ToolBarLucasExperimentGroup.h \
     ../../include/gui/toolBars/ToolBarExportPointCloud.h \
     ../../include/gui/toolBars/ToolBarOthersModelsGroup.h \
@@ -696,6 +697,7 @@ HEADERS += ../../ext/imgui/imconfig.h \
     ../../include/controller/functionSystem/ContextBoxAttachedCreation.h \
     ../../include/controller/functionSystem/ContextBoxDuplication.h \
     ../../include/controller/functionSystem/ContextClippingBoxCreation.h \
+    ../../include/controller/functionSystem/ContextPolygonalSelector.h \
     ../../include/controller/functionSystem/ContextBigCylinderFit.h \
     ../../include/controller/functionSystem/ContextConvertionScan.h \
     ../../include/controller/functionSystem/ContextCreateTag.h \
@@ -785,6 +787,7 @@ SOURCES += ../../ext/imgui/imgui.cpp \
     ../../src/gui/toolBars/ToolBarBaseMeasureGroup.cpp \
     ../../src/gui/toolBars/ToolBarBeamDetection.cpp \
     ../../src/gui/toolBars/ToolBarClippingGroup.cpp \
+    ../../src/gui/toolBars/ToolBarPolygonalSelector.cpp \
     ../../src/gui/toolBars/ToolBarClippingParameters.cpp \
     ../../src/gui/toolBars/ToolBarConnectPipeGroup.cpp \
     ../../src/gui/toolBars/ToolBarExportGroup.cpp \
@@ -1270,6 +1273,7 @@ SOURCES += ../../ext/imgui/imgui.cpp \
     ../../src/controller/functionSystem/ContextBoxAttachedCreation.cpp \
     ../../src/controller/functionSystem/ContextBoxDuplication.cpp \
     ../../src/controller/functionSystem/ContextClippingBoxCreation.cpp \
+    ../../src/controller/functionSystem/ContextPolygonalSelector.cpp \
     ../../src/controller/functionSystem/ContextBigCylinderFit.cpp \
     ../../src/controller/functionSystem/ContextColumnTilt.cpp \
     ../../src/controller/functionSystem/ContextConvertionScan.cpp \
@@ -1385,6 +1389,7 @@ FORMS += ../../src/gui/forms/AddHyperlinkDialog.ui \
     ../../src/gui/forms/toolbar_basemeasuregroup.ui \
     ../../src/gui/forms/toolbar_beamDetection.ui \
     ../../src/gui/forms/toolbar_clippingGroup.ui \
+    ../../src/gui/forms/toolbar_selector.ui \
     ../../src/gui/forms/ListListDialog.ui \
     ../../src/gui/forms/ListModifierDialog.ui \
     ../../src/gui/forms/ListNameDialog.ui \

--- a/projects/OpenScanTools/OpenScanTools.vcxproj
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj
@@ -588,6 +588,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClCompile Include="..\..\src\controller\functionSystem\ContextBoxAttachedCreation.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextBoxDuplication.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextClippingBoxCreation.cpp" />
+    <ClCompile Include="..\..\src\controller\functionSystem\ContextPolygonalSelector.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextBigCylinderFit.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextColumnTilt.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextConvertionScan.cpp">
@@ -806,6 +807,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarAutoSeeding.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarBeamDetection.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarClippingGroup.cpp" />
+    <ClCompile Include="..\..\src\gui\toolBars\ToolBarPolygonalSelector.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarClippingParameters.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarConnectPipeGroup.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarConvertImage.cpp" />
@@ -1275,6 +1277,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClInclude Include="..\..\include\controller\functionSystem\ContextBoxAttachedCreation.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextBoxDuplication.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextClippingBoxCreation.h" />
+    <ClInclude Include="..\..\include\controller\functionSystem\ContextPolygonalSelector.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextBigCylinderFit.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextConvertionScan.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Portable_Prod|x64'">true</ExcludedFromBuild>
@@ -1612,6 +1615,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClInclude Include="..\..\include\gui\Texts.hpp" />
     <QtMoc Include="..\..\include\gui\widgets\PropertySimpleMeasure.h" />
     <QtMoc Include="..\..\include\gui\toolBars\ToolBarClippingGroup.h" />
+    <QtMoc Include="..\..\include\gui\toolBars\ToolBarPolygonalSelector.h" />
     <QtMoc Include="..\..\include\gui\widgets\PropertyClippingSettings.h" />
     <QtMoc Include="..\..\include\gui\toolBars\ToolBarLucasExperimentGroup.h" />
     <QtMoc Include="..\..\include\gui\widgets\PropertyBox.h" />
@@ -2048,6 +2052,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <QtUic Include="..\..\src\gui\forms\toolbar_renderenhancegroup.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_render_ramp_group.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_colorimetric_filter.ui" />
+    <QtUic Include="..\..\src\gui\forms\toolbar_selector.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_importScantra.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_sharegroup.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_showhidegroup.ui" />

--- a/projects/OpenScanTools/OpenScanTools.vcxproj.filters
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj.filters
@@ -889,6 +889,9 @@
     <ClCompile Include="..\..\src\controller\functionSystem\ContextClippingBoxCreation.cpp">
       <Filter>src\controller\contexts</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\controller\functionSystem\ContextPolygonalSelector.cpp">
+      <Filter>src\controller\contexts</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\controller\messages\ColorMessage.cpp">
       <Filter>src\controller\messages</Filter>
     </ClCompile>
@@ -917,6 +920,9 @@
       <Filter>src\gui\widgets\CustomWidgets</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarClippingGroup.cpp">
+      <Filter>src\gui\toolBars</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\gui\toolBars\ToolBarPolygonalSelector.cpp">
       <Filter>src\gui\toolBars</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gui\widgets\CustomWidgets\ACustomLineEdit.cpp">
@@ -2130,6 +2136,9 @@
     <QtMoc Include="..\..\include\gui\toolBars\ToolBarClippingGroup.h">
       <Filter>include\gui\toolBars</Filter>
     </QtMoc>
+    <QtMoc Include="..\..\include\gui\toolBars\ToolBarPolygonalSelector.h">
+      <Filter>include\gui\toolBars</Filter>
+    </QtMoc>
     <QtMoc Include="..\..\include\gui\widgets\CustomWidgets\ACustomLineEdit.h">
       <Filter>include\gui\widgets\CustomWidgets</Filter>
     </QtMoc>
@@ -2880,6 +2889,9 @@
       <Filter>ext\imgui</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\controller\functionSystem\ContextClippingBoxCreation.h">
+      <Filter>include\controller\contexts</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\controller\functionSystem\ContextPolygonalSelector.h">
       <Filter>include\controller\contexts</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\controller\messages\ColorMessage.h">
@@ -4339,6 +4351,9 @@
       <Filter>Form Files</Filter>
     </QtUic>
     <QtUic Include="..\..\src\gui\forms\toolbar_colorimetric_filter.ui">
+      <Filter>Form Files</Filter>
+    </QtUic>
+    <QtUic Include="..\..\src\gui\forms\toolbar_selector.ui">
       <Filter>Form Files</Filter>
     </QtUic>
     <QtUic Include="..\..\src\gui\forms\MultiProperty.ui">

--- a/src/controller/controls/ControlFunctionClipping.cpp
+++ b/src/controller/controls/ControlFunctionClipping.cpp
@@ -243,4 +243,23 @@ namespace control::function::clipping
         return (ControlType::activateDuplicateFunctionClipping);
     }
 
+    ActivatePolygonalSelector::ActivatePolygonalSelector()
+    {
+    }
+
+    ActivatePolygonalSelector::~ActivatePolygonalSelector()
+    {
+    }
+
+    void ActivatePolygonalSelector::doFunction(Controller& controller)
+    {
+        controller.getFunctionManager().launchFunction(controller, ContextType::polygonalSelector);
+        CONTROLLOG << "control::function::clipping::ActivatePolygonalSelector" << LOGENDL;
+    }
+
+    ControlType ActivatePolygonalSelector::getType() const
+    {
+        return ControlType::activatePolygonalSelector;
+    }
+
 }

--- a/src/controller/functionSystem/ContextFactory.cpp
+++ b/src/controller/functionSystem/ContextFactory.cpp
@@ -62,6 +62,7 @@
 #include "controller/functionSystem/ContextTrajectory.h"
 #include "controller/functionSystem/ContextMoveManip.h"
 #include "controller/functionSystem/ContextManipulateObjects.h"
+#include "controller/functionSystem/ContextPolygonalSelector.h"
 
 
 #ifndef PORTABLE
@@ -167,6 +168,8 @@ AContext* ContextFactory::createContext(const ContextType& type, ContextId& id, 
 			return new ContextCreateBoxAttached2Points(id);
 		case ContextType::clippingBoxAttached3Points:
 			return new ContextCreateBoxAttached3Points(id);
+		case ContextType::polygonalSelector:
+			return new ContextPolygonalSelector(id);
 		case ContextType::boxDuplication:
 			return new ContextBoxDuplication(id);
 		case ContextType::pointCloudObjectDuplication:

--- a/src/controller/functionSystem/ContextPolygonalSelector.cpp
+++ b/src/controller/functionSystem/ContextPolygonalSelector.cpp
@@ -1,0 +1,83 @@
+#include "controller/functionSystem/ContextPolygonalSelector.h"
+
+#include "controller/Controller.h"
+#include "controller/controls/ControlFunction.h"
+#include "controller/messages/FullClickMessage.h"
+#include "controller/messages/IMessage.h"
+#include "gui/GuiData/GuiDataMessages.h"
+#include "gui/GuiData/GuiDataRendering.h"
+#include "gui/texts/ContextTexts.hpp"
+
+namespace
+{
+    PolygonalSelectorSettings s_polygonalSelectorRuntimeSettings;
+}
+
+ContextPolygonalSelector::ContextPolygonalSelector(const ContextId& id)
+    : AContext(id)
+{}
+
+ContextPolygonalSelector::~ContextPolygonalSelector()
+{}
+
+ContextState ContextPolygonalSelector::start(Controller& controller)
+{
+    m_settings = s_polygonalSelectorRuntimeSettings;
+    controller.updateInfo(new GuiDataTmpMessage(TEXT_POINT_MEASURE_START));
+    return (m_state = ContextState::waiting_for_input);
+}
+
+ContextState ContextPolygonalSelector::feedMessage(IMessage* message, Controller& controller)
+{
+    if (message->getType() == IMessage::MessageType::FULL_CLICK)
+    {
+        auto* clickMsg = static_cast<FullClickMessage*>(message);
+        const ClickInfo& click = clickMsg->m_clickInfo;
+        float nx = click.width > 0 ? static_cast<float>(click.picking.x / static_cast<double>(click.width)) : 0.0f;
+        float ny = click.height > 0 ? static_cast<float>(click.picking.y / static_cast<double>(click.height)) : 0.0f;
+        m_currentVertices.emplace_back(nx, ny);
+
+        controller.updateInfo(new GuiDataTmpMessage(QString("Polygonal selector: %1 vertex/vertices").arg(m_currentVertices.size())));
+    }
+
+    return (m_state = ContextState::waiting_for_input);
+}
+
+ContextState ContextPolygonalSelector::launch(Controller& controller)
+{
+    (void)controller;
+    return (m_state = ContextState::waiting_for_input);
+}
+
+ContextState ContextPolygonalSelector::abort(Controller& controller)
+{
+    m_currentVertices.clear();
+    return AContext::abort(controller);
+}
+
+ContextState ContextPolygonalSelector::validate(Controller& controller)
+{
+    if (m_currentVertices.size() >= 3)
+    {
+        PolygonalSelectorPolygon polygon;
+        polygon.normalizedVertices = m_currentVertices;
+        m_settings.polygons.push_back(polygon);
+        m_settings.active = true;
+        s_polygonalSelectorRuntimeSettings = m_settings;
+
+        controller.updateInfo(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()));
+    }
+
+    m_currentVertices.clear();
+    return AContext::validate(controller);
+}
+
+bool ContextPolygonalSelector::canAutoRelaunch() const
+{
+    return true;
+}
+
+ContextType ContextPolygonalSelector::getType() const
+{
+    return ContextType::polygonalSelector;
+}

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -61,6 +61,7 @@
 #include "gui/toolBars/ToolBarRenderTransparency.h"
 #include "gui/toolBars/ToolBarRenderEnhance.h"
 #include "gui/toolBars/ToolBarClippingGroup.h"
+#include "gui/toolBars/ToolBarPolygonalSelector.h"
 #include "gui/toolBars/ToolBarMeasureShowOptions.h"
 #include "gui/toolBars/ToolBarStructureAnalysis.h"
 #include "gui/toolBars/ToolBarOthersModelsGroup.h"
@@ -338,6 +339,7 @@ Gui::Gui(Controller& controller)
 	ribbonTabContent = new RibbonTabContent();
 	ribbonTabContent->addWidget(TEXT_ATTRIBUTE, new ToolBarAttributesGroup(controller, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_BOX, new ToolBarClippingGroup(m_dataDispatcher, this, m_guiScale));
+	ribbonTabContent->addWidget("Polygonal selector", new ToolBarPolygonalSelector(m_dataDispatcher, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_CLIPPING_GROUP_NAME, new ToolBarClippingParameters(m_dataDispatcher, this, m_guiScale));
     m_ribbon->addTab(TEXT_CLIPPING, ribbonTabContent);
 

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -648,6 +648,16 @@ guiDType GuiDataRenderColorimetricFilter::getType()
 	return guiDType::renderColorimetricFilter;
 }
 
+GuiDataRenderPolygonalSelector::GuiDataRenderPolygonalSelector(const PolygonalSelectorSettings& settings, const SafePtr<CameraNode>& camera)
+	: GuiDataActiveCamera(camera)
+	, m_settings(settings)
+{}
+
+guiDType GuiDataRenderPolygonalSelector::getType()
+{
+	return guiDType::renderPolygonalSelector;
+}
+
 GuiDataColorimetricFilterPickValue::GuiDataColorimetricFilterPickValue(const Color32& color, uint8_t intensity)
 	: m_color(color)
 	, m_intensity(intensity)

--- a/src/gui/forms/toolbar_selector.ui
+++ b/src/gui/forms/toolbar_selector.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>toolbar_selector</class>
+ <widget class="QWidget" name="toolbar_selector">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>360</width>
+    <height>110</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QToolButton" name="toolButton_polygonalSelector">
+     <property name="text">
+      <string>Selector</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QRadioButton" name="radioButtonShowSelected">
+     <property name="text">
+      <string>Show selected</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QRadioButton" name="radioButtonHideSelected">
+     <property name="text">
+      <string>Hide selected</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="pushButtonApply">
+     <property name="text">
+      <string>Apply</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="pushButtonDeactivate">
+     <property name="text">
+      <string>Deactivate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QPushButton" name="pushButtonReset">
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/toolBars/ToolBarPolygonalSelector.cpp
+++ b/src/gui/toolBars/ToolBarPolygonalSelector.cpp
@@ -1,0 +1,96 @@
+#include "gui/toolBars/ToolBarPolygonalSelector.h"
+
+#include "controller/controls/ControlFunction.h"
+#include "controller/controls/ControlFunctionClipping.h"
+#include "gui/GuiData/GuiDataGeneralProject.h"
+#include "gui/GuiData/GuiDataRendering.h"
+
+ToolBarPolygonalSelector::ToolBarPolygonalSelector(IDataDispatcher& dataDispatcher, QWidget* parent, float guiScale)
+    : QWidget(parent)
+    , m_dataDispatcher(dataDispatcher)
+{
+    m_ui.setupUi(this);
+    setEnabled(false);
+    m_ui.toolButton_polygonalSelector->setIconSize(QSize(20, 20) * guiScale);
+
+    connect(m_ui.toolButton_polygonalSelector, &QToolButton::clicked, this, &ToolBarPolygonalSelector::activateSelector);
+    connect(m_ui.pushButtonApply, &QPushButton::clicked, [this]() { applySettings(true); });
+    connect(m_ui.pushButtonDeactivate, &QPushButton::clicked, [this]() { applySettings(false); });
+    connect(m_ui.pushButtonReset, &QPushButton::clicked, [this]() { resetSettings(); });
+
+    connect(m_ui.radioButtonShowSelected, &QRadioButton::toggled, [this](bool) {
+        m_settings.showSelected = m_ui.radioButtonShowSelected->isChecked();
+        if (m_settings.enabled)
+            applySettings(true);
+    });
+
+    m_dataDispatcher.registerObserverOnKey(this, guiDType::projectLoaded);
+    m_dataDispatcher.registerObserverOnKey(this, guiDType::activatedFunctions);
+    m_dataDispatcher.registerObserverOnKey(this, guiDType::renderPolygonalSelector);
+
+    m_methods.insert({ guiDType::projectLoaded, &ToolBarPolygonalSelector::onProjectLoad });
+    m_methods.insert({ guiDType::activatedFunctions, &ToolBarPolygonalSelector::onActivatedFunctions });
+    m_methods.insert({ guiDType::renderPolygonalSelector, &ToolBarPolygonalSelector::onRenderSettings });
+}
+
+ToolBarPolygonalSelector::~ToolBarPolygonalSelector()
+{
+    m_dataDispatcher.unregisterObserver(this);
+}
+
+void ToolBarPolygonalSelector::informData(IGuiData* data)
+{
+    auto it = m_methods.find(data->getType());
+    if (it != m_methods.end())
+        (this->*(it->second))(data);
+}
+
+void ToolBarPolygonalSelector::onProjectLoad(IGuiData* data)
+{
+    setEnabled(static_cast<GuiDataProjectLoaded*>(data)->m_isProjectLoad);
+}
+
+void ToolBarPolygonalSelector::onActivatedFunctions(IGuiData* data)
+{
+    auto* functionData = static_cast<GuiDataActivatedFunctions*>(data);
+
+    m_ui.toolButton_polygonalSelector->blockSignals(true);
+    m_ui.toolButton_polygonalSelector->setChecked(functionData->type == ContextType::polygonalSelector);
+    m_ui.toolButton_polygonalSelector->blockSignals(false);
+}
+
+void ToolBarPolygonalSelector::onRenderSettings(IGuiData* data)
+{
+    auto* castData = static_cast<GuiDataRenderPolygonalSelector*>(data);
+    m_settings = castData->m_settings;
+
+    m_ui.radioButtonShowSelected->blockSignals(true);
+    m_ui.radioButtonHideSelected->blockSignals(true);
+    m_ui.radioButtonShowSelected->setChecked(m_settings.showSelected);
+    m_ui.radioButtonHideSelected->setChecked(!m_settings.showSelected);
+    m_ui.radioButtonShowSelected->blockSignals(false);
+    m_ui.radioButtonHideSelected->blockSignals(false);
+}
+
+void ToolBarPolygonalSelector::activateSelector()
+{
+    if (m_ui.toolButton_polygonalSelector->isChecked())
+        m_dataDispatcher.sendControl(new control::function::clipping::ActivatePolygonalSelector());
+    else
+        m_dataDispatcher.sendControl(new control::function::Abort());
+}
+
+void ToolBarPolygonalSelector::applySettings(bool enabled)
+{
+    m_settings.enabled = enabled;
+    m_settings.active = enabled;
+    m_settings.showSelected = m_ui.radioButtonShowSelected->isChecked();
+    m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()), this);
+}
+
+void ToolBarPolygonalSelector::resetSettings()
+{
+    m_settings = PolygonalSelectorSettings{};
+    m_ui.radioButtonShowSelected->setChecked(true);
+    m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()), this);
+}

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -49,6 +49,7 @@ namespace
         case ContextType::clippingBoxCreation:
         case ContextType::clippingBoxAttached3Points:
         case ContextType::clippingBoxAttached2Points:
+        case ContextType::polygonalSelector:
         case ContextType::boxDuplication:
         case ContextType::pointCloudObjectCreation:
         case ContextType::pointCloudObjectDuplication:

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -69,6 +69,7 @@ CameraNode::CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher
     registerGuiDataFunction(guiDType::renderDepthLining, &CameraNode::onRenderDepthLining);
     registerGuiDataFunction(guiDType::renderRampScale, &CameraNode::onRenderRampScale);
     registerGuiDataFunction(guiDType::renderColorimetricFilter, &CameraNode::onRenderColorimetricFilter);
+    registerGuiDataFunction(guiDType::renderPolygonalSelector, &CameraNode::onRenderPolygonalSelector);
     registerGuiDataFunction(guiDType::renderFovValueChanged, &CameraNode::onRenderFov);
     registerGuiDataFunction(guiDType::renderExamine, &CameraNode::onRenderExamine);
     registerGuiDataFunction(guiDType::examineOptions, &CameraNode::onExamineOptions);
@@ -1552,6 +1553,13 @@ void CameraNode::onRenderColorimetricFilter(IGuiData* data)
 {
     auto castData = static_cast<GuiDataRenderColorimetricFilter*>(data);
     m_colorimetricFilter = castData->m_settings;
+    sendNewUIViewPoint();
+}
+
+void CameraNode::onRenderPolygonalSelector(IGuiData* data)
+{
+    auto castData = static_cast<GuiDataRenderPolygonalSelector*>(data);
+    m_polygonalSelector = castData->m_settings;
     sendNewUIViewPoint();
 }
 


### PR DESCRIPTION
### Motivation
- Add a new Polygonal Selector feature and ensure the newly introduced source/header/UI files are properly registered in the build/project configuration to avoid compilation/IDE inconsistencies.
- Wire the new feature into the function/context system and GUI so the selector can be activated, configured and rendered from the application UI.

### Description
- Added polygonal selector implementation points: `include/controller/functionSystem/ContextPolygonalSelector.h` and `src/controller/functionSystem/ContextPolygonalSelector.cpp` to handle input, validation and runtime settings for polygons.
- Added toolbar UI and logic with `src/gui/forms/toolbar_selector.ui`, `include/gui/toolBars/ToolBarPolygonalSelector.h` and `src/gui/toolBars/ToolBarPolygonalSelector.cpp` to expose selector controls and settings in the ribbon.
- Extended rendering/GUI data and models with `GuiDataRenderPolygonalSelector`, `PolygonalSelectorSettings` and related structs in `GuiDataRendering.h` and `DisplayParameters.h`, and added handling in `GuiDataRendering.cpp` and `CameraNode` to receive and apply polygonal selector render updates.
- Integrated control flow by adding `activatePolygonalSelector` to `IControl`, implementing `ActivatePolygonalSelector` in `ControlFunctionClipping.*`, and registering the new `ContextType::polygonalSelector` path in `ContextFactory` and blocking examine behavior in `VulkanViewport`.
- Registered all new files in project configuration files by updating `projects/OpenScanTools/OpenScanTools.vcxproj`, `projects/OpenScanTools/OpenScanTools.vcxproj.filters` and `projects/OpenScanTools/OpenScanTools.pro` so sources, headers, Qt MOC and UI forms are included for Visual Studio and qmake flows.

### Testing
- Parsed `OpenScanTools.vcxproj` and `OpenScanTools.vcxproj.filters` as XML successfully to validate the project-file edits.
- Verified the `.pro`/project files contain the new header/source/form entries by automated text searches (file registration checks) and found the expected entries for the polygonal selector files.
- Ran a project-file syntax/whitespace check and a set of basic static validations against the modified project files, and all checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e22a9ebd4832f9d8d777158b7dbde)