### PR TITLE
Polygonal selector: add snapshot clipping support and make ESC consistently abort

### DIFF
--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -264,6 +264,12 @@
 #define Key_Polygonal_Selector_Cam_Proj	"PolygonalSelectorCameraProj"
 #define Key_Polygonal_Selector_Cam_Viewport "PolygonalSelectorCameraViewport"
 #define Key_Polygonal_Selector_Cam_Perspective "PolygonalSelectorCameraPerspective"
+#define Key_Polygonal_Selector_SnapshotUnion "PolygonalSelectorSnapshotUnion"
+#define Key_Polygonal_Selector_SnapshotIntersection "PolygonalSelectorSnapshotIntersection"
+#define Key_Polygonal_Selector_SnapshotClipShape "PolygonalSelectorSnapshotClipShape"
+#define Key_Polygonal_Selector_SnapshotClipMode "PolygonalSelectorSnapshotClipMode"
+#define Key_Polygonal_Selector_SnapshotClipMat "PolygonalSelectorSnapshotClipMat"
+#define Key_Polygonal_Selector_SnapshotClipParams "PolygonalSelectorSnapshotClipParams"
 
 #define Key_Active_Scans				"ActiveScans"
 #define Key_Active_Clippings			"ActiveClippings"

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -24,9 +24,19 @@ struct PolygonalSelectorCameraSnapshot
 
 struct PolygonalSelectorPolygon
 {
+    struct SnapshotClip
+    {
+        int32_t shape = 0; // ClippingShape
+        int32_t mode = 0;  // ClippingMode
+        glm::dmat4 matRTInv = glm::dmat4(1.0);
+        glm::vec4 params = glm::vec4(0.0f);
+    };
+
     std::string name;
     std::vector<glm::vec2> normalizedVertices;
     PolygonalSelectorCameraSnapshot camera;
+    std::vector<SnapshotClip> snapshotUnion;
+    std::vector<SnapshotClip> snapshotIntersection;
 };
 
 struct PolygonalSelectorSettings

--- a/include/pointCloudEngine/RenderingLimits.h
+++ b/include/pointCloudEngine/RenderingLimits.h
@@ -8,5 +8,6 @@ constexpr int MAX_ACTIVE_CLIPPING = 512;
 
 constexpr uint32_t MAX_POLYGONAL_SELECTOR_POLYGONS = 16;
 constexpr uint32_t MAX_POLYGONAL_SELECTOR_VERTICES = 32;
+constexpr uint32_t MAX_POLYGONAL_SELECTOR_SNAPSHOT_CLIPS = 8;
 
 #endif

--- a/include/pointCloudEngine/RenderingTypes.h
+++ b/include/pointCloudEngine/RenderingTypes.h
@@ -116,6 +116,10 @@ struct ColorimetricFilterUniform
     glm::mat4 polygonViewProj[MAX_POLYGONAL_SELECTOR_POLYGONS] = {};
     glm::vec4 polygonVertices[MAX_POLYGONAL_SELECTOR_POLYGONS * MAX_POLYGONAL_SELECTOR_VERTICES] = {}; // xy: normalized screen coords
     glm::vec4 polygonMeta[MAX_POLYGONAL_SELECTOR_POLYGONS] = {}; // x: vertexCount
+    glm::vec4 polygonSnapshotCounts[MAX_POLYGONAL_SELECTOR_POLYGONS] = {}; // x: unionCount, y: intersectionCount
+    glm::mat4 polygonSnapshotMat[MAX_POLYGONAL_SELECTOR_POLYGONS * MAX_POLYGONAL_SELECTOR_SNAPSHOT_CLIPS] = {};
+    glm::vec4 polygonSnapshotParams[MAX_POLYGONAL_SELECTOR_POLYGONS * MAX_POLYGONAL_SELECTOR_SNAPSHOT_CLIPS] = {};
+    glm::vec4 polygonSnapshotMeta[MAX_POLYGONAL_SELECTOR_POLYGONS * MAX_POLYGONAL_SELECTOR_SNAPSHOT_CLIPS] = {}; // x: shape, y: mode
 };
 
 enum class ProjectionMode

--- a/src/gui/ShortcutSystem.cpp
+++ b/src/gui/ShortcutSystem.cpp
@@ -105,11 +105,6 @@ void ShortcutSystem::slotDelete()
 void ShortcutSystem::slotAbort()
 {
 	GUI_LOG << "shortcut abort" << LOGENDL;
-	if (m_activeContext == ContextType::polygonalSelector)
-	{
-		m_dataDispatcher.sendControl(new control::function::Validate());
-		return;
-	}
 
 	if (m_notInContext)
 		m_dataDispatcher.updateInformation(new GuiDataDisableFullScreen());

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -437,6 +437,29 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 			{ Key_Polygonal_Selector_Cam_Perspective, polygon.camera.perspective }
 		};
 
