### PR TITLE
Add polygon manage/delete mode and persistent polygon naming

### DIFF
--- a/include/gui/toolBars/ToolBarPolygonalSelector.h
+++ b/include/gui/toolBars/ToolBarPolygonalSelector.h
@@ -25,6 +25,12 @@ private:
     void activateSelector();
     void applySettings(bool enabled);
     void resetSettings();
+    void setManageMode(bool enabled);
+    void onPolygonSelectionChanged(int index);
+    void deleteSelectedPolygon();
+    void refreshPolygonList();
+    void sendSettingsUpdate();
+    void clearManageSelection();
 
 private:
     typedef void (ToolBarPolygonalSelector::*GuiDataMethod)(IGuiData*);

--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -256,6 +256,7 @@
 #define Key_Polygonal_Selector_PendingApply "PolygonalSelectorPendingApply"
 #define Key_Polygonal_Selector_AppliedCount "PolygonalSelectorAppliedPolygonCount"
 #define Key_Polygonal_Selector_Polygons	"PolygonalSelectorPolygons"
+#define Key_Polygonal_Selector_Name	"PolygonalSelectorName"
 #define Key_Polygonal_Selector_Vertices	"PolygonalSelectorVertices"
 #define Key_Polygonal_Selector_Camera		"PolygonalSelectorCamera"
 #define Key_Polygonal_Selector_Cam_View	"PolygonalSelectorCameraView"

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -9,6 +9,8 @@
 
 #include <glm/glm.hpp>
 #include <array>
+#include <cstdint>
+#include <string>
 #include <vector>
 
 struct PolygonalSelectorCameraSnapshot
@@ -22,6 +24,7 @@ struct PolygonalSelectorCameraSnapshot
 
 struct PolygonalSelectorPolygon
 {
+    std::string name;
     std::vector<glm::vec2> normalizedVertices;
     PolygonalSelectorCameraSnapshot camera;
 };
@@ -33,6 +36,8 @@ struct PolygonalSelectorSettings
     bool active = false;
     bool pendingApply = false;
     uint32_t appliedPolygonCount = 0;
+    int32_t highlightedPolygonIndex = -1;
+    bool manageMode = false;
     std::vector<PolygonalSelectorPolygon> polygons;
 };
 

--- a/include/pointCloudEngine/RenderingTypes.h
+++ b/include/pointCloudEngine/RenderingTypes.h
@@ -111,7 +111,7 @@ struct ColorimetricFilterUniform
     glm::vec4 settings = {}; // x: enabled, y: showColors, z: tolerance(0-1), w: intensityMode
 
     glm::vec4 polygonSettings = {}; // x: enabled, y: showSelected, z: active, w: appliedPolygonCount
-    glm::vec4 polygonCounts = {};   // x: totalPolygonCount, y: pendingApply(0/1)
+    glm::vec4 polygonCounts = {};   // x: totalPolygonCount, y: pendingApply(0/1), z: highlightedPolygonIndex, w: manageMode(0/1)
     glm::mat4 polygonViewProj[8] = {};
     glm::vec4 polygonVertices[8 * 32] = {}; // xy: normalized screen coords
     glm::vec4 polygonMeta[8] = {}; // x: vertexCount

--- a/src/gui/forms/toolbar_selector.ui
+++ b/src/gui/forms/toolbar_selector.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>360</width>
+    <width>780</width>
     <height>110</height>
    </rect>
   </property>
@@ -68,6 +68,64 @@
       <string>Reset</string>
      </property>
     </widget>
+   </item>
+   <item row="0" column="3" rowspan="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="4" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_manageRow">
+     <item>
+      <widget class="QLabel" name="labelPolygonList">
+       <property name="text">
+        <string>List</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBox_polygonList"/>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox_managePolygon">
+       <property name="text">
+        <string>Manage</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="4" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_deleteRow">
+     <item>
+      <widget class="QPushButton" name="deletePolygonButton">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacerRight">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/gui/toolBars/ToolBarPolygonalSelector.cpp
+++ b/src/gui/toolBars/ToolBarPolygonalSelector.cpp
@@ -5,6 +5,9 @@
 #include "gui/GuiData/GuiDataGeneralProject.h"
 #include "gui/GuiData/GuiDataRendering.h"
 
