### PR TITLE
Add viewpoint-based animation preparation and toolbar state handling

### DIFF
--- a/include/controller/FilteredFonctionnalities.h
+++ b/include/controller/FilteredFonctionnalities.h
@@ -365,6 +365,8 @@ static const std::unordered_map<ControlType, std::unordered_set<LicenceVersion>>
 	// control::animation
 	{ControlType::addAnimationKeyPoint, {LicenceVersion::Standard} },
 	{ControlType::addScansAnimationKeyPoint, {LicenceVersion::Standard} },
+	{ControlType::prepareViewpointsAnimation, {LicenceVersion::Free} },
+	{ControlType::refreshViewpointsAnimationState, {LicenceVersion::Free} },
 
 	// control::Measure
 	{ControlType::SendPipeDetectionOptions, {LicenceVersion::Free} },

--- a/include/controller/controls/ControlAnimation.h
+++ b/include/controller/controls/ControlAnimation.h
@@ -31,6 +31,24 @@ namespace control::animation
         ControlType getType() const override;
     };
 
+    class PrepareViewpointsAnimation : public AControl
+    {
+    public:
+        PrepareViewpointsAnimation();
+        ~PrepareViewpointsAnimation();
+        void doFunction(Controller& controller) override;
+        ControlType getType() const override;
+    };
+
+    class RefreshViewpointsAnimationState : public AControl
+    {
+    public:
+        RefreshViewpointsAnimationState();
+        ~RefreshViewpointsAnimationState();
+        void doFunction(Controller& controller) override;
+        ControlType getType() const override;
+    };
+
     class Examine : public AControl
     {
     public:

--- a/include/controller/controls/IControl.h
+++ b/include/controller/controls/IControl.h
@@ -364,6 +364,8 @@ enum class ControlType
 	// control::animation
 	addAnimationKeyPoint,
 	addScansAnimationKeyPoint,
+	prepareViewpointsAnimation,
+	refreshViewpointsAnimationState,
 
 	// control::Measure
 	SendPipeDetectionOptions,//Standard

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -416,6 +416,16 @@ public:
 	const uint16_t m_speed;
 };
 
+class GuiDataRenderAnimationToolbarState : public IGuiData
+{
+public:
+	GuiDataRenderAnimationToolbarState(bool canStart);
+	~GuiDataRenderAnimationToolbarState() {}
+	virtual guiDType getType() override;
+
+	const bool m_canStart;
+};
+
 class GuiDataRenderRecordPerformances : public IGuiData
 {
 public:

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -55,6 +55,7 @@ enum class guiDType
 	renderCleanAnimationList,
 	renderAnimationSpeed,
 	renderAnimationLoop,
+	renderAnimationToolbarState,
 	renderRecordPerformance,
     renderImagesFormat,
     renderMeasureOptions,

--- a/include/gui/texts/ContextTexts.hpp
+++ b/include/gui/texts/ContextTexts.hpp
@@ -147,6 +147,9 @@
 #define TEXT_CONTEXT_EXPORT_VIDEO_FAIL QObject::tr("Fail")
 #define TEXT_CONTEXT_EXPORT_VIDEO_TIME QObject::tr("Sequence generated in %1 seconds")
 
+//ContextAnimation
+#define TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS QObject::tr("At least two perspective viewpoints are required to start the animation.")
+
 //ContextMoveManip
 #define TEXT_MOVE_MANIP_START QObject::tr("Select a temporary position for the manipulator.")
 

--- a/include/gui/toolBars/ToolBarAnimationGroup.h
+++ b/include/gui/toolBars/ToolBarAnimationGroup.h
@@ -22,22 +22,22 @@ public:
 
 private:
 	void onProjectLoad(IGuiData* keyValue);
+	void onProjectTreeActualize(IGuiData* keyValue);
+	void onAnimationToolbarState(IGuiData* keyValue);
 	void updateUI();
+	void refreshAnimationAvailability();
 
 private slots:
 	void slotStartAnimation();
 	void slotStopAnimation();
-	void slotCleanAnimationList();
-	void slotSpeedChange();
-	void slotLoopAnimation();
-	void slotRecordPerformance();
-	void slotScansAnimation();
 
 private:
 	std::unordered_map<guiDType, AnimGroupMethod> m_methods;
 	Ui::toolbar_animationgroup m_ui;
 	IDataDispatcher &m_dataDispatcher;
 	bool m_isStarted;
+	bool m_isProjectLoaded;
+	bool m_canStartAnimation;
 };
 
 #endif // TOOLBAR_ANIMATION_H

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -282,6 +282,9 @@ private:
     double m_offlineAnimStep = 0.0;
     std::chrono::steady_clock::time_point m_startTrajectoryTime;
     SimpleAnimation m_simpleAnimation = SimpleAnimation();
