### PR TITLE
Increase polygon selector capacity to 16 and centralize limits

### DIFF
--- a/include/pointCloudEngine/RenderingLimits.h
+++ b/include/pointCloudEngine/RenderingLimits.h
@@ -1,7 +1,12 @@
 #ifndef RENDERING_LIMITS_H
 #define RENDERING_LIMITS_H
 
+#include <cstdint>
+
 constexpr int MAX_CLIPPING_PER_CELL = 31;
 constexpr int MAX_ACTIVE_CLIPPING = 512;
+
+constexpr uint32_t MAX_POLYGONAL_SELECTOR_POLYGONS = 16;
+constexpr uint32_t MAX_POLYGONAL_SELECTOR_VERTICES = 32;
 
 #endif

--- a/include/pointCloudEngine/RenderingTypes.h
+++ b/include/pointCloudEngine/RenderingTypes.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <glm/glm.hpp>
+#include "pointCloudEngine/RenderingLimits.h"
 
 // RenderColorInput
 enum class UiRenderMode
@@ -112,9 +113,9 @@ struct ColorimetricFilterUniform
 
     glm::vec4 polygonSettings = {}; // x: enabled, y: showSelected, z: active, w: appliedPolygonCount
     glm::vec4 polygonCounts = {};   // x: totalPolygonCount, y: pendingApply(0/1), z: highlightedPolygonIndex, w: manageMode(0/1)
-    glm::mat4 polygonViewProj[8] = {};
-    glm::vec4 polygonVertices[8 * 32] = {}; // xy: normalized screen coords
-    glm::vec4 polygonMeta[8] = {}; // x: vertexCount
+    glm::mat4 polygonViewProj[MAX_POLYGONAL_SELECTOR_POLYGONS] = {};
+    glm::vec4 polygonVertices[MAX_POLYGONAL_SELECTOR_POLYGONS * MAX_POLYGONAL_SELECTOR_VERTICES] = {}; // xy: normalized screen coords
+    glm::vec4 polygonMeta[MAX_POLYGONAL_SELECTOR_POLYGONS] = {}; // x: vertexCount
 };
 
 enum class ProjectionMode

--- a/src/controller/functionSystem/ContextPolygonalSelector.cpp
+++ b/src/controller/functionSystem/ContextPolygonalSelector.cpp
@@ -9,6 +9,7 @@
 #include "gui/texts/ContextTexts.hpp"
 #include "models/graph/CameraNode.h"
 #include "models/graph/GraphManager.h"
+#include "pointCloudEngine/RenderingLimits.h"
 
 #include <glm/gtx/norm.hpp>
 #include <algorithm>
