### PR TITLE
Extend clean point-cloud to consider active clippings and filters

### DIFF
--- a/include/controller/functionSystem/ContextDeletePoints.h
+++ b/include/controller/functionSystem/ContextDeletePoints.h
@@ -3,6 +3,7 @@
 
 #include "controller/functionSystem/AContext.h"
 #include "io/exports/ExportParameters.hpp"
+#include "models/3d/DisplayParameters.h"
 
 class ContextDeletePoints : public AContext
 {
@@ -19,6 +20,7 @@ public:
 private:
     bool prepareOutputDirectory(Controller& controller, const std::filesystem::path& folderPath);
     bool beginDeleteConfirmation(Controller& controller);
+    bool hasActiveFilter() const;
 
 private:
     ExportClippingFilter m_clippingFilter;
@@ -28,6 +30,11 @@ private:
 
     bool m_warningModal;
     bool m_pendingDeleteConfirmation;
+    bool m_waitingSaveModal;
+    bool m_hasCameraSettings;
+    ColorimetricFilterSettings m_colorimetricFilterSettings;
+    PolygonalSelectorSettings m_polygonalSelectorSettings;
+    UiRenderMode m_renderMode = UiRenderMode::RGB;
 };
 
 #endif

--- a/include/gui/texts/ContextTexts.hpp
+++ b/include/gui/texts/ContextTexts.hpp
@@ -98,7 +98,7 @@
 //ContextDeletePoints
 #define TEXT_DELETE_POINTS_QUESTION QObject::tr("Warning: points will be permanently deleted. This action cannot be undone.\nDo you confirm?")
 #define TEXT_DELETE_SAVE_BEFORE_QUESTION QObject::tr("It is recommended to save the project before deleting points. Do you want to save now?")
-#define TEXT_DELETE_POINTS_NO_ACTIVE_CLIPPING QObject::tr("You must activate some clippings to run this feature")
+#define TEXT_DELETE_POINTS_NO_ACTIVE_CLIPPING QObject::tr("You must activate some clippings or filters to run this feature")
 
 //ContextStatisticalOutlierFilter
 #define TEXT_STAT_OUTLIER_FILTER_QUESTION QObject::tr("Warning: some points will be permanently deleted.\nDepending on the size of the scans and the filter settings, the calculation time may be significant. We recommend that you first perform a test on a small clipped portion.\nDo you confirm?")


### PR DESCRIPTION
### Motivation
- Allow the "delete points / clean point cloud" flow to operate not only when clippings are active but also when display filters (colorimetric & polygon selector) are enabled in the active camera, so users can remove points using filters alone.

### Description
- Fetch active camera `DisplayParameters` during the `ContextDeletePoints` start/confirmation flow and store `m_colorimetricFilterSettings`, `m_polygonalSelectorSettings`, and `m_renderMode` in the context.
- Add `hasActiveFilter()` helper to detect enabled colorimetric or polygonal filters and treat them as a valid precondition in `beginDeleteConfirmation()` (now requires clippings OR filters).
- Replace the previous clipping-only write path with a combined filtering path by calling `TlScanOverseer::filterAndWrite(...)` (passes clipping assembly + colorimetric + polygon selector + render mode) and keep the existing temp-file / scan replacement behavior while skipping replacement when no points are removed.
- Update UI text `TEXT_DELETE_POINTS_NO_ACTIVE_CLIPPING` to `"You must activate some clippings or filters to run this feature"` and add necessary includes/fields in `ContextDeletePoints` header.

### Testing
- Ran `git diff --check` to detect whitespace/format issues and it passed. 
- Searched project texts with `rg` to verify the warning message replacement and relevant message locations; the updated string and the new log line were found.
- Performed static code checks (source diffs reviewed) to ensure new members and helper are used consistently and no obvious API mismatches were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f6e04fb0832f8a05fba03d0cc2af)