### PR TITLE
Ignore hidden points during ray-tracing picks

### DIFF
--- a/include/pointCloudEngine/EmbeddedScan.h
+++ b/include/pointCloudEngine/EmbeddedScan.h
@@ -11,6 +11,7 @@
 #include "pointCloudEngine/OctreeRayTracing.h"
 #include "pointCloudEngine/OutlierStats.h"
 #include "models/3d/DisplayParameters.h"
+#include "pointCloudEngine/RayTracingDisplayFilter.h"
 
 // lib_tls
 #include "tls_def.h"
@@ -175,8 +176,8 @@ protected:
 
 public:
     // Lucas functions
-    bool beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3& globalRayOrigin, glm::dvec3& bestPoint, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho);
-    bool beginRayTracingWithPoint(const glm::dvec3& globalRay, const glm::dvec3& globalRayOrigin, glm::dvec3& bestPoint, PointXYZIRGB& bestPointData, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho);
+    bool beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3& globalRayOrigin, glm::dvec3& bestPoint, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, const RayTracingDisplayFilterSettings* displayFilterSettings = nullptr);
+    bool beginRayTracingWithPoint(const glm::dvec3& globalRay, const glm::dvec3& globalRayOrigin, glm::dvec3& bestPoint, PointXYZIRGB& bestPointData, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, const RayTracingDisplayFilterSettings* displayFilterSettings = nullptr);
 	bool findNeighborsBucketsDirected(const glm::dvec3& globalSeedPoint, const glm::dvec3& directedPoint, const double& radius, std::vector<std::vector<glm::dvec3>>& neighborList, const int& numberOfBuckets, const ClippingAssembly& globalClippingAssembly);
 	bool findNeighborsBuckets(const glm::dvec3& globalSeedPoint, const double& radius, std::vector<std::vector<glm::dvec3>>& neighborList, const int& numberOfBuckets, const ClippingAssembly& globalClippingAssembly);
     bool findNeighbors(const glm::dvec3& globalSeedPoint, const double& radius, std::vector<glm::dvec3>& neighborList, const ClippingAssembly& clippingAssembly);
@@ -220,8 +221,8 @@ public:
 protected:
     int updateRay(glm::dvec3& localRay, glm::dvec3& localRayOrigin, const double& rootSize); //returns a=4x+2y+z, where s=0 iff ray.s>0 and 1 otherwise
 	void traceRay(const double& tx0, const double& ty0, const double& tz0, const double& tx1, const double& ty1, const double& tz1, const uint32_t& cellId, const int& rayModifier, std::vector<uint32_t>& leafList, const ClippingAssembly& clippingAssembly, const glm::dvec3& localRayOrigin);	
-	glm::dvec3 findBestPointIterative(const std::vector<uint32_t>& leafList, const glm::dvec3& rayDirection, const glm::dvec3& rayOrigin, const double& cosAngleThreshold, const double& rayRadius, const ClippingAssembly& localClippingAssembly, const bool& isOrtho, bool& success);
-    glm::dvec3 findBestPointIterativeWithPoint(const std::vector<uint32_t>& leafList, const glm::dvec3& rayDirection, const glm::dvec3& rayOrigin, const double& cosAngleThreshold, const double& rayRadius, const ClippingAssembly& localClippingAssembly, const bool& isOrtho, tls::Point& outPoint, bool& success);
+	glm::dvec3 findBestPointIterative(const std::vector<uint32_t>& leafList, const glm::dvec3& rayDirection, const glm::dvec3& rayOrigin, const double& cosAngleThreshold, const double& rayRadius, const ClippingAssembly& localClippingAssembly, const bool& isOrtho, const RayTracingDisplayFilterSettings* displayFilterSettings, bool& success);
+    glm::dvec3 findBestPointIterativeWithPoint(const std::vector<uint32_t>& leafList, const glm::dvec3& rayDirection, const glm::dvec3& rayOrigin, const double& cosAngleThreshold, const double& rayRadius, const ClippingAssembly& localClippingAssembly, const bool& isOrtho, const RayTracingDisplayFilterSettings* displayFilterSettings, tls::Point& outPoint, bool& success);
 
     glm::dvec3 pointInNeighborCell(const glm::dvec3& point);
 

--- a/include/pointCloudEngine/RayTracingDisplayFilter.h
+++ b/include/pointCloudEngine/RayTracingDisplayFilter.h
@@ -1,0 +1,14 @@
+#ifndef RAY_TRACING_DISPLAY_FILTER_H
+#define RAY_TRACING_DISPLAY_FILTER_H
+
+#include "models/3d/DisplayParameters.h"
+
+struct RayTracingDisplayFilterSettings
+{
+    bool enabled = false;
+    UiRenderMode renderMode = UiRenderMode::RGB;
+    ColorimetricFilterSettings colorimetricFilter = {};
+    PolygonalSelectorSettings polygonalSelector = {};
+};
+
+#endif

--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -20,6 +20,7 @@
 #include "pointCloudEngine/OutlierStats.h"
 #include "models/pointCloud/PointXYZIRGB.h"
 #include "models/3d/DisplayParameters.h"