+    bool m_pendingComplexAnimationStart = false;
+    uint64_t m_pendingComplexAnimationStep = 1000;
+    SafePtr<ViewPointNode> m_animationStartViewpoint;
 
     // Uniform for projection and view matrix (separated)
     VkMultiUniform m_uniProjView;

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -1,10 +1,48 @@
 #include "controller/controls/ControlAnimation.h"
 #include "controller/Controller.h"
 #include "models/graph/AGraphNode.h"
+#include "models/graph/CameraNode.h"
+#include "models/graph/ViewPointNode.h"
+
+#include "gui/GuiData/GuiDataRendering.h"
+#include "gui/GuiData/GuiDataMessages.h"
+#include "gui/texts/ContextTexts.hpp"
+
+#include <algorithm>
 
 
 namespace control::animation
 {
+    namespace
+    {
+        std::vector<SafePtr<ViewPointNode>> collectPerspectiveViewpointsSorted(Controller& controller)
+        {
+            std::vector<SafePtr<ViewPointNode>> viewpoints;
+            const std::unordered_set<SafePtr<AGraphNode>> allViewpoints = controller.getGraphManager().getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+            viewpoints.reserve(allViewpoints.size());
+
+            for (const SafePtr<AGraphNode>& node : allViewpoints)
+            {
+                SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(node);
+                ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+                if (!rViewpoint || rViewpoint->getProjectionMode() != ProjectionMode::Perspective)
+                    continue;
+                viewpoints.push_back(viewpoint);
+            }
+
+            std::sort(viewpoints.begin(), viewpoints.end(), [](const SafePtr<ViewPointNode>& a, const SafePtr<ViewPointNode>& b)
+                {
+                    ReadPtr<ViewPointNode> ra = a.cget();
+                    ReadPtr<ViewPointNode> rb = b.cget();
+                    if (!ra || !rb)
+                        return bool(ra);
+                    return ra->getUserIndex() < rb->getUserIndex();
+                });
+
+            return viewpoints;
+        }
+    }
+
     AddViewPoint::AddViewPoint(SafePtr<AGraphNode> toAdd)
         : m_toAdd(toAdd)
     {}
@@ -81,4 +119,55 @@ namespace control::animation
         return ControlType::addScansAnimationKeyPoint;
     }
 
-} 
+    PrepareViewpointsAnimation::PrepareViewpointsAnimation()
+    {}
+
+    PrepareViewpointsAnimation::~PrepareViewpointsAnimation()
+    {}
+
+    void PrepareViewpointsAnimation::doFunction(Controller& controller)
+    {
+        const std::vector<SafePtr<ViewPointNode>> viewpoints = collectPerspectiveViewpointsSorted(controller);
+        const bool canStart = viewpoints.size() >= 2;
+        controller.updateInfo(new GuiDataRenderAnimationToolbarState(canStart));
+
+        if (!canStart)
+        {
+            controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
+            return;
+        }
+
+        WritePtr<CameraNode> wCam = controller.getGraphManager().getCameraNode().get();
+        if (!wCam)
+            return;
+
+        wCam->cleanAnimation();
+        wCam->setLoop(false);
+        wCam->setSpeed(3);
+        for (const SafePtr<ViewPointNode>& viewpoint : viewpoints)
+            wCam->AddViewPoint(viewpoint);
+    }
+
+    ControlType PrepareViewpointsAnimation::getType() const
+    {
+        return ControlType::prepareViewpointsAnimation;
+    }
+
+    RefreshViewpointsAnimationState::RefreshViewpointsAnimationState()
+    {}
+
+    RefreshViewpointsAnimationState::~RefreshViewpointsAnimationState()
+    {}
+
+    void RefreshViewpointsAnimationState::doFunction(Controller& controller)
+    {
+        const std::vector<SafePtr<ViewPointNode>> viewpoints = collectPerspectiveViewpointsSorted(controller);
+        controller.updateInfo(new GuiDataRenderAnimationToolbarState(viewpoints.size() >= 2));
+    }
+
+    ControlType RefreshViewpointsAnimationState::getType() const
+    {
+        return ControlType::refreshViewpointsAnimationState;
+    }
+
+}

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -85,6 +85,7 @@
 #include "gui/toolBars/ToolBarOrthoGrid.h"
 #include "gui/toolBars/ToolBarAutoSeeding.h"
 #include "gui/toolBars/ToolBarExportVideo.h"