+#include <algorithm>
+#include <string>
+
 ToolBarPolygonalSelector::ToolBarPolygonalSelector(IDataDispatcher& dataDispatcher, QWidget* parent, float guiScale)
     : QWidget(parent)
     , m_dataDispatcher(dataDispatcher)
@@ -12,15 +15,20 @@ ToolBarPolygonalSelector::ToolBarPolygonalSelector(IDataDispatcher& dataDispatch
     m_ui.setupUi(this);
     setEnabled(false);
     m_ui.toolButton_polygonalSelector->setIconSize(QSize(20, 20) * guiScale);
+    m_ui.comboBox_polygonList->setEnabled(false);
+    m_ui.deletePolygonButton->setEnabled(false);
 
     connect(m_ui.toolButton_polygonalSelector, &QToolButton::clicked, this, &ToolBarPolygonalSelector::activateSelector);
     connect(m_ui.pushButtonApply, &QPushButton::clicked, [this]() { applySettings(true); });
     connect(m_ui.pushButtonDeactivate, &QPushButton::clicked, [this]() { applySettings(false); });
     connect(m_ui.pushButtonReset, &QPushButton::clicked, [this]() { resetSettings(); });
+    connect(m_ui.checkBox_managePolygon, &QCheckBox::toggled, this, &ToolBarPolygonalSelector::setManageMode);
+    connect(m_ui.comboBox_polygonList, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ToolBarPolygonalSelector::onPolygonSelectionChanged);
+    connect(m_ui.deletePolygonButton, &QPushButton::clicked, this, &ToolBarPolygonalSelector::deleteSelectedPolygon);
 
     connect(m_ui.radioButtonShowSelected, &QRadioButton::toggled, [this](bool) {
         m_settings.showSelected = m_ui.radioButtonShowSelected->isChecked();
-        m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()), this);
+        sendSettingsUpdate();
     });
 
     m_dataDispatcher.registerObserverOnKey(this, guiDType::projectLoaded);
@@ -62,13 +70,25 @@ void ToolBarPolygonalSelector::onRenderSettings(IGuiData* data)
 {
     auto* castData = static_cast<GuiDataRenderPolygonalSelector*>(data);
     m_settings = castData->m_settings;
+    for (size_t i = 0; i < m_settings.polygons.size(); ++i)
+    {
+        if (m_settings.polygons[i].name.empty())
+            m_settings.polygons[i].name = std::string("polygon_") + std::to_string(i + 1);
+    }
 
     m_ui.radioButtonShowSelected->blockSignals(true);
     m_ui.radioButtonHideSelected->blockSignals(true);
+    m_ui.checkBox_managePolygon->blockSignals(true);
+
     m_ui.radioButtonShowSelected->setChecked(m_settings.showSelected);
     m_ui.radioButtonHideSelected->setChecked(!m_settings.showSelected);
+    m_ui.checkBox_managePolygon->setChecked(m_settings.manageMode);
+
     m_ui.radioButtonShowSelected->blockSignals(false);
     m_ui.radioButtonHideSelected->blockSignals(false);
+    m_ui.checkBox_managePolygon->blockSignals(false);
+
+    refreshPolygonList();
 }
 
 void ToolBarPolygonalSelector::activateSelector()
@@ -96,7 +116,7 @@ void ToolBarPolygonalSelector::applySettings(bool enabled)
         m_settings.active = false;
     }
 
-    m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()), this);
+    sendSettingsUpdate();
 }
 
 void ToolBarPolygonalSelector::resetSettings()
@@ -105,5 +125,106 @@ void ToolBarPolygonalSelector::resetSettings()
     m_settings.appliedPolygonCount = 0;
     m_settings.pendingApply = false;
     m_ui.radioButtonShowSelected->setChecked(true);