+		auto writeSnapshotClip = [](const PolygonalSelectorPolygon::SnapshotClip& clip)
+		{
+			return nlohmann::json{
+				{ Key_Polygonal_Selector_SnapshotClipShape, clip.shape },
+				{ Key_Polygonal_Selector_SnapshotClipMode, clip.mode },
+				{ Key_Polygonal_Selector_SnapshotClipMat, {
+					clip.matRTInv[0][0], clip.matRTInv[0][1], clip.matRTInv[0][2], clip.matRTInv[0][3],
+					clip.matRTInv[1][0], clip.matRTInv[1][1], clip.matRTInv[1][2], clip.matRTInv[1][3],
+					clip.matRTInv[2][0], clip.matRTInv[2][1], clip.matRTInv[2][2], clip.matRTInv[2][3],
+					clip.matRTInv[3][0], clip.matRTInv[3][1], clip.matRTInv[3][2], clip.matRTInv[3][3]
+				} },
+				{ Key_Polygonal_Selector_SnapshotClipParams, { clip.params.x, clip.params.y, clip.params.z, clip.params.w } }
+			};
+		};
+
+		polygonJson[Key_Polygonal_Selector_SnapshotUnion] = nlohmann::json::array();
+		for (const PolygonalSelectorPolygon::SnapshotClip& clip : polygon.snapshotUnion)
+			polygonJson[Key_Polygonal_Selector_SnapshotUnion].push_back(writeSnapshotClip(clip));
+
+		polygonJson[Key_Polygonal_Selector_SnapshotIntersection] = nlohmann::json::array();
+		for (const PolygonalSelectorPolygon::SnapshotClip& clip : polygon.snapshotIntersection)
+			polygonJson[Key_Polygonal_Selector_SnapshotIntersection].push_back(writeSnapshotClip(clip));
+
 		json[Key_Polygonal_Selector][Key_Polygonal_Selector_Polygons].push_back(polygonJson);
 	}
 

--- a/src/pointCloudEngine/RenderingEcoSystem.cpp
+++ b/src/pointCloudEngine/RenderingEcoSystem.cpp
@@ -176,6 +176,34 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
         hash += hash_fn_32(polygon.camera.viewportWidth);
         hash += hash_fn_32(polygon.camera.viewportHeight);
         hash += hash_fn_b(polygon.camera.perspective);
+
+        hash += hash_fn_64(static_cast<uint64_t>(polygon.snapshotUnion.size()));
+        for (const PolygonalSelectorPolygon::SnapshotClip& clip : polygon.snapshotUnion)
+        {
+            hash += hash_fn_32(static_cast<uint32_t>(clip.shape));
+            hash += hash_fn_32(static_cast<uint32_t>(clip.mode));
+            hash += hash_fn_f(clip.params.x);
+            hash += hash_fn_f(clip.params.y);
+            hash += hash_fn_f(clip.params.z);
+            hash += hash_fn_f(clip.params.w);
+            for (int c = 0; c < 4; ++c)
+                for (int r = 0; r < 4; ++r)
+                    hash += hash_fn_d(clip.matRTInv[c][r]);
+        }
+
+        hash += hash_fn_64(static_cast<uint64_t>(polygon.snapshotIntersection.size()));
+        for (const PolygonalSelectorPolygon::SnapshotClip& clip : polygon.snapshotIntersection)
+        {
+            hash += hash_fn_32(static_cast<uint32_t>(clip.shape));
+            hash += hash_fn_32(static_cast<uint32_t>(clip.mode));
+            hash += hash_fn_f(clip.params.x);
+            hash += hash_fn_f(clip.params.y);
+            hash += hash_fn_f(clip.params.z);
+            hash += hash_fn_f(clip.params.w);
+            for (int c = 0; c < 4; ++c)
+                for (int r = 0; r < 4; ++r)
+                    hash += hash_fn_d(clip.matRTInv[c][r]);
+        }
     }
 
     //hash += hash_fn_f(display.m_alphaObject);             // Do not affect the point cloud


### PR DESCRIPTION
### Motivation
- Persist polygonal-selector clipping state so polygons snapshot the active clipping geometry when created and later apply the same spatial constraints during rendering and export/import. 
- Provide GPU-side data and shader evaluation so snapshot clips affect point filtering and rendering consistently. 
- Make the `ESC` shortcut consistently cancel polygon-drawing (abort) instead of validating to match the intended UX.

### Description
- Added `SnapshotClip` and snapshot vectors to `PolygonalSelectorPolygon` and introduced `MAX_POLYGONAL_SELECTOR_SNAPSHOT_CLIPS` to limit snapshot clip counts. 
- Captured the current `ClippingAssembly` during polygon creation in `ContextPolygonalSelector::validate` and store converted `SnapshotClip` entries. 
- Extended serialization and deserialization in `DisplayPresetManager`, `DataSerializer`, and `DataDeserializer` to write/read snapshot clip arrays and the new JSON keys. 
- Extended rendering data paths: added snapshot counts/matrices/params/meta to `ColorimetricFilterUniform`, populated them in `CameraNode::buildColorimetricFilterUniform`, added hashing of snapshot clips in `RenderingEcoSystem::HashFrame`, and exposed the snapshot arrays to the point shader. 
- Implemented snapshot-based point acceptance logic in CPU filtering (`EmbeddedScan`) and added equivalent GLSL functions in the point vertex shader to ensure both CPU and GPU use the same union/intersection snapshot semantics. 
- Made `ShortcutSystem::slotAbort` always send `Abort` (removed the polygonal-selector-specific `Validate` override) so `ESC` now cancels polygon drafts. 

### Testing
- Ran `git diff --check` which returned no whitespace/merge errors. 
- Ran `git status --short` to confirm modified files are staged/committed and then committed the changes. 
- Inspected key source files with `nl`/sed and file diffs to verify the new snapshot capture, serialization, GPU uniform wiring, shader code, and `ESC` shortcut change were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a62ea50c832f96d21e7b399d7b0c)