@@ -16,8 +17,6 @@
 
 namespace
 {
-constexpr uint32_t kMaxPolygonalSelectorPolygons = 8;
-
 uint32_t getPolygonSuffix(const std::string& name)
 {
     if (name.rfind("polygon_", 0) != 0)
@@ -93,6 +92,12 @@ ContextState ContextPolygonalSelector::feedMessage(IMessage* message, Controller
         if (!std::isfinite(normalized.x) || !std::isfinite(normalized.y))
             return (m_state = ContextState::waiting_for_input);
 
+        if (m_currentVertices.size() >= MAX_POLYGONAL_SELECTOR_VERTICES)
+        {
+            controller.updateInfo(new GuiDataWarning(QString("The creation of vertices is limited to %1 vertices per polygon.").arg(MAX_POLYGONAL_SELECTOR_VERTICES)));
+            return (m_state = ContextState::waiting_for_input);
+        }
+
         m_currentVertices.emplace_back(normalized);
 
         if (rCam)
@@ -128,9 +133,9 @@ ContextState ContextPolygonalSelector::validate(Controller& controller)
 {
     if (m_currentVertices.size() >= 3)
     {
-        if (m_settings.polygons.size() >= kMaxPolygonalSelectorPolygons)
+        if (m_settings.polygons.size() >= MAX_POLYGONAL_SELECTOR_POLYGONS)
         {
-            controller.updateInfo(new GuiDataWarning(QString("The creation of polygons is limited to %1 items per filter.").arg(kMaxPolygonalSelectorPolygons)));
+            controller.updateInfo(new GuiDataWarning(QString("The creation of polygons is limited to %1 polygons per filter.").arg(MAX_POLYGONAL_SELECTOR_POLYGONS)));
         }
         else
         {

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -253,11 +253,8 @@ ColorimetricFilterUniform CameraNode::buildColorimetricFilterUniform() const
         uniform.colors[0].z = uniform.colors[0].x;
     }
 
-    constexpr uint32_t kMaxPolygonalSelectorPolygons = 8;
-    constexpr uint32_t kMaxPolygonalSelectorVertices = 32;
-
     const PolygonalSelectorSettings& selector = m_polygonalSelector;
-    uint32_t polygonCount = std::min<uint32_t>(static_cast<uint32_t>(selector.polygons.size()), kMaxPolygonalSelectorPolygons);
+    uint32_t polygonCount = std::min<uint32_t>(static_cast<uint32_t>(selector.polygons.size()), MAX_POLYGONAL_SELECTOR_POLYGONS);
     uniform.polygonSettings = glm::vec4(selector.enabled ? 1.0f : 0.0f,
                                         selector.showSelected ? 1.0f : 0.0f,
                                         selector.active ? 1.0f : 0.0f,
@@ -272,13 +269,13 @@ ColorimetricFilterUniform CameraNode::buildColorimetricFilterUniform() const
         const PolygonalSelectorPolygon& polygon = selector.polygons[pIndex];
         uniform.polygonViewProj[pIndex] = glm::mat4(polygon.camera.proj * polygon.camera.view);
 
-        uint32_t vertexCount = std::min<uint32_t>(static_cast<uint32_t>(polygon.normalizedVertices.size()), kMaxPolygonalSelectorVertices);
+        uint32_t vertexCount = std::min<uint32_t>(static_cast<uint32_t>(polygon.normalizedVertices.size()), MAX_POLYGONAL_SELECTOR_VERTICES);
         uniform.polygonMeta[pIndex] = glm::vec4(static_cast<float>(vertexCount), 0.0f, 0.0f, 0.0f);
 
         for (uint32_t v = 0; v < vertexCount; ++v)
         {
             const glm::vec2& uv = polygon.normalizedVertices[v];
-            uniform.polygonVertices[pIndex * kMaxPolygonalSelectorVertices + v] = glm::vec4(uv.x, uv.y, 0.0f, 0.0f);
+            uniform.polygonVertices[pIndex * MAX_POLYGONAL_SELECTOR_VERTICES + v] = glm::vec4(uv.x, uv.y, 0.0f, 0.0f);
         }
     }
 

--- a/src/shaders/blocks/block_point_input_vert.glsl
+++ b/src/shaders/blocks/block_point_input_vert.glsl
@@ -19,6 +19,9 @@ out gl_PerVertex {
 layout(location = 0) out vec4 fragColor;
 layout(location = 1) out float filterReject;
 
+#define MAX_POLYGONAL_SELECTOR_POLYGONS 16
+#define MAX_POLYGONAL_SELECTOR_VERTICES 32
+
 layout(push_constant) uniform PC {
     layout(offset = 0) float ptSize;
     layout(offset = 8) float contrast;
@@ -47,9 +50,9 @@ layout(set = 0, binding = 4) uniform uniformColorimetricFilter {
     vec4 settings; // x: enabled, y: showColors, z: tolerance(0-1), w: intensityMode
     vec4 polygonSettings; // x: enabled, y: showSelected, z: active, w: appliedPolygonCount
     vec4 polygonCounts;   // x: totalPolygonCount, y: pendingApply(0/1)
-    mat4 polygonViewProj[8];
-    vec4 polygonVertices[8 * 32];
-    vec4 polygonMeta[8];
+    mat4 polygonViewProj[MAX_POLYGONAL_SELECTOR_POLYGONS];
+    vec4 polygonVertices[MAX_POLYGONAL_SELECTOR_POLYGONS * MAX_POLYGONAL_SELECTOR_VERTICES];
+    vec4 polygonMeta[MAX_POLYGONAL_SELECTOR_POLYGONS];
 } uColorFilter;
 
 const float COLORIMETRIC_MAX_DISTANCE = 1.7320508;
@@ -87,10 +90,10 @@ bool pointInPolygon(vec2 p, int polygonIndex)
         return false;
 
     bool inside = false;
-    vec2 prev = uColorFilter.polygonVertices[polygonIndex * 32 + (vertexCount - 1)].xy;
+    vec2 prev = uColorFilter.polygonVertices[polygonIndex * MAX_POLYGONAL_SELECTOR_VERTICES + (vertexCount - 1)].xy;
     for (int i = 0; i < vertexCount; ++i)
     {
-        vec2 curr = uColorFilter.polygonVertices[polygonIndex * 32 + i].xy;
+        vec2 curr = uColorFilter.polygonVertices[polygonIndex * MAX_POLYGONAL_SELECTOR_VERTICES + i].xy;
         bool condY = (curr.y > p.y) != (prev.y > p.y);
         if (condY)
         {


### PR DESCRIPTION
### Motivation
- Éviter les valeurs en dur et centraliser les limites liées au polygon selector pour maintenir la cohérence CPU/GPU. 
- Augmenter la capacité du sélecteur polygonal de 8 à 16 polygones tout en conservant 32 sommets par polygone pour améliorer l'utilisabilité sans impacter la compatibilité shader.

### Description
- Ajout des constantes dans `include/pointCloudEngine/RenderingLimits.h` : `MAX_POLYGONAL_SELECTOR_POLYGONS = 16` et `MAX_POLYGONAL_SELECTOR_VERTICES = 32` et inclusion de `<cstdint>`.
- Remplacement des tailles et indexations codées en dur dans `include/pointCloudEngine/RenderingTypes.h` pour utiliser les nouvelles constantes et éviter les divergences CPU/GPU.
- Mise à jour de la génération d'uniforms dans `src/models/graph/CameraNode.cpp` pour utiliser `MAX_POLYGONAL_SELECTOR_*` et corriger l'indexation des vertices lors du remplissage du buffer uniforme.
- Remplacement de la constante locale et ajout d'une vérification dans `src/controller/functionSystem/ContextPolygonalSelector.cpp` pour empêcher l'ajout de plus de `MAX_POLYGONAL_SELECTOR_VERTICES` sommets et modification du message d'avertissement pour utiliser le libellé "polygons".
- Alignement du shader `src/shaders/blocks/block_point_input_vert.glsl` en déclarant `#define MAX_POLYGONAL_SELECTOR_POLYGONS 16` et `#define MAX_POLYGONAL_SELECTOR_VERTICES 32` et en adaptant les tailles d'array et l'indexation.

### Testing
- Recherches automatisées avec `rg` pour vérifier l'usage des symboles `MAX_POLYGONAL_SELECTOR_POLYGONS` et `MAX_POLYGONAL_SELECTOR_VERTICES` ont trouvé les remplacements attendus, toutes réussies.
- Inspection des diffs via `git diff` et vérification d'état avec `git status --short` ont confirmé les fichiers modifiés et le commit appliqué (`9d7d453c`).
- Vérification par affichage de fichiers (`nl`/`sed`) pour valider les lignes modifiées et les messages d'avertissement mis à jour, toutes vérifications automatisées réussies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69906212db58832f9b0c80eb3add979e)