+#include "pointCloudEngine/RayTracingDisplayFilter.h"
 
 /*
 template<typename T>
@@ -229,8 +230,8 @@ public:
     //tls::ScanGuid clipNewScan(tls::ScanGuid scanGuid, const glm::dmat4& modelMat, const ClippingAssembly& clippingAssembly, const std::filesystem::path& outPath, uint64_t& pointDeletedCount);
 
     // Lucas functions
-    bool rayTracing(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName);
-    bool rayTracingWithPoint(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, PointXYZIRGB& bestPointData, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName);
+    bool rayTracing(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName, const RayTracingDisplayFilterSettings* displayFilterSettings = nullptr);
+    bool rayTracingWithPoint(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, PointXYZIRGB& bestPointData, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName, const RayTracingDisplayFilterSettings* displayFilterSettings = nullptr);
     bool findNeighborsBucketsDirected(const glm::dvec3& globalSeedPoint, const glm::dvec3& directedPoint, const double& radius, std::vector<std::vector<glm::dvec3>>& neighborList, int numberOfBuckets, const ClippingAssembly& clippingAssembly);
     bool findNeighborsBuckets(const glm::dvec3& globalSeedPoint, const double& radius, std::vector<std::vector<glm::dvec3>>& neighborList, int numberOfBuckets, const ClippingAssembly& clippingAssembly);
     bool findNeighborsBucketsTest(const glm::dvec3& globalSeedPoint, const double& radius, std::vector<std::vector<glm::dvec3>>& neighborList, int numberOfBuckets, const ClippingAssembly& clippingAssembly, std::vector<glm::dquat>& rotations, std::vector<glm::dvec3>& positions, std::vector<double>& scales);

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -543,7 +543,7 @@ void TlScanOverseer::collectPointsInGeometricBox(const GeometricBox& box, const 
 //    return newScan->getGuid();
 //}
 
-bool TlScanOverseer::rayTracing(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName)
+bool TlScanOverseer::rayTracing(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName, const RayTracingDisplayFilterSettings* displayFilterSettings)
 {
     double rayRadius(0.0015);
     std::vector<glm::dvec3> pointList;
@@ -558,7 +558,7 @@ bool TlScanOverseer::rayTracing(const glm::dvec3& ray, const glm::dvec3& rayOrig
         {
             localAssembly = clippingAssembly;
         }
-        bool test = _pair.scan.beginRayTracing(ray, rayOrigin, currentBest, cosAngleThreshold, localAssembly, isOrtho);
+        bool test = _pair.scan.beginRayTracing(ray, rayOrigin, currentBest, cosAngleThreshold, localAssembly, isOrtho, displayFilterSettings);
         if ((test) && (!std::isnan(currentBest.x)))
         {
             pointList.push_back(currentBest);
@@ -591,7 +591,7 @@ bool TlScanOverseer::rayTracing(const glm::dvec3& ray, const glm::dvec3& rayOrig
     return false;
 }
 
-bool TlScanOverseer::rayTracingWithPoint(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, PointXYZIRGB& bestPointData, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName)
+bool TlScanOverseer::rayTracingWithPoint(const glm::dvec3& ray, const glm::dvec3& rayOrigin, glm::dvec3& bestPoint, PointXYZIRGB& bestPointData, const double& cosAngleThreshold, const ClippingAssembly& clippingAssembly, const bool& isOrtho, std::string& scanName, const RayTracingDisplayFilterSettings* displayFilterSettings)
 {
     double rayRadius(0.0015);
     std::vector<glm::dvec3> pointList;
@@ -607,7 +607,7 @@ bool TlScanOverseer::rayTracingWithPoint(const glm::dvec3& ray, const glm::dvec3
         {
             localAssembly = clippingAssembly;
         }
-        bool test = _pair.scan.beginRayTracingWithPoint(ray, rayOrigin, currentBest, currentPoint, cosAngleThreshold, localAssembly, isOrtho);
+        bool test = _pair.scan.beginRayTracingWithPoint(ray, rayOrigin, currentBest, currentPoint, cosAngleThreshold, localAssembly, isOrtho, displayFilterSettings);
         if ((test) && (!std::isnan(currentBest.x)))
         {
             pointList.push_back(currentBest);


### PR DESCRIPTION
### Motivation
- Faire en sorte que la sélection par ray-tracing respecte les mêmes filtres d'affichage que le rendu (colorimétrie et polygon selector) pour éviter de sélectionner des points masqués à l'écran.
- Propager l'état de la caméra / paramètres d'affichage au pipeline de ray-tracing afin d'avoir un comportement cohérent entre visualisation et picking.

### Description
- Ajout de `RayTracingDisplayFilterSettings` (`include/pointCloudEngine/RayTracingDisplayFilter.h`) pour porter `UiRenderMode`, `ColorimetricFilterSettings` et `PolygonalSelectorSettings` jusqu'au moteur de ray-tracing.
- Modification des signatures de ray-tracing pour accepter un argument optionnel `const RayTracingDisplayFilterSettings* displayFilterSettings` dans `EmbeddedScan::beginRayTracing*`, `EmbeddedScan::findBestPointIterative*` et `TlScanOverseer::rayTracing*` afin de propager les settings sans casser les appels existants.
- Intégration côté UI/contrôleur : construction des `RayTracingDisplayFilterSettings` à partir de la caméra active et passage à `TlScanOverseer` depuis `ARayTracingContext`, `ContextPickColorimetric` et `ContextPickTemperature`.
- Implémentation d'un prédicat CPU dans `src/pointCloudEngine/EmbeddedScan.cpp` qui prépare (`prepareRayTracingDisplayFilter`) et applique (`isPointRejectedByDisplayFilters`) les filtres avant le scoring de hit, incluant : normalisation des couleurs, mode intensité vs RGB, tolérances, logique `showColors`/`hide`, et inclusion/exclusion selon les polygons appliqués.

### Testing
- `git diff --check` exécuté et sans avertissements (succès).
- Tentative de génération via `cmake -S . -B build` exécutée mais échoue car le dépôt n'a pas de `CMakeLists.txt` à la racine (comportement attendu pour ce repository), donc la compilation complète n'a pas été réalisée dans cet environnement (échec signalé).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69906cd94300832f9bea7d3a2057ee40)