### PR TITLE
Persist polygonal selector state (viewpoints, presets, rendering/GUI integration)

### DIFF
--- a/include/controller/controls/ControlFunctionClipping.h
+++ b/include/controller/controls/ControlFunctionClipping.h
@@ -99,6 +99,15 @@ namespace control::function::clipping
 		ControlType getType() const override;
 	};
 
+	class ActivatePolygonalSelector : public AControl
+	{
+	public:
+		ActivatePolygonalSelector();
+		~ActivatePolygonalSelector();
+		void doFunction(Controller& controller) override;
+		ControlType getType() const override;
+	};
+
 }
 
 #endif // !CONTROL_FUNCTION_TAG_H_

--- a/include/controller/controls/IControl.h
+++ b/include/controller/controls/IControl.h
@@ -211,6 +211,7 @@ enum class ControlType
 	setDefaultOffsetFunctionClipping,
 	activateDuplicateFunctionClipping,
 	setClippingAlignementValue,
+	activatePolygonalSelector,
 
 	// control::duplication
 	setDefaultDuplicationModeFunction,

--- a/include/controller/functionSystem/AContext.h
+++ b/include/controller/functionSystem/AContext.h
@@ -46,6 +46,7 @@ enum class ContextType
 	clippingBoxCreation,
 	clippingBoxAttached3Points,
 	clippingBoxAttached2Points,
+	polygonalSelector,
 	boxDuplication,
 	pointCloudObjectCreation,
 	pointCloudObjectDuplication,

--- a/include/controller/functionSystem/ContextPolygonalSelector.h
+++ b/include/controller/functionSystem/ContextPolygonalSelector.h
@@ -1,0 +1,27 @@
+#ifndef CONTEXT_POLYGONAL_SELECTOR_H
+#define CONTEXT_POLYGONAL_SELECTOR_H
+
+#include "controller/functionSystem/AContext.h"
+#include "models/3d/DisplayParameters.h"
+#include <vector>
+
+class ContextPolygonalSelector : public AContext
+{
+public:
+    ContextPolygonalSelector(const ContextId& id);
+    ~ContextPolygonalSelector();
+
+    ContextState start(Controller& controller) override;
+    ContextState feedMessage(IMessage* message, Controller& controller) override;
+    ContextState launch(Controller& controller) override;
+    ContextState abort(Controller& controller) override;
+    ContextState validate(Controller& controller) override;
+    bool canAutoRelaunch() const override;
+    ContextType getType() const override;
+
+private:
+    std::vector<glm::vec2> m_currentVertices;
+    PolygonalSelectorSettings m_settings;
+};
+
+#endif

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -15,6 +15,7 @@
 
 #include <filesystem>
 #include <cstdint>
+#include <vector>
 
 class IPanel;
 
@@ -623,6 +624,18 @@ public:
 	virtual guiDType getType() override;
 public:
 	ColorimetricFilterSettings m_settings;
+};
+
+class GuiDataRenderPolygonalSelector : public GuiDataActiveCamera
+{
+public:
+	GuiDataRenderPolygonalSelector(const PolygonalSelectorSettings& settings, const SafePtr<CameraNode>& camera, const std::vector<glm::vec2>& previewVertices = {}, bool previewClosed = false);
+	~GuiDataRenderPolygonalSelector() {};
+	virtual guiDType getType() override;
+public:
+	PolygonalSelectorSettings m_settings;
+	std::vector<glm::vec2> m_previewVertices;
+	bool m_previewClosed = false;
 };
 
 class GuiDataColorimetricFilterPickValue : public IGuiData

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -76,6 +76,7 @@ enum class guiDType
         renderDepthLining,
         renderRampScale,
         renderColorimetricFilter,
+        renderPolygonalSelector,
         renderDisplayParameters,
         renderUpdate,
         renderGuizmo,

--- a/include/gui/ShortcutSystem.h
+++ b/include/gui/ShortcutSystem.h
@@ -3,6 +3,7 @@
 
 #include "gui/IPanel.h"
 #include "gui/IDataDispatcher.h"
+#include "controller/functionSystem/AContext.h"
 
 #include <QtWidgets/qshortcut.h>
 #include <deque>
@@ -25,6 +26,7 @@ public:
 public slots :
 	void slotDelete();
 	void slotAbort();
+	void slotValidateCurrentContext();
 	void slotBackground();
 	void slotManipulatorTranslation();
 	void slotManipulatorRotation();
@@ -57,6 +59,7 @@ private:
 private:
 	bool m_isEditing;
 	bool m_notInContext;
+	ContextType m_activeContext;
 	IDataDispatcher& m_dataDispatcher;
 
 	std::deque<ShortcutDef> m_shortcutDefs;

--- a/include/gui/toolBars/ToolBarPolygonalSelector.h
+++ b/include/gui/toolBars/ToolBarPolygonalSelector.h
@@ -1,0 +1,38 @@
+#ifndef TOOLBAR_POLYGONAL_SELECTOR_H
+#define TOOLBAR_POLYGONAL_SELECTOR_H
+
+#include "ui_toolbar_selector.h"
+#include "gui/IPanel.h"
+#include "gui/IDataDispatcher.h"
+#include "models/3d/DisplayParameters.h"
+
+#include <unordered_map>
+
+class ToolBarPolygonalSelector : public QWidget, public IPanel
+{
+    Q_OBJECT
+
+public:
+    explicit ToolBarPolygonalSelector(IDataDispatcher& dataDispatcher, QWidget* parent = nullptr, float guiScale = 1.f);
+    ~ToolBarPolygonalSelector();
+
+private:
+    void informData(IGuiData* data) override;
+    void onProjectLoad(IGuiData* data);
+    void onActivatedFunctions(IGuiData* data);
+    void onRenderSettings(IGuiData* data);
+
+    void activateSelector();
+    void applySettings(bool enabled);
+    void resetSettings();
+
+private:
+    typedef void (ToolBarPolygonalSelector::*GuiDataMethod)(IGuiData*);
+    std::unordered_map<guiDType, GuiDataMethod> m_methods;
+
+    Ui::toolbar_selector m_ui;
+    IDataDispatcher& m_dataDispatcher;
+    PolygonalSelectorSettings m_settings;
+};
+
+#endif

--- a/include/gui/viewport/VulkanViewport.h
+++ b/include/gui/viewport/VulkanViewport.h
@@ -13,6 +13,7 @@
 
 #include <mutex>
 #include <unordered_map>
+#include <vector>
 
 #include <QtGui/QWindow.h>
 
@@ -129,6 +130,8 @@ public:
     void refreshHoveredId(uint32_t textId);
     Rect2D getSelectionRect() const;
     Rect2D getHoverRect() const;
+    const std::vector<glm::vec2>& getPolygonalSelectorPreview() const;
+    bool isPolygonalSelectorPreviewClosed() const;
     glm::ivec2 getMousePos() const;
     glm::vec2 getMousePosNormalized() const;
     void setMissingScanPart(bool isMissingScanPart);
@@ -184,6 +187,7 @@ protected:
     void onRenderDecimationOptions(IGuiData* data);
 	void onRenderOctreePrecision(IGuiData* data);
     void onActivatedFunctions(IGuiData* data);
+    void onRenderPolygonalSelectorPreview(IGuiData* data);
 
 private:
     void initSurface();
@@ -233,6 +237,9 @@ private:
     bool m_forceObjectCenterOnExamine = false;
     bool m_isDoubleClickExamineBlocked = false;
     bool m_ignoreNextLeftReleaseClick = false;
