### PR TITLE
Persist point-cloud `clippable` state in viewpoints

### DIFF
--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -280,6 +280,7 @@
 #define Key_Active_Ramps				"ActiveRamps"
 #define Key_Visible_Objects				"VisibleObjects"
 #define Key_Objects_Colors				"ObjectsColors"
+#define Key_PointCloud_Objects_Clippable	"PointCloudObjectsClippable"
 #define Key_Ortho_Grid_Active			"OrthoGridActive"
 #define Key_Ortho_Grid_Color			"OrthoGridColor"
 #define Key_Ortho_Grid_Step				"OrthoGridStep"

--- a/include/models/data/ViewPoint/ViewPointData.h
+++ b/include/models/data/ViewPoint/ViewPointData.h
@@ -33,6 +33,7 @@ public:
 	void setVisibleObjects(const std::unordered_set<SafePtr<AGraphNode>>& list);
 
 	void setScanClusterColors(const std::unordered_map<SafePtr<AGraphNode>, Color32>& map);
+	void setPointCloudObjectsClippable(const std::unordered_map<SafePtr<AGraphNode>, bool>& map);
 
 	bool isPanoramicScan() const;
 	SafePtr<PointCloudNode> getPanoramicScan() const;
@@ -45,6 +46,7 @@ public:
 	const std::unordered_set<SafePtr<AGraphNode>>& getVisibleObjects() const;
 
 	const std::unordered_map<SafePtr<AGraphNode>, Color32>& getScanClusterColors() const;
+	const std::unordered_map<SafePtr<AGraphNode>, bool>& getPointCloudObjectsClippable() const;
 
 	static void updateViewpointsObjectsValue(Controller& controller, SafePtr<ViewPointNode> viewpoint);
 
@@ -59,6 +61,7 @@ protected:
 	std::unordered_set<SafePtr<AGraphNode>> m_visibleObjects;
 
 	std::unordered_map<SafePtr<AGraphNode>, Color32> m_scanClusterColors;
+	std::unordered_map<SafePtr<AGraphNode>, bool> m_pointCloudObjectsClippable;
 
 };
 

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -542,6 +542,16 @@ void ExportViewPointData(nlohmann::json& json, const ViewPointData& data)
 		childrenElem.push_back({ rObj->getId(), colorSet.second.r, colorSet.second.g, colorSet.second.b, colorSet.second.a });
 	}
 	json[Key_Objects_Colors] = childrenElem;
+
+	childrenElem.clear();
+	for (const std::pair<SafePtr<AGraphNode>, bool>& clippableState : data.getPointCloudObjectsClippable())
+	{
+		ReadPtr<AGraphNode> rObj = clippableState.first.cget();
+		if (!rObj)
+			continue;
+		childrenElem.push_back({ rObj->getId(), clippableState.second });
+	}
+	json[Key_PointCloud_Objects_Clippable] = childrenElem;
 }
 
 void DataSerializer::Serialize(nlohmann::json& json, const SafePtr<TagNode>& object)

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -2083,6 +2083,31 @@ bool ImportViewPointData(const nlohmann::json& json, ViewPointData& data, const 
         IOLOG << "ViewPoint ObjectsColors read error" << LOGENDL;
     }
 
+    if (json.find(Key_PointCloud_Objects_Clippable) != json.end())
+    {
+        std::unordered_map<SafePtr<AGraphNode>, bool> map;
+        for (const nlohmann::json& child : json.at(Key_PointCloud_Objects_Clippable))
+        {
+            if (!child.is_array() || child.size() < 2)
+            {
+                IOLOG << "ViewPoint PointCloudObjectsClippable malformed" << LOGENDL;
+                continue;
+            }
+
+            xg::Guid guid = xg::Guid(child[0].get<std::string>());
+            if (nodeById.find(guid) == nodeById.end())
+            {
+                IOLOG << "ViewPoint PointCloudObjectsClippable couldnt find object" << LOGENDL;
+                continue;
+            }
+
+            SafePtr<AGraphNode> childNode = nodeById.at(guid);
+            if (childNode)
+                map[childNode] = child[1].get<bool>();
+        }
+        data.setPointCloudObjectsClippable(map);
+    }
+
     //if (json.find(Key_Active_Scans) != json.end())
     //{
     //	std::unordered_set<xg::Guid> list;


### PR DESCRIPTION
### Motivation
- Ensure viewpoint snapshots store and restore the per-point-cloud `clippable` flag so a viewpoint fully restores rendering/processing semantics for scans and PCOs.

### Description
- Add new serializer key `Key_PointCloud_Objects_Clippable` and export/import support to serialize a `PointCloudObject -> bool` map into JSON under `PointCloudObjectsClippable` (`src/io/exports/DataSerializer.cpp`, `src/io/imports/DataDeserializer.cpp`, `include/io/SerializerKeys.h`).
- Extend `ViewPointData` with a `m_pointCloudObjectsClippable` map plus `setPointCloudObjectsClippable`/`getPointCloudObjectsClippable` and copy semantics (`include/models/data/ViewPoint/ViewPointData.h`, `src/models/data/ViewPoint/ViewPointData.cpp`).
- Capture clippable state when creating/updating viewpoint snapshots in `updateViewpointsObjectsValue` and persist it into the viewpoint (`src/models/data/ViewPoint/ViewPointData.cpp`).
- Restore the saved flag during viewpoint application in `UpdateStatesFromViewpoint::doFunction`, applying `setClippable` only for `ElementType::Scan`/`ElementType::PCO` and marking modified nodes for tree refresh (`src/controller/controls/ControlViewPoint.cpp`).

### Testing
- Ran repository static checks with `git diff --check` and pattern searches (`rg`) to verify symbols and keys were added and referenced; checks succeeded.
- Performed manual code inspection of the changed serialization, deserialization, capture, and restore paths and verified type guards and defensive parsing were implemented; inspection passed.
- Full build and runtime tests were not executed because the required Windows/Qt/Vulkan toolchain (`msbuild`/`qmake`) is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7b20d5a0832f8e781b07a1785d60)