+#include "gui/toolBars/ToolBarAnimationGroup.h"
 #include "gui/toolBars/ToolBarManipulateObjects.h"
 #include "gui/toolBars/ToolBarConvertImage.h"
 #include "gui/DisplayPresetManager.h"
@@ -365,6 +366,7 @@ Gui::Gui(Controller& controller)
 	ribbonTabContent->addWidget(TEXT_POINT_CLOUD, new ToolBarExportPointCloud(m_dataDispatcher, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_IMAGE, new ToolBarImageGroup(m_dataDispatcher, this, m_guiScale));
 	ribbonTabContent->addWidget(TEXT_VIDEO, new ToolBarExportVideo(m_dataDispatcher, this, m_guiScale));
+	ribbonTabContent->addWidget(TEXT_ANIMATION, new ToolBarAnimationGroup(m_dataDispatcher, this, m_guiScale));
 	m_ribbon->addTab(TEXT_EXPORT, ribbonTabContent);
 
 	// Add groups to the Filter Tab

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -405,6 +405,15 @@ guiDType GuiDataRenderAnimationSpeed::getType()
 	return guiDType::renderAnimationSpeed;
 }
 
+GuiDataRenderAnimationToolbarState::GuiDataRenderAnimationToolbarState(bool canStart)
+	: m_canStart(canStart)
+{}
+
+guiDType GuiDataRenderAnimationToolbarState::getType()
+{
+	return guiDType::renderAnimationToolbarState;
+}
+
 GuiDataRenderAnimationLoop::GuiDataRenderAnimationLoop(const bool& loop)
 	:_loop(loop)
 {}

--- a/src/gui/forms/toolbar_animationgroup.ui
+++ b/src/gui/forms/toolbar_animationgroup.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>421</width>
-    <height>151</height>
+    <width>240</width>
+    <height>139</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,29 +30,6 @@
     <number>3</number>
    </property>
    <item row="0" column="0">
-    <widget class="QPushButton" name="cleanListButton">
-     <property name="text">
-      <string>Clean animation list</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="scansAnimPushButton">
-     <property name="text">
-      <string>Viewpoint list</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QComboBox" name="formatComboBox"/>
-   </item>
-   <item row="1" column="0">
     <widget class="QPushButton" name="startAnimationButton">
      <property name="text">
       <string>Start animation</string>
@@ -62,24 +39,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Speed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QSlider" name="animationSpeedSlider">
-     <property name="maximum">
-      <number>3</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QPushButton" name="stopAnimationButton">
      <property name="text">
       <string>Stop animation</string>
@@ -89,14 +49,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QCheckBox" name="recordPerfCheckBox">
-     <property name="text">
-      <string>Record Perf</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="5">
+   <item row="2" column="0">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -108,13 +61,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="2" column="3">
-    <widget class="QCheckBox" name="loopCheckBox">
-     <property name="text">
-      <string>Loop</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -1,35 +1,29 @@
 #include "gui/toolBars/ToolBarAnimationGroup.h"
 #include "gui/GuiData/GuiDataRendering.h"
 #include "gui/GuiData/GuiDataGeneralProject.h"
-#include "controller/controls/ControlIO.h"
 #include "controller/controls/ControlAnimation.h"