+    bool m_lockNavigationForCurrentContext = false;
+    std::vector<glm::vec2> m_polygonalSelectorPreview;
+    bool m_polygonalSelectorPreviewClosed = false;
 
     // Window state
     bool m_initialized;

--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -249,6 +249,18 @@
 #define Key_Colorimetric_Filter_Colors		"ColorimetricFilterColors"
 #define Key_Colorimetric_Filter_Colors_Enabled "ColorimetricFilterColorsEnabled"
 
+#define Key_Polygonal_Selector			"PolygonalSelector"
+#define Key_Polygonal_Selector_Enabled	"PolygonalSelectorEnabled"
+#define Key_Polygonal_Selector_Show		"PolygonalSelectorShowSelected"
+#define Key_Polygonal_Selector_Active	"PolygonalSelectorActive"
+#define Key_Polygonal_Selector_Polygons	"PolygonalSelectorPolygons"
+#define Key_Polygonal_Selector_Vertices	"PolygonalSelectorVertices"
+#define Key_Polygonal_Selector_Camera		"PolygonalSelectorCamera"
+#define Key_Polygonal_Selector_Cam_View	"PolygonalSelectorCameraView"
+#define Key_Polygonal_Selector_Cam_Proj	"PolygonalSelectorCameraProj"
+#define Key_Polygonal_Selector_Cam_Viewport "PolygonalSelectorCameraViewport"
+#define Key_Polygonal_Selector_Cam_Perspective "PolygonalSelectorCameraPerspective"
+
 #define Key_Active_Scans				"ActiveScans"
 #define Key_Active_Clippings			"ActiveClippings"
 #define Key_Interior_Clippings			"InteriorClippings"

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -9,6 +9,30 @@
 
 #include <glm/glm.hpp>
 #include <array>
+#include <vector>
+
+struct PolygonalSelectorCameraSnapshot
+{
+    glm::dmat4 view = glm::dmat4(1.0);
+    glm::dmat4 proj = glm::dmat4(1.0);
+    uint32_t viewportWidth = 0;
+    uint32_t viewportHeight = 0;
+    bool perspective = true;
+};
+
+struct PolygonalSelectorPolygon
+{
+    std::vector<glm::vec2> normalizedVertices;
+    PolygonalSelectorCameraSnapshot camera;
+};
+
+struct PolygonalSelectorSettings
+{
+    bool enabled = false;
+    bool showSelected = true;
+    bool active = false;
+    std::vector<PolygonalSelectorPolygon> polygons;
+};
 
 struct ColorimetricFilterSettings
 {
@@ -73,6 +97,7 @@ public:
     bool                    m_displayAllMarkersTexts = true;
     bool                    m_displayAllMeasures = true;
     ColorimetricFilterSettings m_colorimetricFilter = {};
+    PolygonalSelectorSettings m_polygonalSelector = {};
 
     //Ortho
     bool            m_orthoGridActive = false;

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -237,6 +237,7 @@ private:
     void onRenderDepthLining(IGuiData* data);
     void onRenderRampScale(IGuiData* data);
     void onRenderColorimetricFilter(IGuiData* data);
+    void onRenderPolygonalSelector(IGuiData* data);
     void onBackgroundColor(IGuiData* data);
     void onAdjustZoomToScene(IGuiData* data);
     void onRenderCameraMoveTo(IGuiData* data);

--- a/projects/OpenScanTools/OpenScanTools.pro
+++ b/projects/OpenScanTools/OpenScanTools.pro
@@ -196,6 +196,7 @@ HEADERS += ../../ext/imgui/imconfig.h \
     ../../include/gui/toolBars/ToolBarAnimationGroup.h \
     ../../include/gui/toolBars/ToolBarMeasureShowOptions.h \
     ../../include/gui/toolBars/ToolBarClippingGroup.h \
+    ../../include/gui/toolBars/ToolBarPolygonalSelector.h \
     ../../include/gui/toolBars/ToolBarLucasExperimentGroup.h \
     ../../include/gui/toolBars/ToolBarExportPointCloud.h \
     ../../include/gui/toolBars/ToolBarOthersModelsGroup.h \
@@ -696,6 +697,7 @@ HEADERS += ../../ext/imgui/imconfig.h \
     ../../include/controller/functionSystem/ContextBoxAttachedCreation.h \
     ../../include/controller/functionSystem/ContextBoxDuplication.h \
     ../../include/controller/functionSystem/ContextClippingBoxCreation.h \
+    ../../include/controller/functionSystem/ContextPolygonalSelector.h \
     ../../include/controller/functionSystem/ContextBigCylinderFit.h \
     ../../include/controller/functionSystem/ContextConvertionScan.h \
     ../../include/controller/functionSystem/ContextCreateTag.h \
@@ -785,6 +787,7 @@ SOURCES += ../../ext/imgui/imgui.cpp \
     ../../src/gui/toolBars/ToolBarBaseMeasureGroup.cpp \
     ../../src/gui/toolBars/ToolBarBeamDetection.cpp \
     ../../src/gui/toolBars/ToolBarClippingGroup.cpp \
+    ../../src/gui/toolBars/ToolBarPolygonalSelector.cpp \
     ../../src/gui/toolBars/ToolBarClippingParameters.cpp \
     ../../src/gui/toolBars/ToolBarConnectPipeGroup.cpp \
     ../../src/gui/toolBars/ToolBarExportGroup.cpp \
@@ -1270,6 +1273,7 @@ SOURCES += ../../ext/imgui/imgui.cpp \
     ../../src/controller/functionSystem/ContextBoxAttachedCreation.cpp \
     ../../src/controller/functionSystem/ContextBoxDuplication.cpp \
     ../../src/controller/functionSystem/ContextClippingBoxCreation.cpp \
+    ../../src/controller/functionSystem/ContextPolygonalSelector.cpp \
     ../../src/controller/functionSystem/ContextBigCylinderFit.cpp \
     ../../src/controller/functionSystem/ContextColumnTilt.cpp \
     ../../src/controller/functionSystem/ContextConvertionScan.cpp \
@@ -1385,6 +1389,7 @@ FORMS += ../../src/gui/forms/AddHyperlinkDialog.ui \
     ../../src/gui/forms/toolbar_basemeasuregroup.ui \
     ../../src/gui/forms/toolbar_beamDetection.ui \
     ../../src/gui/forms/toolbar_clippingGroup.ui \
+    ../../src/gui/forms/toolbar_selector.ui \
     ../../src/gui/forms/ListListDialog.ui \
     ../../src/gui/forms/ListModifierDialog.ui \
     ../../src/gui/forms/ListNameDialog.ui \

--- a/projects/OpenScanTools/OpenScanTools.vcxproj
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj
@@ -588,6 +588,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClCompile Include="..\..\src\controller\functionSystem\ContextBoxAttachedCreation.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextBoxDuplication.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextClippingBoxCreation.cpp" />
+    <ClCompile Include="..\..\src\controller\functionSystem\ContextPolygonalSelector.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextBigCylinderFit.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextColumnTilt.cpp" />
     <ClCompile Include="..\..\src\controller\functionSystem\ContextConvertionScan.cpp">
@@ -806,6 +807,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarAutoSeeding.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarBeamDetection.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarClippingGroup.cpp" />
+    <ClCompile Include="..\..\src\gui\toolBars\ToolBarPolygonalSelector.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarClippingParameters.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarConnectPipeGroup.cpp" />
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarConvertImage.cpp" />
@@ -1275,6 +1277,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClInclude Include="..\..\include\controller\functionSystem\ContextBoxAttachedCreation.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextBoxDuplication.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextClippingBoxCreation.h" />
+    <ClInclude Include="..\..\include\controller\functionSystem\ContextPolygonalSelector.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextBigCylinderFit.h" />
     <ClInclude Include="..\..\include\controller\functionSystem\ContextConvertionScan.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Portable_Prod|x64'">true</ExcludedFromBuild>
@@ -1612,6 +1615,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClInclude Include="..\..\include\gui\Texts.hpp" />
     <QtMoc Include="..\..\include\gui\widgets\PropertySimpleMeasure.h" />
     <QtMoc Include="..\..\include\gui\toolBars\ToolBarClippingGroup.h" />
+    <QtMoc Include="..\..\include\gui\toolBars\ToolBarPolygonalSelector.h" />
     <QtMoc Include="..\..\include\gui\widgets\PropertyClippingSettings.h" />
     <QtMoc Include="..\..\include\gui\toolBars\ToolBarLucasExperimentGroup.h" />
     <QtMoc Include="..\..\include\gui\widgets\PropertyBox.h" />
@@ -2048,6 +2052,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <QtUic Include="..\..\src\gui\forms\toolbar_renderenhancegroup.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_render_ramp_group.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_colorimetric_filter.ui" />
+    <QtUic Include="..\..\src\gui\forms\toolbar_selector.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_importScantra.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_sharegroup.ui" />
     <QtUic Include="..\..\src\gui\forms\toolbar_showhidegroup.ui" />

--- a/projects/OpenScanTools/OpenScanTools.vcxproj.filters
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj.filters
@@ -889,6 +889,9 @@
     <ClCompile Include="..\..\src\controller\functionSystem\ContextClippingBoxCreation.cpp">
       <Filter>src\controller\contexts</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\controller\functionSystem\ContextPolygonalSelector.cpp">
+      <Filter>src\controller\contexts</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\controller\messages\ColorMessage.cpp">
       <Filter>src\controller\messages</Filter>
     </ClCompile>
@@ -917,6 +920,9 @@
       <Filter>src\gui\widgets\CustomWidgets</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gui\toolBars\ToolBarClippingGroup.cpp">
+      <Filter>src\gui\toolBars</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\gui\toolBars\ToolBarPolygonalSelector.cpp">
       <Filter>src\gui\toolBars</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gui\widgets\CustomWidgets\ACustomLineEdit.cpp">
@@ -2130,6 +2136,9 @@
     <QtMoc Include="..\..\include\gui\toolBars\ToolBarClippingGroup.h">
       <Filter>include\gui\toolBars</Filter>
     </QtMoc>
+    <QtMoc Include="..\..\include\gui\toolBars\ToolBarPolygonalSelector.h">
+      <Filter>include\gui\toolBars</Filter>
+    </QtMoc>
     <QtMoc Include="..\..\include\gui\widgets\CustomWidgets\ACustomLineEdit.h">
       <Filter>include\gui\widgets\CustomWidgets</Filter>
     </QtMoc>
@@ -2880,6 +2889,9 @@
       <Filter>ext\imgui</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\controller\functionSystem\ContextClippingBoxCreation.h">
+      <Filter>include\controller\contexts</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\controller\functionSystem\ContextPolygonalSelector.h">
       <Filter>include\controller\contexts</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\controller\messages\ColorMessage.h">
@@ -4339,6 +4351,9 @@
       <Filter>Form Files</Filter>
     </QtUic>
     <QtUic Include="..\..\src\gui\forms\toolbar_colorimetric_filter.ui">
+      <Filter>Form Files</Filter>
+    </QtUic>
+    <QtUic Include="..\..\src\gui\forms\toolbar_selector.ui">
       <Filter>Form Files</Filter>
     </QtUic>
     <QtUic Include="..\..\src\gui\forms\MultiProperty.ui">

--- a/src/controller/controls/ControlFunctionClipping.cpp
+++ b/src/controller/controls/ControlFunctionClipping.cpp
@@ -243,4 +243,23 @@ namespace control::function::clipping
         return (ControlType::activateDuplicateFunctionClipping);
     }
 
