### PR TITLE
Fix PCO name persistence when reloading projects

### DIFF
--- a/include/models/graph/PointCloudNode.h
+++ b/include/models/graph/PointCloudNode.h
@@ -18,7 +18,7 @@ public:
 
     std::wstring getComposedName() const override;
 
-    void setTlsFilePath(const std::filesystem::path& file_path, bool init_position, const tls::ScanGuid& scan_guid = tls::ScanGuid());
+    void setTlsFilePath(const std::filesystem::path& file_path, bool init_position, const tls::ScanGuid& scan_guid = tls::ScanGuid(), bool reset_name = true);
     std::filesystem::path getTlsFilePath() const;
 
     void setManipulable(bool is_manipulable);

--- a/src/controller/functionSystem/ContextDeletePoints.cpp
+++ b/src/controller/functionSystem/ContextDeletePoints.cpp
@@ -290,7 +290,7 @@ ContextState ContextDeletePoints::launch(Controller& controller)
             std::filesystem::path absolutePath = wScan->getTlsFilePath();
             // NOTE - On choisi de ne pas supprimer le fichier au cas où cela soit une mauvaise manipulation.
             TlScanOverseer::getInstance().freeScan_async(old_guid, false);
-            wScan->setTlsFilePath(temp_path, false);
+            wScan->setTlsFilePath(temp_path, false, tls::ScanGuid(), false);
             if (new_guid == xg::Guid())
             {
                 controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Scan %1 totally deleted from project.").arg(qScanName)));

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -346,7 +346,7 @@ std::unordered_set<SafePtr<AGraphNode>> SaveLoadSystem::LoadFileObjects(Controll
                 continue;
 
             std::filesystem::path pcPath = findPointCloudPath(wPCNode, internalInfo, folder);
-            wPCNode->setTlsFilePath(pcPath, false);
+            wPCNode->setTlsFilePath(pcPath, false, tls::ScanGuid(), false);
             if (wPCNode->getScanGuid() == tls::ScanGuid())
                 failedFileImport.insert(object);
             else if (forceCopy)

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -369,7 +369,7 @@ bool ImportPointCloudNode(const nlohmann::json& json, PointCloudNode& data)
     bool retVal = true;
 
     if (json.find(Key_Path) != json.end())
-        data.setTlsFilePath(Utils::from_utf8(json.at(Key_Path).get<std::string>()), false);
+        data.setTlsFilePath(Utils::from_utf8(json.at(Key_Path).get<std::string>()), false, tls::ScanGuid(), false);
     else
     {
         IOLOG << "Scan Path read error" << LOGENDL;

--- a/src/models/graph/PointCloudNode.cpp
+++ b/src/models/graph/PointCloudNode.cpp
@@ -49,13 +49,14 @@ std::wstring PointCloudNode::getComposedName() const
     }
 }
 
-void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool init_position, const tls::ScanGuid& scanGuid)
+void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool init_position, const tls::ScanGuid& scanGuid, bool reset_name)
 {
     if (scanGuid != tls::ScanGuid())
         m_scanGuid = scanGuid;
     else
         tlGetScanGuid(scanPath, m_scanGuid);
-    setName(scanPath.stem().wstring());
+    if (reset_name)
+        setName(scanPath.stem().wstring());
     backup_file_path_ = scanPath;
 
     tls::ScanHeader scanHeader;


### PR DESCRIPTION
### Motivation
- During project reload the point-cloud object (PCO/Scan) business name was overwritten by `setTlsFilePath(...)` which unconditionally set the object name from the file stem. 
- The change aims to preserve names that were restored from project data while still keeping the default filename-based naming for fresh imports.

### Description
- Add a `reset_name` boolean parameter (default `true`) to `PointCloudNode::setTlsFilePath(...)` in `include/models/graph/PointCloudNode.h` and `src/models/graph/PointCloudNode.cpp` to decouple TLS path assignment from automatic renaming. 
- Update load/deserialization paths to preserve existing names by calling `setTlsFilePath(..., false)` with `reset_name = false` in `src/io/imports/DataDeserializer.cpp` and `src/io/SaveLoadSystem.cpp`. 
- Avoid accidental renames during temporary TLS path swaps in the delete-points flow by passing `reset_name = false` in `src/controller/functionSystem/ContextDeletePoints.cpp`. 
- Keep existing behavior (default `reset_name = true`) for other call sites so initial imports still set the name from the filename stem.

### Testing
- Verified all `setTlsFilePath(...)` usages with `rg` and updated only load-related call sites (search validation succeeded). 
- Ran `git diff --check` with no issues reported. 
- Created a commit containing the changes (commit created successfully) and opened the PR; no build was executed in this environment (`no_build_dir`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994371b1f34832f9dfb2e93db2c3341)