-#include "io/ImageTypes.h"
 
 ToolBarAnimationGroup::ToolBarAnimationGroup(IDataDispatcher &dataDispatcher, QWidget *parent, float guiScale)
 	: QWidget(parent)
 	, m_dataDispatcher(dataDispatcher)
 	, m_isStarted(false)
+	, m_isProjectLoaded(false)
+	, m_canStartAnimation(false)
 {
 	m_ui.setupUi(this);
 	setEnabled(false);
 
-	connect(m_ui.cleanListButton, &QPushButton::pressed, this, &ToolBarAnimationGroup::slotCleanAnimationList);
 	connect(m_ui.startAnimationButton, &QPushButton::pressed, this, &ToolBarAnimationGroup::slotStartAnimation); 
 	connect(m_ui.stopAnimationButton, &QPushButton::pressed, this, &ToolBarAnimationGroup::slotStopAnimation); 
-	connect(m_ui.loopCheckBox, &QCheckBox::clicked, this, &ToolBarAnimationGroup::slotLoopAnimation);
-	connect(m_ui.animationSpeedSlider, &QSlider::valueChanged, this, &ToolBarAnimationGroup::slotSpeedChange);
-	connect(m_ui.recordPerfCheckBox, &QCheckBox::clicked, this, &ToolBarAnimationGroup::slotRecordPerformance);
-	connect(m_ui.scansAnimPushButton, &QPushButton::clicked, this, &ToolBarAnimationGroup::slotScansAnimation);
-
-	m_ui.formatComboBox->clear();
-	for (const auto& iterator : ImageFormatDictio)
-		m_ui.formatComboBox->addItem(QString::fromStdString(iterator.second));
-	m_ui.formatComboBox->setCurrentIndex(1);
 
 	updateUI();
 
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::projectLoaded);
+	m_dataDispatcher.registerObserverOnKey(this, guiDType::actualizeNodes);
+	m_dataDispatcher.registerObserverOnKey(this, guiDType::renderAnimationToolbarState);
 	m_methods.insert({ guiDType::projectLoaded, &ToolBarAnimationGroup::onProjectLoad });
+	m_methods.insert({ guiDType::actualizeNodes, &ToolBarAnimationGroup::onProjectTreeActualize });
+	m_methods.insert({ guiDType::renderAnimationToolbarState, &ToolBarAnimationGroup::onAnimationToolbarState });
 }
 
 ToolBarAnimationGroup::~ToolBarAnimationGroup()
@@ -49,58 +43,68 @@ void ToolBarAnimationGroup::informData(IGuiData* data)
 void ToolBarAnimationGroup::onProjectLoad(IGuiData* data)
 {
 	GuiDataProjectLoaded* plData = static_cast<GuiDataProjectLoaded*>(data);
-	setEnabled(plData->m_isProjectLoad);
+	m_isProjectLoaded = plData->m_isProjectLoad;
+	setEnabled(m_isProjectLoaded);
+	if (m_isProjectLoaded)
+		refreshAnimationAvailability();
+	else
+	{
+		m_canStartAnimation = false;
+		m_isStarted = false;
+		updateUI();
+	}
+}
+
+void ToolBarAnimationGroup::onProjectTreeActualize(IGuiData* data)
+{
+	(void)data;
+	if (!m_isProjectLoaded)
+		return;
+	refreshAnimationAvailability();
+}
+
+void ToolBarAnimationGroup::onAnimationToolbarState(IGuiData* data)
+{
+	auto state = static_cast<GuiDataRenderAnimationToolbarState*>(data);
+	m_canStartAnimation = state->m_canStart;
+	if (!m_canStartAnimation)
+		m_isStarted = false;
+	updateUI();
 }
 
 void ToolBarAnimationGroup::updateUI()
 {
-	m_ui.cleanListButton->setDisabled(m_isStarted);
-	m_ui.startAnimationButton->setDisabled(m_isStarted);
-	m_ui.cleanListButton->setDisabled(m_isStarted);
-	m_ui.formatComboBox->setDisabled(m_isStarted);
-	m_ui.stopAnimationButton->setEnabled(m_isStarted);
+	const bool canStart = m_isProjectLoaded && m_canStartAnimation && !m_isStarted;
+	m_ui.startAnimationButton->setEnabled(canStart);
+	m_ui.stopAnimationButton->setEnabled(m_isProjectLoaded && m_isStarted);
 }
 
 void ToolBarAnimationGroup::slotStartAnimation()
 {
+	if (!m_isProjectLoaded || !m_canStartAnimation)
+		return;
+
+	m_dataDispatcher.sendControl(new control::animation::PrepareViewpointsAnimation());
+	if (!m_canStartAnimation)
+		return;
+
 	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation());
 	m_isStarted = true;
 	updateUI();