+    ActivatePolygonalSelector::ActivatePolygonalSelector()
+    {
+    }
+
+    ActivatePolygonalSelector::~ActivatePolygonalSelector()
+    {
+    }
+
+    void ActivatePolygonalSelector::doFunction(Controller& controller)
+    {
+        controller.getFunctionManager().launchFunction(controller, ContextType::polygonalSelector);
+        CONTROLLOG << "control::function::clipping::ActivatePolygonalSelector" << LOGENDL;
+    }
+
+    ControlType ActivatePolygonalSelector::getType() const
+    {
+        return ControlType::activatePolygonalSelector;
+    }
+
 }

--- a/src/controller/functionSystem/ContextFactory.cpp
+++ b/src/controller/functionSystem/ContextFactory.cpp
@@ -62,6 +62,7 @@
 #include "controller/functionSystem/ContextTrajectory.h"
 #include "controller/functionSystem/ContextMoveManip.h"
 #include "controller/functionSystem/ContextManipulateObjects.h"
+#include "controller/functionSystem/ContextPolygonalSelector.h"
 
 
 #ifndef PORTABLE
@@ -167,6 +168,8 @@ AContext* ContextFactory::createContext(const ContextType& type, ContextId& id, 
 			return new ContextCreateBoxAttached2Points(id);
 		case ContextType::clippingBoxAttached3Points:
 			return new ContextCreateBoxAttached3Points(id);
+		case ContextType::polygonalSelector:
+			return new ContextPolygonalSelector(id);
 		case ContextType::boxDuplication:
 			return new ContextBoxDuplication(id);
 		case ContextType::pointCloudObjectDuplication:

--- a/src/controller/functionSystem/ContextPolygonalSelector.cpp
+++ b/src/controller/functionSystem/ContextPolygonalSelector.cpp
@@ -1,0 +1,122 @@
+#include "controller/functionSystem/ContextPolygonalSelector.h"
+
+#include "controller/Controller.h"
+#include "controller/controls/ControlFunction.h"
+#include "controller/messages/FullClickMessage.h"
+#include "controller/messages/IMessage.h"
+#include "gui/GuiData/GuiDataMessages.h"
+#include "gui/GuiData/GuiDataRendering.h"
+#include "gui/texts/ContextTexts.hpp"
+#include "models/graph/CameraNode.h"
+
+#include <glm/gtx/norm.hpp>
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+    PolygonalSelectorSettings s_polygonalSelectorRuntimeSettings;
+    PolygonalSelectorCameraSnapshot s_lastSnapshot;
+}
+
+ContextPolygonalSelector::ContextPolygonalSelector(const ContextId& id)
+    : AContext(id)
+{}
+
+ContextPolygonalSelector::~ContextPolygonalSelector()
+{}
+
+ContextState ContextPolygonalSelector::start(Controller& controller)
+{
+    m_settings = s_polygonalSelectorRuntimeSettings;
+    m_currentVertices.clear();
+    controller.updateInfo(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>(), m_currentVertices, false));
+    controller.updateInfo(new GuiDataTmpMessage(TEXT_POINT_MEASURE_START));
+    return (m_state = ContextState::waiting_for_input);
+}
+
+ContextState ContextPolygonalSelector::feedMessage(IMessage* message, Controller& controller)
+{
+    if (message->getType() == IMessage::MessageType::FULL_CLICK)
+    {
+        auto* clickMsg = static_cast<FullClickMessage*>(message);
+        const ClickInfo& click = clickMsg->m_clickInfo;
+        glm::vec2 normalized(0.0f, 0.0f);
+
+        ReadPtr<CameraNode> rCam = click.viewport.cget();
+        if (rCam && click.width > 0 && click.height > 0)
+        {
+            glm::dvec3 rayDir = glm::length2(click.ray) > 0.0 ? glm::normalize(click.ray) : glm::dvec3(0.0, 0.0, -1.0);
+            glm::dvec3 markerPoint = click.rayOrigin + rayDir;
+            glm::dvec3 screen = rCam->getScreenProjection(markerPoint, glm::ivec2(click.width, click.height));
+
+            normalized.x = static_cast<float>(screen.x / static_cast<double>(click.width));
+            normalized.y = static_cast<float>(screen.y / static_cast<double>(click.height));
+            normalized.x = std::clamp(normalized.x, 0.0f, 1.0f);
+            normalized.y = std::clamp(normalized.y, 0.0f, 1.0f);
+        }
+
+        if (!std::isfinite(normalized.x) || !std::isfinite(normalized.y))
+            return (m_state = ContextState::waiting_for_input);
+
+        m_currentVertices.emplace_back(normalized);
+
+        if (rCam)
+        {
+            s_lastSnapshot.view = rCam->getViewMatrix();
+            s_lastSnapshot.proj = rCam->getProjMatrix();
+            s_lastSnapshot.viewportWidth = click.width;
+            s_lastSnapshot.viewportHeight = click.height;
+            s_lastSnapshot.perspective = (rCam->getProjectionMode() == ProjectionMode::Perspective);
+        }
+
+        controller.updateInfo(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>(), m_currentVertices, false));
+        controller.updateInfo(new GuiDataTmpMessage(QString("Polygonal selector: %1 vertex/vertices").arg(m_currentVertices.size())));
+    }
+
+    return (m_state = ContextState::waiting_for_input);
+}
+
+ContextState ContextPolygonalSelector::launch(Controller& controller)
+{
+    (void)controller;
+    return (m_state = ContextState::waiting_for_input);
+}
+
+ContextState ContextPolygonalSelector::abort(Controller& controller)
+{
+    m_currentVertices.clear();
+    controller.updateInfo(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>(), m_currentVertices, false));
+    return AContext::abort(controller);
+}
+
+ContextState ContextPolygonalSelector::validate(Controller& controller)
+{
+    if (m_currentVertices.size() >= 3)
+    {
+        PolygonalSelectorPolygon polygon;
+        polygon.normalizedVertices = m_currentVertices;
+        polygon.camera = s_lastSnapshot;
+
+        controller.updateInfo(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>(), m_currentVertices, true));
+
+        m_settings.polygons.push_back(polygon);
+        m_settings.enabled = true;
+        m_settings.active = true;
+        s_polygonalSelectorRuntimeSettings = m_settings;
+    }
+
+    m_currentVertices.clear();
+    controller.updateInfo(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>(), m_currentVertices, false));
+    return AContext::validate(controller);
+}
+
+bool ContextPolygonalSelector::canAutoRelaunch() const
+{
+    return true;
+}
+
+ContextType ContextPolygonalSelector::getType() const
+{
+    return ContextType::polygonalSelector;
+}

