### PR TITLE
Persistance de l'état 'clippable' des scans dans les viewpoints

### DIFF
--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -280,6 +280,7 @@
 #define Key_Active_Ramps				"ActiveRamps"
 #define Key_Visible_Objects				"VisibleObjects"
 #define Key_Objects_Colors				"ObjectsColors"
+#define Key_Objects_Clippable			"ObjectsClippable"
 #define Key_Ortho_Grid_Active			"OrthoGridActive"
 #define Key_Ortho_Grid_Color			"OrthoGridColor"
 #define Key_Ortho_Grid_Step				"OrthoGridStep"

--- a/include/models/data/ViewPoint/ViewPointData.h
+++ b/include/models/data/ViewPoint/ViewPointData.h
@@ -5,6 +5,7 @@
 #include "utils/safe_ptr.h"
 #include "utils/Color32.hpp"
 
+#include <unordered_map>
 #include <unordered_set>
 
 class PointCloudNode;
@@ -33,6 +34,7 @@ public:
 	void setVisibleObjects(const std::unordered_set<SafePtr<AGraphNode>>& list);
 
 	void setScanClusterColors(const std::unordered_map<SafePtr<AGraphNode>, Color32>& map);
+	void setObjectsClippable(const std::unordered_map<SafePtr<AGraphNode>, bool>& map);
 
 	bool isPanoramicScan() const;
 	SafePtr<PointCloudNode> getPanoramicScan() const;
@@ -45,6 +47,7 @@ public:
 	const std::unordered_set<SafePtr<AGraphNode>>& getVisibleObjects() const;
 
 	const std::unordered_map<SafePtr<AGraphNode>, Color32>& getScanClusterColors() const;
+	const std::unordered_map<SafePtr<AGraphNode>, bool>& getObjectsClippable() const;
 
 	static void updateViewpointsObjectsValue(Controller& controller, SafePtr<ViewPointNode> viewpoint);
 
@@ -59,6 +62,7 @@ protected:
 	std::unordered_set<SafePtr<AGraphNode>> m_visibleObjects;
 
 	std::unordered_map<SafePtr<AGraphNode>, Color32> m_scanClusterColors;
+	std::unordered_map<SafePtr<AGraphNode>, bool> m_objectsClippable;
 
 };
 

--- a/src/controller/controls/ControlViewPoint.cpp
+++ b/src/controller/controls/ControlViewPoint.cpp
@@ -6,6 +6,7 @@
 #include "models/graph/GraphManager.h"
 #include "models/graph/AClippingNode.h"
 #include "models/graph/ViewPointNode.h"
+#include "models/graph/PointCloudNode.h"
 #include "models/graph/CameraNode.h"
 
 #include "utils/Logger.h"
@@ -208,6 +209,7 @@ namespace control::viewpoint
 
         std::unordered_set<SafePtr<AGraphNode>> visibleList;
         std::unordered_map<SafePtr<AGraphNode>, Color32> colorList;
+        std::unordered_map<SafePtr<AGraphNode>, bool> clippableList;
 
         {
             ReadPtr<ViewPointNode> readViewpoint = m_viewPoint.cget();
@@ -220,6 +222,7 @@ namespace control::viewpoint
             activeRampList = readViewpoint->getActiveRamps(); // NEW
             visibleList = readViewpoint->getVisibleObjects();
             colorList = readViewpoint->getScanClusterColors();
+            clippableList = readViewpoint->getObjectsClippable();
         }
 
         GraphManager& graphManager = controller.getGraphManager();
@@ -278,6 +281,16 @@ namespace control::viewpoint
             {
                 writeObject->setColor(colorList.at(object));
                 editedNodes.insert(object);
+            }
+
+            if (clippableList.find(object) != clippableList.end() && writeObject->getType() == ElementType::Scan)
+            {
+                WritePtr<PointCloudNode> writePointCloud = static_pointer_cast<PointCloudNode>(object).get();
+                if (writePointCloud && writePointCloud->getClippable() != clippableList.at(object))
+                {
+                    writePointCloud->setClippable(clippableList.at(object));
+                    editedNodes.insert(object);
+                }
             }
         }
 

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -542,6 +542,16 @@ void ExportViewPointData(nlohmann::json& json, const ViewPointData& data)
 		childrenElem.push_back({ rObj->getId(), colorSet.second.r, colorSet.second.g, colorSet.second.b, colorSet.second.a });
 	}
 	json[Key_Objects_Colors] = childrenElem;
+
+	childrenElem.clear();
+	for (const std::pair<SafePtr<AGraphNode>, bool>& clippableSet : data.getObjectsClippable())
+	{
+		ReadPtr<AGraphNode> rObj = clippableSet.first.cget();
+		if (!rObj)
+			continue;
+		childrenElem.push_back({ rObj->getId(), clippableSet.second });
+	}
+	json[Key_Objects_Clippable] = childrenElem;
 }
 
 void DataSerializer::Serialize(nlohmann::json& json, const SafePtr<TagNode>& object)

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -2083,6 +2083,29 @@ bool ImportViewPointData(const nlohmann::json& json, ViewPointData& data, const 
         IOLOG << "ViewPoint ObjectsColors read error" << LOGENDL;
     }
 
+    if (json.find(Key_Objects_Clippable) != json.end())
+    {
+        std::unordered_map<SafePtr<AGraphNode>, bool> map;
+        for (const nlohmann::json& child : json.at(Key_Objects_Clippable))
+        {
+            bool clippable = child[1].get<bool>();
+            xg::Guid guid = xg::Guid(child[0].get<std::string>());
+            if (nodeById.find(guid) == nodeById.end())
+            {
+                IOLOG << "ViewPoint ObjectsClippable couldnt find object" << LOGENDL;
+                continue;
+            }
+            SafePtr<AGraphNode> childNode = nodeById.at(guid);
+            if (childNode)
+                map[childNode] = clippable;
+        }
+        data.setObjectsClippable(map);
+    }
+    else
+    {
+        IOLOG << "ViewPoint ObjectsClippable read missing" << LOGENDL;
+    }
+
     //if (json.find(Key_Active_Scans) != json.end())
     //{
     //	std::unordered_set<xg::Guid> list;