-	if (m_ui.recordPerfCheckBox->isChecked())
-		m_dataDispatcher.sendControl(new control::io::RecordPerformance());
-	else
-		m_dataDispatcher.updateInformation(new GuiDataRenderRecordPerformances(""));
 }
 
 void ToolBarAnimationGroup::slotStopAnimation()
 {
+	if (!m_isStarted)
+		return;
+
 	m_dataDispatcher.updateInformation(new GuiDataRenderStopAnimation());
 	m_isStarted = false;
+	refreshAnimationAvailability();
 	updateUI();
 }
 
-void ToolBarAnimationGroup::slotCleanAnimationList()
+void ToolBarAnimationGroup::refreshAnimationAvailability()
 {
-	m_dataDispatcher.updateInformation(new GuiDataRenderCleanAnimationList());
-}
-
-void ToolBarAnimationGroup::slotLoopAnimation()
-{
-	m_dataDispatcher.updateInformation(new GuiDataRenderAnimationLoop(m_ui.loopCheckBox->isChecked()));
-}
-
-void ToolBarAnimationGroup::slotSpeedChange()
-{
-	m_dataDispatcher.updateInformation(new GuiDataRenderAnimationSpeed(m_ui.animationSpeedSlider->value()));
-}
-
-void ToolBarAnimationGroup::slotRecordPerformance()
-{
-	if(m_ui.recordPerfCheckBox->isChecked())
-		m_dataDispatcher.updateInformation(new GuiDataRenderRecordPerformances(""));
-}
-
-void ToolBarAnimationGroup::slotScansAnimation()
-{
-	m_dataDispatcher.sendControl(new control::animation::AddScansViewPoint());
+	m_dataDispatcher.sendControl(new control::animation::RefreshViewpointsAnimationState());
 }

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -537,7 +537,25 @@ bool CameraNode::animateSimpleTrajectory()
     if (progress > 1.0 || !m_simpleAnimation.end.dtime_arrival)
     {
         m_center = m_simpleAnimation.end.point;
-        if (!m_animation.empty())
+        if (m_pendingComplexAnimationStart)
+        {
+            ReadPtr<ViewPointNode> rVp = m_animationStartViewpoint.cget();
+            if (rVp)
+            {
+                static_cast<DisplayParameters&>(*this) = *&rVp;
+                applyProjection(*&rVp);
+                m_quaternion = rVp->getOrientation();
+                m_dataDispatcher.sendControl(new control::viewpoint::UpdateStatesFromViewpoint(m_animationStartViewpoint));
+            }
+
+            m_pendingComplexAnimationStart = false;
+            m_animationStartViewpoint.reset();
+            m_animMode = AnimationMode::Complex;
+            startPlayTrajectory(m_pendingComplexAnimationStep);
+            m_isAnimated = (m_trajectory.size() >= 2);
+            return m_isAnimated;
+        }
+        else if (!m_animation.empty())
         {
             //Note(Aurélien) #363 do stuff
             ReadPtr<ViewPointNode> rVp = m_animation.begin()->cget();
@@ -596,12 +614,11 @@ void CameraNode::AddViewPoint1(SafePtr<ViewPointNode> vp, const InterpolationVal
 
 bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
 {
-    m_animMode = AnimationMode::Complex;
     m_isOfflineRendering = isOffline;
-    if (m_animation.size() == 0)
+    if (m_animation.size() < 2)
     {
         m_isAnimated = false;
-        return true;
+        return false;
     }
     // TODO - Update the values in the UI.
 
@@ -622,8 +639,38 @@ bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
         //AddViewPoint(animation, InterpolationValueWithPreviousAnimation::BEZIER);
         AddViewPoint1(vp, InterpolationValueWithPreviousAnimation::BEZIER);
     }
+
+    SafePtr<ViewPointNode> firstViewpoint = m_animation.front();
+    ReadPtr<ViewPointNode> rFirstViewpoint = firstViewpoint.cget();
+    if (!rFirstViewpoint)
+    {
+        m_isAnimated = false;
+        return false;
+    }
+
+    const glm::dvec3 startPoint = rFirstViewpoint->getCenter();
+    const glm::dvec3 startLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFirstViewpoint->getInverseTransformation();
+    const bool needMoveToFirstViewpoint = glm::distance(getCenter(), startPoint) > 0.001;
+
+    if (needMoveToFirstViewpoint)
+    {
+        m_animMode = AnimationMode::Simple;
+        m_pendingComplexAnimationStart = true;
+        m_pendingComplexAnimationStep = step;
+        m_animationStartViewpoint = firstViewpoint;
+        moveTo(startPoint, 1.0, startLookDir, glm::dvec3(0.0, 0.0, 1.0));
+        m_isAnimated = true;
+        return true;
+    }
+
+    static_cast<DisplayParameters&>(*this) = *&rFirstViewpoint;
+    applyProjection(*&rFirstViewpoint);
+    m_quaternion = rFirstViewpoint->getOrientation();
+    m_dataDispatcher.sendControl(new control::viewpoint::UpdateStatesFromViewpoint(firstViewpoint));
+
+    m_animMode = AnimationMode::Complex;
     startPlayTrajectory(step);
-    m_isAnimated = true;
+    m_isAnimated = (m_trajectory.size() >= 2);
     return true;
 }
 
@@ -646,7 +693,7 @@ void CameraNode::cleanAnimation()
 
 void CameraNode::setSpeed(const int& speed)
 {
-    m_speed = speed ? speed * 1.2f : 1.0f;
+    m_speed = speed > 0 ? static_cast<double>(speed) : 1.0;
 }
 
 void CameraNode::setLoop(const bool& loop)


### PR DESCRIPTION
### Motivation
- Enable starting animations from perspective viewpoints only when sufficient viewpoints exist and centralize preparation logic for animations.
- Expose toolbar state to the GUI so the animation controls can be enabled/disabled based on project and viewpoint availability.
- Improve Camera animation startup to smoothly move the camera to the first viewpoint before running complex trajectories.

### Description
- Added two new animation controls: `PrepareViewpointsAnimation` and `RefreshViewpointsAnimationState`, and registered their `ControlType` values (`prepareViewpointsAnimation`, `refreshViewpointsAnimationState`).
- Implemented `collectPerspectiveViewpointsSorted` helper to gather and sort perspective `ViewPointNode` instances and used it in the new controls to decide availability and prepare animations.
- Introduced `GuiDataRenderAnimationToolbarState` and a new `guiDType::renderAnimationToolbarState` to notify the UI whether an animation can be started; added the text constant `TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS` for warnings.
- Updated `ToolBarAnimationGroup` UI and logic: removed multiple controls (speed, loop, record, list, etc.), kept start/stop buttons, added project and node-actualization awareness, and use the new `renderAnimationToolbarState` to enable/disable the start button.
- Hooked the animation toolbar into the ribbon (`Gui::Gui`) and registered for `actualizeNodes` and `renderAnimationToolbarState` updates.
- Extended `CameraNode` to support pending complex animation start behavior that moves the camera to the first viewpoint (if needed) before starting the complex trajectory, adjusted `startAnimation`, `animateSimpleTrajectory`, `cleanAnimation`, and `setSpeed` logic.
- Updated license mapping to include the new control types in `FilteredFonctionnalities.h`.

### Testing
- Built the project with the changes (`cmake`/`make`) and verified the build succeeds in a development environment; build completed successfully.
- Executed the project's automated unit test suite and GUI-related tests where available, and they passed without regressions.
- Ran automated toolbar state updates by simulating project load and node actualization messages, and the animation start/stop enablement behaved as expected in the test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a839570348832f93b53b30758de4e3)