--- a/src/gui/DisplayPresetManager.cpp
+++ b/src/gui/DisplayPresetManager.cpp
@@ -96,6 +96,26 @@ namespace
 			} }
 		};
 
+		json[Key_Polygonal_Selector] = {
+			{ Key_Polygonal_Selector_Enabled, params.m_polygonalSelector.enabled },
+			{ Key_Polygonal_Selector_Show, params.m_polygonalSelector.showSelected },
+			{ Key_Polygonal_Selector_Active, params.m_polygonalSelector.active },
+			{ Key_Polygonal_Selector_Polygons, nlohmann::json::array() }
+		};
+
+		for (const PolygonalSelectorPolygon& polygon : params.m_polygonalSelector.polygons)
+		{
+			nlohmann::json polygonJson;
+			polygonJson[Key_Polygonal_Selector_Vertices] = nlohmann::json::array();
+			for (const glm::vec2& vertex : polygon.normalizedVertices)
+				polygonJson[Key_Polygonal_Selector_Vertices].push_back({ vertex.x, vertex.y });
+			polygonJson[Key_Polygonal_Selector_Camera] = {
+				{ Key_Polygonal_Selector_Cam_Viewport, { polygon.camera.viewportWidth, polygon.camera.viewportHeight } },
+				{ Key_Polygonal_Selector_Cam_Perspective, polygon.camera.perspective }
+			};
+			json[Key_Polygonal_Selector][Key_Polygonal_Selector_Polygons].push_back(polygonJson);
+		}
+
 		json[Key_Ortho_Grid_Active] = params.m_orthoGridActive;
 		json[Key_Ortho_Grid_Color] = { params.m_orthoGridColor.r, params.m_orthoGridColor.g, params.m_orthoGridColor.b, params.m_orthoGridColor.a };
 		json[Key_Ortho_Grid_Step] = params.m_orthoGridStep;
@@ -326,6 +346,51 @@ namespace
 				const auto& enabled = filterJson.at(Key_Colorimetric_Filter_Colors_Enabled);
 				for (size_t i = 0; i < data.m_colorimetricFilter.colorsEnabled.size() && i < enabled.size(); ++i)
 					data.m_colorimetricFilter.colorsEnabled[i] = enabled.at(i).get<bool>();
+			}
+		}
+
+		if (json.find(Key_Polygonal_Selector) != json.end())
+		{
+			const auto& selectorJson = json.at(Key_Polygonal_Selector);
+			if (selectorJson.find(Key_Polygonal_Selector_Enabled) != selectorJson.end())
+				data.m_polygonalSelector.enabled = selectorJson.at(Key_Polygonal_Selector_Enabled).get<bool>();
+			if (selectorJson.find(Key_Polygonal_Selector_Show) != selectorJson.end())
+				data.m_polygonalSelector.showSelected = selectorJson.at(Key_Polygonal_Selector_Show).get<bool>();
+			if (selectorJson.find(Key_Polygonal_Selector_Active) != selectorJson.end())
+				data.m_polygonalSelector.active = selectorJson.at(Key_Polygonal_Selector_Active).get<bool>();
+
+			if (selectorJson.find(Key_Polygonal_Selector_Polygons) != selectorJson.end())
+			{
+				data.m_polygonalSelector.polygons.clear();
+				const auto& polygons = selectorJson.at(Key_Polygonal_Selector_Polygons);
+				for (const auto& polygonJson : polygons)
+				{
+					PolygonalSelectorPolygon polygon;
+					if (polygonJson.find(Key_Polygonal_Selector_Vertices) != polygonJson.end())
+					{
+						for (const auto& vertexJson : polygonJson.at(Key_Polygonal_Selector_Vertices))
+						{
+							if (vertexJson.size() >= 2)
+								polygon.normalizedVertices.emplace_back(vertexJson.at(0).get<float>(), vertexJson.at(1).get<float>());
+						}
+					}
+					if (polygonJson.find(Key_Polygonal_Selector_Camera) != polygonJson.end())
+					{
+						const auto& cameraJson = polygonJson.at(Key_Polygonal_Selector_Camera);
+						if (cameraJson.find(Key_Polygonal_Selector_Cam_Viewport) != cameraJson.end())
+						{
+							const auto& viewport = cameraJson.at(Key_Polygonal_Selector_Cam_Viewport);
+							if (viewport.size() >= 2)
+							{
+								polygon.camera.viewportWidth = viewport.at(0).get<uint32_t>();
+								polygon.camera.viewportHeight = viewport.at(1).get<uint32_t>();
+							}
+						}
+						if (cameraJson.find(Key_Polygonal_Selector_Cam_Perspective) != cameraJson.end())
+							polygon.camera.perspective = cameraJson.at(Key_Polygonal_Selector_Cam_Perspective).get<bool>();
+					}
+					data.m_polygonalSelector.polygons.push_back(std::move(polygon));
+				}
 			}
 		}
 
