### PR TITLE
Remove duplicate Enter/Return shortcuts and unconditionally trigger Validate in ShortcutSystem

### DIFF
--- a/src/gui/ShortcutSystem.cpp
+++ b/src/gui/ShortcutSystem.cpp
@@ -34,8 +34,6 @@ ShortcutSystem::ShortcutSystem(IDataDispatcher& dataDispacher, QWidget* parent)
 						{ Qt::Key_F12, &ShortcutSystem::slotCreateHdImage},
 						{ Qt::Key_H, &ShortcutSystem::slotHideSelectedObjects},
 						{ Qt::Key_Escape, &ShortcutSystem::slotAbort },
-						{ Qt::Key_Return, &ShortcutSystem::slotValidateCurrentContext },
-						{ Qt::Key_Enter, &ShortcutSystem::slotValidateCurrentContext }
 		})
 {
 
@@ -121,8 +119,7 @@ void ShortcutSystem::slotAbort()
 
 void ShortcutSystem::slotValidateCurrentContext()
 {
-	if (!m_notInContext || m_activeContext == ContextType::polygonalSelector)
-		m_dataDispatcher.sendControl(new control::function::Validate());
+	m_dataDispatcher.sendControl(new control::function::Validate());
 }
 
 void ShortcutSystem::slotEdition(const bool& isEditing)


### PR DESCRIPTION
### Motivation
- Enter/Return were registered in both `ShortcutSystem` and `ViewportOrganizer`, causing conflicting shortcut activation and preventing the validate action from reliably firing.

### Description
- Removed `Qt::Key_Return` and `Qt::Key_Enter` entries from `m_shortcutDefs` in `src/gui/ShortcutSystem.cpp`.
- Changed `slotValidateCurrentContext()` to always call `m_dataDispatcher.sendControl(new control::function::Validate());` so Validate is dispatched when invoked.
- Kept Enter/Return handling in `ViewportOrganizer` as the single registration point to avoid duplicate bindings.

### Testing
- Verified the modified `ShortcutSystem` and existing `ViewportOrganizer` bindings with `nl -ba src/gui/ShortcutSystem.cpp | sed -n '24,44p'` and `nl -ba src/gui/viewport/ViewportOrganizer.cpp | sed -n '59,66p'`, which showed the duplicate entries removed and ViewportOrganizer registrations present (succeeded).
- Confirmed there are no remaining `Key_Return`/`Key_Enter` definitions across the two files using `rg -n "Key_Return|Key_Enter" src/gui/ShortcutSystem.cpp src/gui/viewport/ViewportOrganizer.cpp` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3a290e38832f9df7cf02b6e12ca4)