--- a/src/models/data/ViewPoint/ViewPointData.cpp
+++ b/src/models/data/ViewPoint/ViewPointData.cpp
@@ -5,6 +5,7 @@
 
 #include "models/graph/AClippingNode.h"
 #include "models/graph/ViewPointNode.h"
+#include "models/graph/PointCloudNode.h"
 
 ViewPointData::ViewPointData()
 {}
@@ -27,6 +28,7 @@ void ViewPointData::copyViewPointData(const ViewPointData& data)
 	m_activeRamps = data.getActiveRamps();
 	m_visibleObjects = data.getVisibleObjects();
 	m_scanClusterColors = data.getScanClusterColors();
+	m_objectsClippable = data.getObjectsClippable();
 }
 
 void ViewPointData::setPanoramicScan(SafePtr<PointCloudNode> id)
@@ -62,6 +64,11 @@ void ViewPointData::setVisibleObjects(const std::unordered_set<SafePtr<AGraphNod
 void ViewPointData::setScanClusterColors(const std::unordered_map<SafePtr<AGraphNode>, Color32>& map)
 {
 	m_scanClusterColors = map;
+}
+
+void ViewPointData::setObjectsClippable(const std::unordered_map<SafePtr<AGraphNode>, bool>& map)
+{
+	m_objectsClippable = map;
 }
 
 bool ViewPointData::isPanoramicScan() const
@@ -109,6 +116,11 @@ const std::unordered_map<SafePtr<AGraphNode>, Color32>& ViewPointData::getScanCl
 	return m_scanClusterColors;
 }
 
+const std::unordered_map<SafePtr<AGraphNode>, bool>& ViewPointData::getObjectsClippable() const
+{
+	return m_objectsClippable;
+}
+
 void ViewPointData::updateViewpointsObjectsValue(Controller& controller, SafePtr<ViewPointNode> viewpoint)
 {
 	GraphManager& graphManager = controller.getGraphManager();
@@ -131,11 +143,19 @@ void ViewPointData::updateViewpointsObjectsValue(Controller& controller, SafePtr
 	std::unordered_set<SafePtr<AClippingNode>> activeRamps = graphManager.getRampObjects(true, false);
 
 	std::unordered_map<SafePtr<AGraphNode>, Color32> scanClusterColors;
+	std::unordered_map<SafePtr<AGraphNode>, bool> objectsClippable;
 	for (const SafePtr<AGraphNode>& object : graphManager.getNodesByTypes({ ElementType::Cluster, ElementType::Scan }))
 	{
 		ReadPtr<AGraphNode> rObject = object.cget();
 		if (rObject)
 			scanClusterColors[object] = rObject->getColor();
+
+		if (rObject && rObject->getType() == ElementType::Scan)
+		{
+			ReadPtr<PointCloudNode> rPointCloud = static_pointer_cast<PointCloudNode>(object).cget();
+			if (rPointCloud)
+				objectsClippable[object] = rPointCloud->getClippable();
+		}
 	}
 
 	std::unordered_set<SafePtr<AGraphNode>> visible;
@@ -152,5 +172,6 @@ void ViewPointData::updateViewpointsObjectsValue(Controller& controller, SafePtr
 	wVP->setPhaseClippings(phases);
 	wVP->setActiveRamps(activeRamps);
 	wVP->setScanClusterColors(scanClusterColors);
+	wVP->setObjectsClippable(objectsClippable);
 	wVP->setVisibleObjects(visible);
 }


### PR DESCRIPTION
### Motivation
- Permettre de sauvegarder et restaurer le statut `clippable` des objets (scans/point clouds) dans les snapshots de viewpoint pour conserver fidèlement l'état de la scène.
- Assurer une sérialisation cohérente de cet état dans le JSON des viewpoints afin de rendre les exports/imports rétro-compatibles.

### Description
- Ajout d'une map `m_objectsClippable` et des accesseurs `setObjectsClippable` / `getObjectsClippable` dans `ViewPointData` pour stocker l'état `clippable` par objet via `SafePtr<AGraphNode>`.
- Lors de la capture d'un viewpoint (`ViewPointData::updateViewpointsObjectsValue`) on récupère le `clippable` des `PointCloudNode` (seulement pour `ElementType::Scan`) et on l'enregistre dans le viewpoint.
- À l'application d'un viewpoint (flow `UpdateStatesFromViewpoint` dans `ControlViewPoint`) on restaure l'état `clippable` sur les `PointCloudNode` en réalisant un cast sécurisé et en ne touchant que les scans.
- Ajout de la clé de sérialisation `Key_Objects_Clippable` et implémentation de l'export (`DataSerializer::ExportViewPointData`) et de l'import (`ImportViewPointData` dans `DataDeserializer`) au format `[objectGuid, bool]`, avec log en cas d'absence d'objet ou de clé manquante.

### Testing
- Exécution de `git diff --check` pour détecter les problèmes de diff, qui a réussi.
- Recherche de références avec `rg -n "ObjectsClippable|getObjectsClippable|setObjectsClippable" include src` pour valider l'intégration, qui a retourné les nouveaux usages attendus.
- Vérification rapide de l'état du dépôt (staged/modified files et HEAD court) pour confirmer les fichiers modifiés, qui a fonctionné correctement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c862601a4832fbbeb9c606ee9d834)