@@ -728,6 +793,7 @@ void DisplayPresetManager::applyPreset(const DisplayPreset& preset)
 	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(params.m_edgeAwareBlur, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataDepthLining(params.m_depthLining, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderColorimetricFilter(params.m_colorimetricFilter, m_focusCamera), this);
+	m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(params.m_polygonalSelector, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataMarkerDisplayOptions(params.m_markerOptions, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderTextFilter(params.m_textOptions.m_filter, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderTextTheme(params.m_textOptions.m_textTheme, m_focusCamera), this);

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -61,6 +61,7 @@
 #include "gui/toolBars/ToolBarRenderTransparency.h"
 #include "gui/toolBars/ToolBarRenderEnhance.h"
 #include "gui/toolBars/ToolBarClippingGroup.h"
+#include "gui/toolBars/ToolBarPolygonalSelector.h"
 #include "gui/toolBars/ToolBarMeasureShowOptions.h"
 #include "gui/toolBars/ToolBarStructureAnalysis.h"
 #include "gui/toolBars/ToolBarOthersModelsGroup.h"
@@ -338,6 +339,7 @@ Gui::Gui(Controller& controller)
 	ribbonTabContent = new RibbonTabContent();
 	ribbonTabContent->addWidget(TEXT_ATTRIBUTE, new ToolBarAttributesGroup(controller, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_BOX, new ToolBarClippingGroup(m_dataDispatcher, this, m_guiScale));
+	ribbonTabContent->addWidget("Polygonal selector", new ToolBarPolygonalSelector(m_dataDispatcher, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_CLIPPING_GROUP_NAME, new ToolBarClippingParameters(m_dataDispatcher, this, m_guiScale));
     m_ribbon->addTab(TEXT_CLIPPING, ribbonTabContent);
 

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -648,6 +648,18 @@ guiDType GuiDataRenderColorimetricFilter::getType()
 	return guiDType::renderColorimetricFilter;
 }
 
+GuiDataRenderPolygonalSelector::GuiDataRenderPolygonalSelector(const PolygonalSelectorSettings& settings, const SafePtr<CameraNode>& camera, const std::vector<glm::vec2>& previewVertices, bool previewClosed)
+	: GuiDataActiveCamera(camera)
+	, m_settings(settings)
+	, m_previewVertices(previewVertices)
+	, m_previewClosed(previewClosed)
+{}
+
+guiDType GuiDataRenderPolygonalSelector::getType()
+{
+	return guiDType::renderPolygonalSelector;
+}
+
 GuiDataColorimetricFilterPickValue::GuiDataColorimetricFilterPickValue(const Color32& color, uint8_t intensity)
 	: m_color(color)
 	, m_intensity(intensity)

--- a/src/gui/ShortcutSystem.cpp
+++ b/src/gui/ShortcutSystem.cpp
@@ -18,6 +18,7 @@ ShortcutSystem::ShortcutSystem(IDataDispatcher& dataDispacher, QWidget* parent)
 	, QObject(parent)
 	, m_isEditing(false)
 	, m_notInContext(true)
+	, m_activeContext(ContextType::none)
 	, m_shortcutDefs({ { Qt::Key_Delete, &ShortcutSystem::slotDelete},
 						{ Qt::Key_A, &ShortcutSystem::slotAlignView2PointsFunction},
 						{ Qt::Key_B, &ShortcutSystem::slotBackground},
@@ -32,7 +33,9 @@ ShortcutSystem::ShortcutSystem(IDataDispatcher& dataDispacher, QWidget* parent)
 						{ Qt::Key_ScreenSaver, &ShortcutSystem::slotQuickScreenshot},
 						{ Qt::Key_F12, &ShortcutSystem::slotCreateHdImage},
 						{ Qt::Key_H, &ShortcutSystem::slotHideSelectedObjects},
-						{ Qt::Key_Escape, &ShortcutSystem::slotAbort }
+						{ Qt::Key_Escape, &ShortcutSystem::slotAbort },
+						{ Qt::Key_Return, &ShortcutSystem::slotValidateCurrentContext },
+						{ Qt::Key_Enter, &ShortcutSystem::slotValidateCurrentContext }
 		})
 {
 
@@ -91,6 +94,7 @@ void ShortcutSystem::onProjectLoad(IGuiData * data)
 void ShortcutSystem::onActivatedFunctions(IGuiData* data)
 {
 	GuiDataActivatedFunctions* function = static_cast<GuiDataActivatedFunctions*>(data);
+	m_activeContext = function->type;
 	m_notInContext = function->type == ContextType::none;
 }
 
@@ -103,10 +107,22 @@ void ShortcutSystem::slotDelete()
 void ShortcutSystem::slotAbort()
 {
 	GUI_LOG << "shortcut abort" << LOGENDL;
+	if (m_activeContext == ContextType::polygonalSelector)
+	{
+		m_dataDispatcher.sendControl(new control::function::Validate());
+		return;
+	}
+
 	if (m_notInContext)
 		m_dataDispatcher.updateInformation(new GuiDataDisableFullScreen());
 	m_dataDispatcher.sendControl(new control::function::Abort());
 	m_dataDispatcher.sendControl(new control::function::AbortSelection());
+}
+
+void ShortcutSystem::slotValidateCurrentContext()
+{
+	if (!m_notInContext || m_activeContext == ContextType::polygonalSelector)
+		m_dataDispatcher.sendControl(new control::function::Validate());
 }
 
 void ShortcutSystem::slotEdition(const bool& isEditing)

--- a/src/gui/forms/toolbar_selector.ui
+++ b/src/gui/forms/toolbar_selector.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>toolbar_selector</class>
+ <widget class="QWidget" name="toolbar_selector">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>360</width>
+    <height>110</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QToolButton" name="toolButton_polygonalSelector">
+     <property name="text">
+      <string>Selector</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QRadioButton" name="radioButtonShowSelected">
+     <property name="text">
+      <string>Show selected</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QRadioButton" name="radioButtonHideSelected">
+     <property name="text">
+      <string>Hide selected</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="pushButtonApply">
+     <property name="text">
+      <string>Apply</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="pushButtonDeactivate">
+     <property name="text">
+      <string>Deactivate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QPushButton" name="pushButtonReset">
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/toolBars/ToolBarPolygonalSelector.cpp
+++ b/src/gui/toolBars/ToolBarPolygonalSelector.cpp
@@ -1,0 +1,96 @@
+#include "gui/toolBars/ToolBarPolygonalSelector.h"
+
+#include "controller/controls/ControlFunction.h"
+#include "controller/controls/ControlFunctionClipping.h"
+#include "gui/GuiData/GuiDataGeneralProject.h"
+#include "gui/GuiData/GuiDataRendering.h"
+
+ToolBarPolygonalSelector::ToolBarPolygonalSelector(IDataDispatcher& dataDispatcher, QWidget* parent, float guiScale)
+    : QWidget(parent)
+    , m_dataDispatcher(dataDispatcher)
+{
+    m_ui.setupUi(this);
+    setEnabled(false);
+    m_ui.toolButton_polygonalSelector->setIconSize(QSize(20, 20) * guiScale);
+
+    connect(m_ui.toolButton_polygonalSelector, &QToolButton::clicked, this, &ToolBarPolygonalSelector::activateSelector);
+    connect(m_ui.pushButtonApply, &QPushButton::clicked, [this]() { applySettings(true); });
+    connect(m_ui.pushButtonDeactivate, &QPushButton::clicked, [this]() { applySettings(false); });
+    connect(m_ui.pushButtonReset, &QPushButton::clicked, [this]() { resetSettings(); });
+
+    connect(m_ui.radioButtonShowSelected, &QRadioButton::toggled, [this](bool) {
+        m_settings.showSelected = m_ui.radioButtonShowSelected->isChecked();
+        if (m_settings.enabled)
+            applySettings(true);
+    });
+
+    m_dataDispatcher.registerObserverOnKey(this, guiDType::projectLoaded);
+    m_dataDispatcher.registerObserverOnKey(this, guiDType::activatedFunctions);
+    m_dataDispatcher.registerObserverOnKey(this, guiDType::renderPolygonalSelector);
+
+    m_methods.insert({ guiDType::projectLoaded, &ToolBarPolygonalSelector::onProjectLoad });
+    m_methods.insert({ guiDType::activatedFunctions, &ToolBarPolygonalSelector::onActivatedFunctions });
+    m_methods.insert({ guiDType::renderPolygonalSelector, &ToolBarPolygonalSelector::onRenderSettings });
+}
+
+ToolBarPolygonalSelector::~ToolBarPolygonalSelector()
+{
+    m_dataDispatcher.unregisterObserver(this);
+}
+
+void ToolBarPolygonalSelector::informData(IGuiData* data)
+{
+    auto it = m_methods.find(data->getType());
+    if (it != m_methods.end())
+        (this->*(it->second))(data);
+}
+
+void ToolBarPolygonalSelector::onProjectLoad(IGuiData* data)
+{
+    setEnabled(static_cast<GuiDataProjectLoaded*>(data)->m_isProjectLoad);
+}
+
+void ToolBarPolygonalSelector::onActivatedFunctions(IGuiData* data)
+{
+    auto* functionData = static_cast<GuiDataActivatedFunctions*>(data);
+
+    m_ui.toolButton_polygonalSelector->blockSignals(true);
+    m_ui.toolButton_polygonalSelector->setChecked(functionData->type == ContextType::polygonalSelector);
+    m_ui.toolButton_polygonalSelector->blockSignals(false);
+}
+
+void ToolBarPolygonalSelector::onRenderSettings(IGuiData* data)
+{
+    auto* castData = static_cast<GuiDataRenderPolygonalSelector*>(data);
+    m_settings = castData->m_settings;
+
+    m_ui.radioButtonShowSelected->blockSignals(true);
+    m_ui.radioButtonHideSelected->blockSignals(true);
+    m_ui.radioButtonShowSelected->setChecked(m_settings.showSelected);
+    m_ui.radioButtonHideSelected->setChecked(!m_settings.showSelected);
+    m_ui.radioButtonShowSelected->blockSignals(false);
+    m_ui.radioButtonHideSelected->blockSignals(false);
+}
+
+void ToolBarPolygonalSelector::activateSelector()
+{
+    if (m_ui.toolButton_polygonalSelector->isChecked())
+        m_dataDispatcher.sendControl(new control::function::clipping::ActivatePolygonalSelector());
+    else
+        m_dataDispatcher.sendControl(new control::function::Abort());
+}
+
+void ToolBarPolygonalSelector::applySettings(bool enabled)
+{
+    m_settings.enabled = enabled;
+    m_settings.active = enabled;
+    m_settings.showSelected = m_ui.radioButtonShowSelected->isChecked();
+    m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()), this);
+}
+
+void ToolBarPolygonalSelector::resetSettings()
+{
+    m_settings = PolygonalSelectorSettings{};
+    m_ui.radioButtonShowSelected->setChecked(true);
+    m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()), this);
+}

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -49,6 +49,7 @@ namespace
         case ContextType::clippingBoxCreation:
         case ContextType::clippingBoxAttached3Points:
         case ContextType::clippingBoxAttached2Points:
+        case ContextType::polygonalSelector:
         case ContextType::boxDuplication:
         case ContextType::pointCloudObjectCreation:
         case ContextType::pointCloudObjectDuplication:
@@ -126,6 +127,7 @@ VulkanViewport::VulkanViewport(IDataDispatcher& dataDispatcher, float guiScale)
     registerGuiDataFunction(guiDType::renderDecimationOptions, &VulkanViewport::onRenderDecimationOptions);
 	registerGuiDataFunction(guiDType::renderOctreePrecision, &VulkanViewport::onRenderOctreePrecision);
     registerGuiDataFunction(guiDType::activatedFunctions, &VulkanViewport::onActivatedFunctions);
+    registerGuiDataFunction(guiDType::renderPolygonalSelector, &VulkanViewport::onRenderPolygonalSelectorPreview);
 }
 
 VulkanViewport::~VulkanViewport()