+    m_ui.checkBox_managePolygon->setChecked(false);
+    sendSettingsUpdate();
+}
+
+void ToolBarPolygonalSelector::setManageMode(bool enabled)
+{
+    m_settings.manageMode = enabled;
+
+    if (enabled)
+    {
+        m_ui.toolButton_polygonalSelector->setChecked(false);
+        m_dataDispatcher.sendControl(new control::function::Abort());
+    }
+
+    m_ui.toolButton_polygonalSelector->setEnabled(!enabled);
+    m_ui.comboBox_polygonList->setEnabled(enabled && m_ui.comboBox_polygonList->count() > 0);
+
+    if (!enabled)
+        clearManageSelection();
+    else
+        onPolygonSelectionChanged(m_ui.comboBox_polygonList->currentIndex());
+
+    refreshPolygonList();
+    sendSettingsUpdate();
+}
+
+void ToolBarPolygonalSelector::onPolygonSelectionChanged(int index)
+{
+    if (!m_settings.manageMode)
+    {
+        clearManageSelection();
+        return;
+    }
+
+    if (index >= 0 && index < static_cast<int>(m_settings.polygons.size()))
+        m_settings.highlightedPolygonIndex = index;
+    else
+        m_settings.highlightedPolygonIndex = -1;
+
+    m_ui.deletePolygonButton->setEnabled(m_settings.highlightedPolygonIndex >= 0);
+    sendSettingsUpdate();
+}
+
+void ToolBarPolygonalSelector::deleteSelectedPolygon()
+{
+    if (!m_settings.manageMode)
+        return;
+
+    const int selectedIndex = m_ui.comboBox_polygonList->currentIndex();
+    if (selectedIndex < 0 || selectedIndex >= static_cast<int>(m_settings.polygons.size()))
+        return;
+
+    m_settings.polygons.erase(m_settings.polygons.begin() + selectedIndex);
+
+    const uint32_t polygonCount = static_cast<uint32_t>(m_settings.polygons.size());
+    m_settings.appliedPolygonCount = std::min<uint32_t>(m_settings.appliedPolygonCount, polygonCount);
+    m_settings.pendingApply = (m_settings.appliedPolygonCount < polygonCount);
+    if (polygonCount == 0)
+    {
+        m_settings.enabled = false;
+        m_settings.active = false;
+    }
+
+    clearManageSelection();
+    refreshPolygonList();
+
+    if (m_settings.manageMode && m_ui.comboBox_polygonList->count() > 0)
+    {
+        m_ui.comboBox_polygonList->setCurrentIndex(std::min(selectedIndex, m_ui.comboBox_polygonList->count() - 1));
+        m_settings.highlightedPolygonIndex = m_ui.comboBox_polygonList->currentIndex();
+    }
+
+    m_ui.deletePolygonButton->setEnabled(m_settings.highlightedPolygonIndex >= 0);
+    sendSettingsUpdate();
+}
+
+void ToolBarPolygonalSelector::refreshPolygonList()
+{
+    m_ui.comboBox_polygonList->blockSignals(true);
+    m_ui.comboBox_polygonList->clear();
+    for (const PolygonalSelectorPolygon& polygon : m_settings.polygons)
+        m_ui.comboBox_polygonList->addItem(QString::fromStdString(polygon.name));
+
+    if (m_settings.highlightedPolygonIndex >= 0 && m_settings.highlightedPolygonIndex < m_ui.comboBox_polygonList->count())
+        m_ui.comboBox_polygonList->setCurrentIndex(m_settings.highlightedPolygonIndex);
+
+    m_ui.comboBox_polygonList->blockSignals(false);
+
+    m_ui.comboBox_polygonList->setEnabled(m_settings.manageMode && m_ui.comboBox_polygonList->count() > 0);
+    m_ui.deletePolygonButton->setEnabled(m_settings.manageMode && m_settings.highlightedPolygonIndex >= 0);
+    m_ui.toolButton_polygonalSelector->setEnabled(!m_settings.manageMode);
+}
+
+void ToolBarPolygonalSelector::sendSettingsUpdate()
+{
     m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(m_settings, SafePtr<CameraNode>()), this);