@@ -237,6 +239,21 @@ void VulkanViewport::onActivatedFunctions(IGuiData* data)
 {
     auto* functionData = static_cast<GuiDataActivatedFunctions*>(data);
     m_isDoubleClickExamineBlocked = blockExamineOnDoubleClick(functionData->type);
+    m_lockNavigationForCurrentContext = (functionData->type == ContextType::polygonalSelector);
+    if (!m_lockNavigationForCurrentContext)
+    {
+        m_polygonalSelectorPreview.clear();
+        m_polygonalSelectorPreviewClosed = false;
+    }
+}
+
+
+void VulkanViewport::onRenderPolygonalSelectorPreview(IGuiData* data)
+{
+    auto* selectorData = static_cast<GuiDataRenderPolygonalSelector*>(data);
+    m_polygonalSelectorPreview = selectorData->m_previewVertices;
+    m_polygonalSelectorPreviewClosed = selectorData->m_previewClosed;
+    m_refreshViewport = true;
 }
 
 void VulkanViewport::initSurface()
@@ -400,6 +417,17 @@ Rect2D VulkanViewport::getSelectionRect() const
 Rect2D VulkanViewport::getHoverRect() const
 {
     return m_hoverRect;
+}
+
+
+const std::vector<glm::vec2>& VulkanViewport::getPolygonalSelectorPreview() const
+{
+    return m_polygonalSelectorPreview;
+}
+
+bool VulkanViewport::isPolygonalSelectorPreviewClosed() const
+{
+    return m_polygonalSelectorPreviewClosed;
 }
 
 glm::ivec2 VulkanViewport::getMousePos() const
@@ -588,9 +616,13 @@ void VulkanViewport::mousePressEvent(QMouseEvent *_event)
         m_MI.leftButtonPressed = true;
         break;
     case Qt::RightButton:
+        if (m_lockNavigationForCurrentContext)
+            break;
         m_MI.rightButtonPressed = true;
         break;
     case Qt::MiddleButton:
+        if (m_lockNavigationForCurrentContext)
+            break;
         m_MI.middleButtonPressed = true;
         break;
     default:
@@ -816,12 +848,24 @@ void VulkanViewport::keyReleaseEvent(QKeyEvent* _event)
 
 void VulkanViewport::wheelEvent(QWheelEvent* _event)
 {
+    if (m_lockNavigationForCurrentContext)
+        return;
+
     m_MI.wheel += m_navParams.wheelInverted ? _event->angleDelta().y() : -_event->angleDelta().y();
 }
 
 void VulkanViewport::updateMouseInputEffect(WritePtr<CameraNode>& wCam, SafePtr<ManipulatorNode>& manipNode)
 {
     std::lock_guard<std::mutex> lock(m_inputMutex);
+
+    if (m_lockNavigationForCurrentContext)
+    {
+        m_mouseInputEffect = MouseInputEffect::None;
+        m_MI.deltaX = 0;
+        m_MI.deltaY = 0;
+        m_MI.wheel = 0;
+        return;
+    }
 
     bool hasMoved = (m_MI.deltaX != 0) || (m_MI.deltaY != 0);
 
@@ -1062,6 +1106,17 @@ void VulkanViewport::applyMouseInput(WritePtr<CameraNode>& wCam, SafePtr<Manipul
 void VulkanViewport::applyKeyboardInput(WritePtr<CameraNode>& wCam)
 {
     std::lock_guard<std::mutex> lock(m_inputMutex);
+
+    if (m_lockNavigationForCurrentContext)
+    {
+        if (wCam)
+        {
+            wCam->setSpeedRight(0.0);
+            wCam->setSpeedForward(0.0);
+            wCam->setSpeedUp(0.0);
+        }
+        return;
+    }
 
     double leftRightSum(0.);
     double upDownSum(0.);

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -402,6 +402,40 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 		} }
 	};
 
+	json[Key_Polygonal_Selector] = {
+		{ Key_Polygonal_Selector_Enabled, params.m_polygonalSelector.enabled },
+		{ Key_Polygonal_Selector_Show, params.m_polygonalSelector.showSelected },
+		{ Key_Polygonal_Selector_Active, params.m_polygonalSelector.active },
+		{ Key_Polygonal_Selector_Polygons, nlohmann::json::array() }
+	};
+
+	for (const PolygonalSelectorPolygon& polygon : params.m_polygonalSelector.polygons)
+	{
+		nlohmann::json polygonJson;
+		polygonJson[Key_Polygonal_Selector_Vertices] = nlohmann::json::array();
+		for (const glm::vec2& vertex : polygon.normalizedVertices)
+			polygonJson[Key_Polygonal_Selector_Vertices].push_back({ vertex.x, vertex.y });
+
+		polygonJson[Key_Polygonal_Selector_Camera] = {
+			{ Key_Polygonal_Selector_Cam_View, {
+				polygon.camera.view[0][0], polygon.camera.view[0][1], polygon.camera.view[0][2], polygon.camera.view[0][3],
+				polygon.camera.view[1][0], polygon.camera.view[1][1], polygon.camera.view[1][2], polygon.camera.view[1][3],
+				polygon.camera.view[2][0], polygon.camera.view[2][1], polygon.camera.view[2][2], polygon.camera.view[2][3],
+				polygon.camera.view[3][0], polygon.camera.view[3][1], polygon.camera.view[3][2], polygon.camera.view[3][3]
+			} },
+			{ Key_Polygonal_Selector_Cam_Proj, {
+				polygon.camera.proj[0][0], polygon.camera.proj[0][1], polygon.camera.proj[0][2], polygon.camera.proj[0][3],
+				polygon.camera.proj[1][0], polygon.camera.proj[1][1], polygon.camera.proj[1][2], polygon.camera.proj[1][3],
+				polygon.camera.proj[2][0], polygon.camera.proj[2][1], polygon.camera.proj[2][2], polygon.camera.proj[2][3],
+				polygon.camera.proj[3][0], polygon.camera.proj[3][1], polygon.camera.proj[3][2], polygon.camera.proj[3][3]
+			} },
+			{ Key_Polygonal_Selector_Cam_Viewport, { polygon.camera.viewportWidth, polygon.camera.viewportHeight } },
+			{ Key_Polygonal_Selector_Cam_Perspective, polygon.camera.perspective }
+		};
+
+		json[Key_Polygonal_Selector][Key_Polygonal_Selector_Polygons].push_back(polygonJson);
+	}
+
 	json[Key_Ortho_Grid_Active] = params.m_orthoGridActive;
 	json[Key_Ortho_Grid_Color] = { params.m_orthoGridColor.r, params.m_orthoGridColor.g, params.m_orthoGridColor.b, params.m_orthoGridColor.a };
 	json[Key_Ortho_Grid_Step] = params.m_orthoGridStep;

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -713,6 +713,69 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
         }
     }
 
+    if (json.find(Key_Polygonal_Selector) != json.end())
+    {
+        const auto& selectorJson = json.at(Key_Polygonal_Selector);
+        if (selectorJson.find(Key_Polygonal_Selector_Enabled) != selectorJson.end())
+            data.m_polygonalSelector.enabled = selectorJson.at(Key_Polygonal_Selector_Enabled).get<bool>();
+        if (selectorJson.find(Key_Polygonal_Selector_Show) != selectorJson.end())
+            data.m_polygonalSelector.showSelected = selectorJson.at(Key_Polygonal_Selector_Show).get<bool>();
+        if (selectorJson.find(Key_Polygonal_Selector_Active) != selectorJson.end())
+            data.m_polygonalSelector.active = selectorJson.at(Key_Polygonal_Selector_Active).get<bool>();
+
+        if (selectorJson.find(Key_Polygonal_Selector_Polygons) != selectorJson.end())
+        {
+            data.m_polygonalSelector.polygons.clear();
+            const auto& polygons = selectorJson.at(Key_Polygonal_Selector_Polygons);
+            for (const auto& polygonJson : polygons)
+            {
+                PolygonalSelectorPolygon polygon;
+
+                if (polygonJson.find(Key_Polygonal_Selector_Vertices) != polygonJson.end())
+                {
+                    const auto& vertices = polygonJson.at(Key_Polygonal_Selector_Vertices);
+                    for (const auto& vertexJson : vertices)
+                    {
+                        if (vertexJson.size() >= 2)
+                            polygon.normalizedVertices.emplace_back(vertexJson.at(0).get<float>(), vertexJson.at(1).get<float>());
+                    }
+                }
+
+                if (polygonJson.find(Key_Polygonal_Selector_Camera) != polygonJson.end())
+                {
+                    const auto& cameraJson = polygonJson.at(Key_Polygonal_Selector_Camera);
+
+                    auto readMat4 = [](const nlohmann::json& arr, glm::dmat4& out)
+                    {
+                        if (!arr.is_array() || arr.size() != 16)
+                            return;
+                        for (int c = 0; c < 4; ++c)
+                            for (int r = 0; r < 4; ++r)
+                                out[c][r] = arr.at(c * 4 + r).get<double>();
+                    };
+
+                    if (cameraJson.find(Key_Polygonal_Selector_Cam_View) != cameraJson.end())
+                        readMat4(cameraJson.at(Key_Polygonal_Selector_Cam_View), polygon.camera.view);
+                    if (cameraJson.find(Key_Polygonal_Selector_Cam_Proj) != cameraJson.end())
+                        readMat4(cameraJson.at(Key_Polygonal_Selector_Cam_Proj), polygon.camera.proj);
+                    if (cameraJson.find(Key_Polygonal_Selector_Cam_Viewport) != cameraJson.end())
+                    {
+                        const auto& viewport = cameraJson.at(Key_Polygonal_Selector_Cam_Viewport);
+                        if (viewport.size() >= 2)
+                        {
+                            polygon.camera.viewportWidth = viewport.at(0).get<uint32_t>();
+                            polygon.camera.viewportHeight = viewport.at(1).get<uint32_t>();
+                        }
+                    }
+                    if (cameraJson.find(Key_Polygonal_Selector_Cam_Perspective) != cameraJson.end())
+                        polygon.camera.perspective = cameraJson.at(Key_Polygonal_Selector_Cam_Perspective).get<bool>();
+                }
+
+                data.m_polygonalSelector.polygons.push_back(std::move(polygon));
+            }
+        }
+    }
+
     if (json.find(Key_Marker_Rendering_Parameters) != json.end())
     {
         nlohmann::json options = json.at(Key_Marker_Rendering_Parameters);

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -69,6 +69,7 @@ CameraNode::CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher
     registerGuiDataFunction(guiDType::renderDepthLining, &CameraNode::onRenderDepthLining);
     registerGuiDataFunction(guiDType::renderRampScale, &CameraNode::onRenderRampScale);
     registerGuiDataFunction(guiDType::renderColorimetricFilter, &CameraNode::onRenderColorimetricFilter);
+    registerGuiDataFunction(guiDType::renderPolygonalSelector, &CameraNode::onRenderPolygonalSelector);
     registerGuiDataFunction(guiDType::renderFovValueChanged, &CameraNode::onRenderFov);
     registerGuiDataFunction(guiDType::renderExamine, &CameraNode::onRenderExamine);
     registerGuiDataFunction(guiDType::examineOptions, &CameraNode::onExamineOptions);
@@ -1552,6 +1553,13 @@ void CameraNode::onRenderColorimetricFilter(IGuiData* data)
 {
     auto castData = static_cast<GuiDataRenderColorimetricFilter*>(data);
     m_colorimetricFilter = castData->m_settings;
+    sendNewUIViewPoint();
+}
+
+void CameraNode::onRenderPolygonalSelector(IGuiData* data)
+{
+    auto castData = static_cast<GuiDataRenderPolygonalSelector*>(data);
+    m_polygonalSelector = castData->m_settings;
     sendNewUIViewPoint();
 }
 

--- a/src/pointCloudEngine/RenderingEcoSystem.cpp
+++ b/src/pointCloudEngine/RenderingEcoSystem.cpp
@@ -151,6 +151,30 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
         hash += hash_fn_b(display.m_colorimetricFilter.colorsEnabled[i]);
     }
 