+}
+
+void ToolBarPolygonalSelector::clearManageSelection()
+{
+    m_settings.highlightedPolygonIndex = -1;
+    m_ui.deletePolygonButton->setEnabled(false);
 }

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -414,6 +414,7 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 	for (const PolygonalSelectorPolygon& polygon : params.m_polygonalSelector.polygons)
 	{
 		nlohmann::json polygonJson;
+		polygonJson[Key_Polygonal_Selector_Name] = polygon.name;
 		polygonJson[Key_Polygonal_Selector_Vertices] = nlohmann::json::array();
 		for (const glm::vec2& vertex : polygon.normalizedVertices)
 			polygonJson[Key_Polygonal_Selector_Vertices].push_back({ vertex.x, vertex.y });

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -40,6 +40,15 @@
 #include "magic_enum/magic_enum.hpp"
 
 #include <algorithm>
+#include <string>
+
+namespace
+{
+std::string makePolygonNameFromIndex(size_t index)
+{
+    return std::string("polygon_") + std::to_string(index + 1);
+}
+}
 
 #define IOLOG Logger::log(LoggerMode::IOLog)
 
@@ -737,6 +746,9 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
             {
                 PolygonalSelectorPolygon polygon;
 
+                if (polygonJson.find(Key_Polygonal_Selector_Name) != polygonJson.end())
+                    polygon.name = polygonJson.at(Key_Polygonal_Selector_Name).get<std::string>();
+
                 if (polygonJson.find(Key_Polygonal_Selector_Vertices) != polygonJson.end())
                 {
                     const auto& vertices = polygonJson.at(Key_Polygonal_Selector_Vertices);
@@ -778,6 +790,12 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
                 }
 
                 data.m_polygonalSelector.polygons.push_back(std::move(polygon));
+            }
+
+            for (size_t i = 0; i < data.m_polygonalSelector.polygons.size(); ++i)
+            {
+                if (data.m_polygonalSelector.polygons[i].name.empty())
+                    data.m_polygonalSelector.polygons[i].name = makePolygonNameFromIndex(i);
             }
 
             data.m_polygonalSelector.appliedPolygonCount = std::min<uint32_t>(

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -234,8 +234,8 @@ ColorimetricFilterUniform CameraNode::buildColorimetricFilterUniform() const
                                         static_cast<float>(std::min<uint32_t>(selector.appliedPolygonCount, polygonCount)));
     uniform.polygonCounts = glm::vec4(static_cast<float>(polygonCount),
                                      selector.pendingApply ? 1.0f : 0.0f,
-                                     0.0f,
-                                     0.0f);
+                                     static_cast<float>(selector.highlightedPolygonIndex),
+                                     selector.manageMode ? 1.0f : 0.0f);
 
     for (uint32_t pIndex = 0; pIndex < polygonCount; ++pIndex)
     {


### PR DESCRIPTION
### Motivation
- Provide a way for users to manage existing polygonal selectors (list, select/highlight, delete) without drawing new polygons. 
- Persist human-readable polygon identities across saves/presets to allow deterministic selection and reuse. 
- Highlight the selected polygon in the GPU pipeline when manage mode is active so users can see which polygon is targeted.

### Description
- Added persistent polygon `name` to `PolygonalSelectorPolygon` and transient UI state `highlightedPolygonIndex` and `manageMode` to `PolygonalSelectorSettings` (see `include/models/3d/DisplayParameters.h`).
- Implemented toolbar UI controls (`List` combobox, `Manage` checkbox, `Delete` button) in `src/gui/forms/toolbar_selector.ui` and a new panel implementation `ToolBarPolygonalSelector` (`include/gui/toolBars/ToolBarPolygonalSelector.h` / `src/gui/toolBars/ToolBarPolygonalSelector.cpp`) to drive manage-mode behavior and emit updates via `GuiDataRenderPolygonalSelector`.
- Added deterministic naming logic (`makePolygonName` / `makePolygonNameFromIndex`) and an 8-polygon guard with a user `GuiDataWarning` in `ContextPolygonalSelector` to reuse name holes and limit count (`src/controller/functionSystem/ContextPolygonalSelector.cpp`).
- Made polygon names part of serialization by adding `Key_Polygonal_Selector_Name` and writing/reading the name in `DataSerializer`, `DataDeserializer` and `DisplayPresetManager`, with backward compatibility that auto-generates `polygon_<index>` when names are missing (`include/io/SerializerKeys.h`, `src/io/exports/DataSerializer.cpp`, `src/io/imports/DataDeserializer.cpp`, `src/gui/DisplayPresetManager.cpp`).
- Extended GPU uniform payload to include `highlightedPolygonIndex` and `manageMode`, updated camera upload (`CameraNode::buildColorimetricFilterUniform`) and shader to compute/manage point highlighting for the selected polygon (`include/pointCloudEngine/RenderingTypes.h`, `src/models/graph/CameraNode.cpp`, `src/shaders/blocks/block_point_input_vert.glsl`).

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and it passed. 
- Used targeted `rg` searches for the new symbols (`highlightedPolygonIndex`, `manageMode`, `PolygonalSelectorName`) to verify the changes were applied and found expected references. 
- Verified the working tree and performed the commit (`git status --short` / `git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f68a2dbb0832fbd1f90c22d2781a0)