+    hash += hash_fn_b(display.m_polygonalSelector.enabled);
+    hash += hash_fn_b(display.m_polygonalSelector.showSelected);
+    hash += hash_fn_b(display.m_polygonalSelector.active);
+    hash += hash_fn_64(static_cast<uint64_t>(display.m_polygonalSelector.polygons.size()));
+    for (const PolygonalSelectorPolygon& polygon : display.m_polygonalSelector.polygons)
+    {
+        hash += hash_fn_64(static_cast<uint64_t>(polygon.normalizedVertices.size()));
+        for (const glm::vec2& vertex : polygon.normalizedVertices)
+        {
+            hash += hash_fn_f(vertex.x);
+            hash += hash_fn_f(vertex.y);
+        }
+
+        for (int c = 0; c < 4; ++c)
+            for (int r = 0; r < 4; ++r)
+            {
+                hash += hash_fn_d(polygon.camera.view[c][r]);
+                hash += hash_fn_d(polygon.camera.proj[c][r]);
+            }
+        hash += hash_fn_32(polygon.camera.viewportWidth);
+        hash += hash_fn_32(polygon.camera.viewportHeight);
+        hash += hash_fn_b(polygon.camera.perspective);
+    }
+
     //hash += hash_fn_f(display.m_alphaObject);             // Do not affect the point cloud
 
     return hash;

--- a/src/pointCloudEngine/RenderingEngine.cpp
+++ b/src/pointCloudEngine/RenderingEngine.cpp
@@ -1144,6 +1144,35 @@ void RenderingEngine::drawSelectionRect(VkCommandBuffer, const VulkanViewport& v
         }
     }
 
+    // Polygonal selector preview
+    {
+        const std::vector<glm::vec2>& preview = viewport.getPolygonalSelectorPreview();
+        if (!preview.empty())
+        {
+            ImU32 selectorColor = IM_COL32(242, 214, 0, 255);
+            const float thickness = 2.0f;
+
+            for (size_t i = 1; i < preview.size(); ++i)
+            {
+                ImVec2 p0(preview[i - 1].x * extent.width, preview[i - 1].y * extent.height);
+                ImVec2 p1(preview[i].x * extent.width, preview[i].y * extent.height);
+                dl->AddLine(p0, p1, selectorColor, thickness);
+            }
+
+            for (const glm::vec2& p : preview)
+            {
+                dl->AddCircleFilled(ImVec2(p.x * extent.width, p.y * extent.height), 3.0f, selectorColor);
+            }
+
+            if (viewport.isPolygonalSelectorPreviewClosed() && preview.size() > 2)
+            {
+                ImVec2 first(preview.front().x * extent.width, preview.front().y * extent.height);
+                ImVec2 last(preview.back().x * extent.width, preview.back().y * extent.height);
+                dl->AddLine(last, first, selectorColor, thickness);
+            }
+        }
+    }
+
     ImGui::End();
     ImGui::PopStyleVar();
     ImGui::PopStyleColor(2);


### PR DESCRIPTION
### Motivation
- Make the Polygonal Selector state (enabled/active/show, polygons and camera snapshots) persist across saved viewpoints and display presets and ensure changes trigger correct render refreshes and UI restoration.
- Integrate selector preview into the viewport overlay and lock navigation while the selector context is active to avoid input conflicts.

### Description
- Data model: added PolygonalSelectorSettings, PolygonalSelectorPolygon and PolygonalSelectorCameraSnapshot to `DisplayParameters` to carry selector state and per-polygon camera snapshots.
- Serialization: added serializer keys and extended export/import paths (`DataSerializer`, `DataDeserializer`, `SerializerKeys.h`) to persist polygonal selector settings and polygons (vertices + camera view/proj/viewport/perspective).
- Presets & viewpoints: extended `DisplayPresetManager` to serialize/deserialize polygonal selector and to dispatch `GuiDataRenderPolygonalSelector` when applying presets so the UI/camera restores selector state.
- GUI & controls: added toolbar UI (`toolbar_selector.ui`, `ToolBarPolygonalSelector`), wired it into the ribbon (`Gui.cpp`, project files), created `GuiDataRenderPolygonalSelector` and new guiDType, and added control/context plumbing (`ControlFunctionClipping`, `IControl`, `ContextPolygonalSelector`, `ContextFactory`) to enter/validate/abort the selector workflow and record polygons.
- Viewport & rendering: added preview handling and preview draw in `VulkanViewport` / `RenderingEngine` (preview lines, points and closing line), and made viewport lock navigation/input when polygonal selector context is active to prevent conflicts.
- Shortcuts: extended `ShortcutSystem` to track active context and validate polygonal selector with Enter/Return, and to change abort behavior while in selector context.
- Render hashing: updated `RenderingEcoSystem::hashRenderingData` to include polygonal selector state (enabled/active/show, polygon payload and camera snapshots) so selector changes influence rendering cache/refresh decisions.

### Testing
- Ran static symbol/search checks to verify new keys/types are referenced (`rg` scans for `Key_Polygonal_Selector`, `GuiDataRenderPolygonalSelector`, `m_polygonalSelector`) and found expected usages across producer/consumer code paths; success.
- Ran a repository diff/lint check for whitespace/merge issues (`diff --check`) with no reported problems; success.
- Verified project file and build lists were updated (headers/sources/forms added) and source changes staged for persistence; staging/consistency checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e22a9ebd4832f9d8d777158b7dbde)