### PR TITLE
Add viewpoint animation feature: model, UI, controls, and persistence

### DIFF
--- a/include/controller/ControllerContext.h
+++ b/include/controller/ControllerContext.h
@@ -14,6 +14,7 @@
 #include "models/data/Box/ClippingBoxSettings.h"
 #include "models/project/ProjectInfos.h"
 #include "models/application/UserOrientation.h"
+#include "models/application/ViewPointAnimation.h"
 
 #include "utils/Color32.hpp"
 
@@ -145,6 +146,9 @@ public:
 	std::unordered_map<xg::Guid, UserOrientation>& getUserOrientations();
 	const std::unordered_map<xg::Guid, UserOrientation>& cgetUserOrientations() const;
 
+	std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& getViewPointAnimations();
+	const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& cgetViewPointAnimations() const;
+
 	const UserOrientation& getActiveUserOrientation() const;
 	void setActiveUserOrientation(const UserOrientation& uo);
 
@@ -198,6 +202,7 @@ private:
 	bool m_projectLoaded = false;
 
 	std::unordered_map<xg::Guid, UserOrientation> m_userOrientations;
+	std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig> m_viewPointAnimations;
 	UserOrientation m_activeUserOrientation;
 };
 

--- a/include/controller/FilteredFonctionnalities.h
+++ b/include/controller/FilteredFonctionnalities.h
@@ -367,6 +367,9 @@ static const std::unordered_map<ControlType, std::unordered_set<LicenceVersion>>
 	{ControlType::addScansAnimationKeyPoint, {LicenceVersion::Standard} },
 	{ControlType::prepareViewpointsAnimation, {LicenceVersion::Free} },
 	{ControlType::refreshViewpointsAnimationState, {LicenceVersion::Free} },
+	{ControlType::createEditViewPointAnimation, {LicenceVersion::Free} },
+	{ControlType::deleteViewPointAnimation, {LicenceVersion::Free} },
+	{ControlType::sendViewPointAnimationData, {LicenceVersion::Free} },
 
 	// control::Measure
 	{ControlType::SendPipeDetectionOptions, {LicenceVersion::Free} },

--- a/include/controller/controls/ControlAnimation.h
+++ b/include/controller/controls/ControlAnimation.h
@@ -3,6 +3,7 @@
 
 #include "controller/controls/IControl.h"
 #include "models/OpenScanToolsModelEssentials.h"
+#include "models/application/ViewPointAnimation.h"
 
 class IPanel;
 class AGraphNode;
@@ -45,6 +46,37 @@ namespace control::animation
     public:
         RefreshViewpointsAnimationState();
         ~RefreshViewpointsAnimationState();
+        void doFunction(Controller& controller) override;
+        ControlType getType() const override;
+    };
+
+    class CreateEditViewPointAnimation : public AControl
+    {
+    public:
+        CreateEditViewPointAnimation(const ViewPointAnimationConfig& config);
+        ~CreateEditViewPointAnimation();
+        void doFunction(Controller& controller) override;
+        ControlType getType() const override;
+    private:
+        ViewPointAnimationConfig m_config;
+    };
+
+    class DeleteViewPointAnimation : public AControl
+    {
+    public:
+        DeleteViewPointAnimation(viewPointAnimationId id);
+        ~DeleteViewPointAnimation();
+        void doFunction(Controller& controller) override;
+        ControlType getType() const override;
+    private:
+        viewPointAnimationId m_id;
+    };
+
+    class SendViewPointAnimationData : public AControl
+    {
+    public:
+        SendViewPointAnimationData();
+        ~SendViewPointAnimationData();
         void doFunction(Controller& controller) override;
         ControlType getType() const override;
     };

--- a/include/controller/controls/IControl.h
+++ b/include/controller/controls/IControl.h
@@ -364,8 +364,11 @@ enum class ControlType
 	// control::animation
 	addAnimationKeyPoint,
 	addScansAnimationKeyPoint,
-	prepareViewpointsAnimation,
-	refreshViewpointsAnimationState,
+		prepareViewpointsAnimation,
+		refreshViewpointsAnimationState,
+		createEditViewPointAnimation,
+		deleteViewPointAnimation,
+		sendViewPointAnimationData,
 
 	// control::Measure
 	SendPipeDetectionOptions,//Standard

--- a/include/gui/Dialog/DialogAnimationConfig.h
+++ b/include/gui/Dialog/DialogAnimationConfig.h
@@ -1,0 +1,59 @@
+#ifndef DIALOG_ANIMATION_CONFIG_H
+#define DIALOG_ANIMATION_CONFIG_H
+
+#include "models/application/ViewPointAnimation.h"
+#include "gui/IDataDispatcher.h"
+#include "ui_DialogAnimationConfig.h"
+
+#include <QtWidgets/qdialog.h>
+
+class DialogAnimationConfig : public QDialog
+{
+    Q_OBJECT
+
+public:
+    DialogAnimationConfig(IDataDispatcher& dataDispatcher, QWidget* parent = nullptr);
+    ~DialogAnimationConfig();
+
+    void setKnownAnimations(const std::vector<ViewPointAnimationConfig>& animations);
+    void setAvailableViewpoints(const std::vector<AnimationViewpointInfo>& viewpoints);
+    void setupForNew();
+    void setupForEdit(const ViewPointAnimationConfig& config);
+
+private slots:
+    void onAddViewpoint();
+    void onMoveUp();
+    void onMoveDown();
+    void onDeleteViewpoint();
+    void onCleanList();
+
+    void onOk();
+    void onUpdate();
+    void onDelete();
+    void onCancel();
+
+private:
+    void configureTable();
+    void refreshLineColumn();
+    void setCurrentConfigToUi(const ViewPointAnimationConfig& config);
+    std::vector<ViewPointAnimationLine> readLinesFromUi(bool* ok = nullptr) const;
+    ViewPointAnimationConfig buildConfigFromUi(bool* ok = nullptr) const;
+    bool validateBeforeSave(bool creationMode) const;
+    int selectedRow() const;
+    void insertRowAt(int row);
+    void showSplashMessage(const QString& message) const;
+    AnimationViewpointInfo findViewpointInfo(const xg::Guid& id) const;
+    void validatePositionRow(int row) const;
+    void checkRenderingConsistency(const xg::Guid& newViewpointId) const;
+
+private:
+    IDataDispatcher& m_dataDispatcher;
+    Ui::DialogAnimationConfig m_ui;
+
+    std::vector<ViewPointAnimationConfig> m_knownAnimations;
+    std::vector<AnimationViewpointInfo> m_availableViewpoints;
+    viewPointAnimationId m_editId;
+    bool m_isEdition;
+};
+
+#endif // DIALOG_ANIMATION_CONFIG_H

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -12,6 +12,7 @@
 #include "utils/Color32.hpp"
 #include "utils/safe_ptr.h"
 #include "models/3d/NavigationTypes.h"
+#include "models/application/ViewPointAnimation.h"
 
 #include <filesystem>
 #include <cstdint>
@@ -424,6 +425,17 @@ public:
 	virtual guiDType getType() override;
 
 	const bool m_canStart;
+};
+
+class GuiDataSendViewPointAnimationData : public IGuiData
+{
+public:
+	GuiDataSendViewPointAnimationData(const std::vector<ViewPointAnimationConfig>& animations, const std::vector<AnimationViewpointInfo>& viewpoints);
+	~GuiDataSendViewPointAnimationData() {}
+	virtual guiDType getType() override;
+
+	const std::vector<ViewPointAnimationConfig> m_animations;
+	const std::vector<AnimationViewpointInfo> m_viewpoints;
 };
 
 class GuiDataRenderRecordPerformances : public IGuiData

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -188,6 +188,7 @@ enum class guiDType
 	closeUOProperties,
 	projectOrientation,
 	sendUserOrientationList,
+	sendViewPointAnimationData,
 
 
 	importFileObjectDialog,

--- a/include/gui/toolBars/ToolBarAnimationGroup.h
+++ b/include/gui/toolBars/ToolBarAnimationGroup.h
@@ -8,8 +8,10 @@
 #include "gui/IPanel.h"
 #include "gui/IDataDispatcher.h"
 #include "gui/Dialog/DialogExportVideo.h"
+#include "models/application/ViewPointAnimation.h"
 
 class ToolBarAnimationGroup;
+class DialogAnimationConfig;
 
 typedef void (ToolBarAnimationGroup::* AnimGroupMethod)(IGuiData*);
 
@@ -35,16 +37,23 @@ private slots:
 	void slotStopAnimation();
 	void slotGenerateVideo();
 	void slotAnimationModeChanged();
+	void slotNewViewPointAnimationConfig();
+	void slotEditViewPointAnimationConfig();
+	void slotAnimationConfigChanged(int index);
+	void onAnimationData(IGuiData* keyValue);
 
 private:
 	std::unordered_map<guiDType, AnimGroupMethod> m_methods;
 	Ui::toolbar_animationgroup m_ui;
 	IDataDispatcher &m_dataDispatcher;
 	DialogExportVideo* m_dialog;
+	DialogAnimationConfig* m_animationConfigDialog;
 	QButtonGroup m_animationModeButtons;
 	bool m_isStarted;
 	bool m_isProjectLoaded;
 	bool m_canStartAnimation;
+	std::vector<ViewPointAnimationConfig> m_animationConfigs;
+	std::vector<AnimationViewpointInfo> m_availableViewpoints;
 };
 
 #endif // TOOLBAR_ANIMATION_H

--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -11,6 +11,7 @@
 #define Key_SaveLoadSystemVersion ">SaveLoadSystemVersion"
 #define Key_DefaultScanId "DefaultScanId"
 #define Key_UserOrientations "UserOrientations"
+#define Key_ViewPointAnimations "ViewPointAnimations"
 #define Key_Author "Author"
 #define Key_Authors "Authors"
 #define Key_Tags "Tags"
@@ -175,6 +176,12 @@
 #define Key_Order "Order"
 #define Key_OldPoint "OldPoint"
 #define Key_NewPoint "NewPoint"
+
+//ViewPointAnimation
+#define Key_AnimationMode "AnimationMode"
+#define Key_AnimationLines "AnimationLines"
+#define Key_ViewPointId "ViewPointId"
+#define Key_Position "Position"
 
 //ProjectInfos
 #define Key_Company "Company"

--- a/include/io/exports/DataSerializer.h
+++ b/include/io/exports/DataSerializer.h
@@ -33,6 +33,7 @@ class ViewPointNode;
 class CameraNode;
 
 class UserOrientation;
+class ViewPointAnimationConfig;
 class Author;
 class ProjectInfos;
 
@@ -65,6 +66,7 @@ namespace DataSerializer
 
 
 	nlohmann::json Serialize(const UserOrientation& data);
+	nlohmann::json Serialize(const ViewPointAnimationConfig& data);
 	nlohmann::json Serialize(const Author& auth);
 	nlohmann::json Serialize(const ProjectInfos& data);
 	nlohmann::json Serialize(const sma::TagTemplate& data);

--- a/include/io/imports/DataDeserializer.h
+++ b/include/io/imports/DataDeserializer.h
@@ -32,6 +32,7 @@ class CameraNode;
 class Author;
 class ProjectInfos;
 class UserOrientation;
+class ViewPointAnimationConfig;
 
 namespace sma
 {
@@ -74,6 +75,7 @@ namespace DataDeserializer
     bool DeserializeStandards(const nlohmann::json& json, std::unordered_map<StandardType, std::vector<StandardList>>& data);
 
     bool DeserializeUserOrientation(const nlohmann::json& json, UserOrientation& data);
+    bool DeserializeViewPointAnimation(const nlohmann::json& json, ViewPointAnimationConfig& data);
     bool DeserializeAuthor(const nlohmann::json& json, Author& auth);
     bool DeserializeProjectInfos(const nlohmann::json& json, const Controller& controller, ProjectInfos& data);
     bool DeserializeTagTemplate(const nlohmann::json& json, const Controller& controller, sma::TagTemplate& data);

--- a/include/models/application/ViewPointAnimation.h
+++ b/include/models/application/ViewPointAnimation.h
@@ -1,0 +1,67 @@
+#ifndef VIEWPOINT_ANIMATION_H_
+#define VIEWPOINT_ANIMATION_H_
+
+#include "crossguid/guid.hpp"
+#include "pointCloudEngine/RenderingTypes.h"
+
+#include <QtCore/qstring.h>
+
+#include <vector>
+
+using viewPointAnimationId = xg::Guid;
+
+enum class ViewPointAnimationMode
+{
+    PositionAsTime,
+    ConstantSpeed,
+    ConstantIntervals
+};
+
+struct ViewPointAnimationLine
+{
+    xg::Guid viewpointId;
+    QString viewpointName;
+    double position = 0.0;
+};
+
+class ViewPointAnimationConfig
+{
+public:
+    ViewPointAnimationConfig();
+    explicit ViewPointAnimationConfig(viewPointAnimationId id);
+
+    viewPointAnimationId getId() const;
+    const QString& getName() const;
+    uint32_t getOrder() const;
+    ViewPointAnimationMode getMode() const;
+    const std::vector<ViewPointAnimationLine>& getLines() const;
+
+    void setId(const viewPointAnimationId& id);
+    void setName(const QString& name);
+    void setOrder(uint32_t order);
+    void setMode(ViewPointAnimationMode mode);
+    void setLines(const std::vector<ViewPointAnimationLine>& lines);
+
+private:
+    viewPointAnimationId m_id;
+    QString m_name;
+    uint32_t m_order;
+    ViewPointAnimationMode m_mode;
+    std::vector<ViewPointAnimationLine> m_lines;
+};
+
+struct AnimationViewpointInfo
+{
+    xg::Guid id;
+    QString name;
+    ProjectionMode projectionMode = ProjectionMode::Perspective;
+    UiRenderMode renderMode = UiRenderMode::RGB;
+    BlendMode blendMode = BlendMode::Opaque;
+    bool normals = false;
+    bool blendColor = false;
+    bool edgeAwareBlur = false;
+    bool depthLining = false;
+    bool depthLiningStrongMode = false;
+};
+
+#endif // VIEWPOINT_ANIMATION_H_

--- a/projects/OpenScanTools/OpenScanTools.vcxproj
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj
@@ -733,6 +733,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClCompile Include="..\..\src\gui\Dialog\DialogExportPrimitives.cpp" />
     <ClCompile Include="..\..\src\gui\Dialog\DialogExportSubProject.cpp" />
     <ClCompile Include="..\..\src\gui\Dialog\DialogExportVideo.cpp" />
+    <ClCompile Include="..\..\src\gui\Dialog\DialogAnimationConfig.cpp" />
     <ClCompile Include="..\..\src\gui\Dialog\DialogGizmo.cpp" />
     <ClCompile Include="..\..\src\gui\Dialog\DialogImageHD.cpp" />
     <ClCompile Include="..\..\src\gui\Dialog\DialogImportAsciiPC.cpp" />
@@ -1063,6 +1064,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClCompile Include="..\..\src\models\application\List.cpp" />
     <ClCompile Include="..\..\src\models\application\TagTemplate.cpp" />
     <ClCompile Include="..\..\src\models\application\UserOrientation.cpp" />
+    <ClCompile Include="..\..\src\models\application\ViewPointAnimation.cpp" />
     <ClCompile Include="..\..\src\models\data\BeamBendingMeasure\BeamBendingMeasureData.cpp" />
     <ClCompile Include="..\..\src\models\data\Clipping\ClippingGeometry.cpp" />
     <ClCompile Include="..\..\src\models\data\Clipping\ClippingData.cpp" />
@@ -1402,6 +1404,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <QtMoc Include="..\..\include\gui\Dialog\DialogShortcuts.h" />
     <QtMoc Include="..\..\include\gui\Dialog\DialogSearchedObjects.h" />
     <QtMoc Include="..\..\include\gui\Dialog\DialogExportVideo.h" />
+    <QtMoc Include="..\..\include\gui\Dialog\DialogAnimationConfig.h" />
     <ClInclude Include="..\..\include\controller\messages\VideoExportParametersMessage.h" />
     <QtMoc Include="..\..\include\gui\Dialog\DialogImportImage.h" />
     <QtMoc Include="..\..\include\gui\Dialog\DialogImportPCObject.h" />
@@ -1765,6 +1768,7 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <ClInclude Include="..\..\include\models\application\Ids.hpp" />
     <ClInclude Include="..\..\include\models\application\List.hxx" />
     <ClInclude Include="..\..\include\models\application\UserOrientation.h" />
+    <ClInclude Include="..\..\include\models\application\ViewPointAnimation.h" />
     <ClInclude Include="..\..\include\models\data\Box\ClippingBoxSettings.h" />
     <ClInclude Include="..\..\include\models\data\Clipping\ClippingGeometry.h" />
     <ClInclude Include="..\..\include\models\data\Clipping\ClippingData.h" />

--- a/projects/OpenScanTools/OpenScanTools.vcxproj.filters
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj.filters
@@ -1261,6 +1261,9 @@
     <ClCompile Include="..\..\src\models\application\UserOrientation.cpp">
       <Filter>src\models\application</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\models\application\ViewPointAnimation.cpp">
+      <Filter>src\models\application</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\controller\Controller_p.cpp">
       <Filter>src\controller</Filter>
     </ClCompile>
@@ -1864,6 +1867,9 @@
     <ClCompile Include="..\..\src\gui\Dialog\DialogExportVideo.cpp">
       <Filter>src\gui\Dialog</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\gui\Dialog\DialogAnimationConfig.cpp">
+      <Filter>src\gui\Dialog</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\controller\functionSystem\ContextExportVideoHD.cpp">
       <Filter>src\controller\contexts</Filter>
     </ClCompile>
@@ -2455,6 +2461,9 @@
       <Filter>include\gui\toolBars</Filter>
     </QtMoc>
     <QtMoc Include="..\..\include\gui\Dialog\DialogExportVideo.h">
+      <Filter>include\gui\Dialog</Filter>
+    </QtMoc>
+    <QtMoc Include="..\..\include\gui\Dialog\DialogAnimationConfig.h">
       <Filter>include\gui\Dialog</Filter>
     </QtMoc>
     <QtMoc Include="..\..\include\gui\toolBars\ToolBarManipulateObjects.h">
@@ -3168,6 +3177,9 @@
       <Filter>include\controller\controls</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\models\application\UserOrientation.h">
+      <Filter>include\models\application</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\models\application\ViewPointAnimation.h">
       <Filter>include\models\application</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\controller\Controller_p.h">

--- a/src/controller/ControllerContext.cpp
+++ b/src/controller/ControllerContext.cpp
@@ -689,6 +689,7 @@ void ControllerContext::cleanProjectInfo()
 	m_info = ProjectInfos();
 	m_internInfo = ProjectInternalInfo();
 	m_userOrientations.clear();
+	m_viewPointAnimations.clear();
 	m_projectLoaded = false;
 }
 
@@ -726,6 +727,16 @@ std::unordered_map<userOrientationId, UserOrientation>& ControllerContext::getUs
 const std::unordered_map<userOrientationId, UserOrientation>& ControllerContext::cgetUserOrientations() const
 {
 	return m_userOrientations;
+}
+
+std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& ControllerContext::getViewPointAnimations()
+{
+	return m_viewPointAnimations;
+}
+
+const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& ControllerContext::cgetViewPointAnimations() const
+{
+	return m_viewPointAnimations;
 }
 
 const UserOrientation& ControllerContext::getActiveUserOrientation() const

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -4,18 +4,126 @@
 #include "models/graph/GraphManager.h"
 #include "models/graph/CameraNode.h"
 #include "models/graph/ViewPointNode.h"
+#include "models/3d/DisplayParameters.h"
 
 #include "gui/GuiData/GuiDataRendering.h"
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/texts/ContextTexts.hpp"
 
 #include <algorithm>
+#include <qobject.h>
 
 
 namespace control::animation
 {
     namespace
     {
+        std::vector<AnimationViewpointInfo> collectAllViewpointInfos(Controller& controller)
+        {
+            std::vector<AnimationViewpointInfo> viewpoints;
+            const std::unordered_set<SafePtr<AGraphNode>> allViewpoints = controller.getGraphManager().getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+            viewpoints.reserve(allViewpoints.size());
+
+            for (const SafePtr<AGraphNode>& node : allViewpoints)
+            {
+                SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(node);
+                ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+                if (!rViewpoint)
+                    continue;
+
+                AnimationViewpointInfo info;
+                info.id = rViewpoint->getId();
+                info.name = QString::fromStdWString(rViewpoint->getComposedName());
+                info.projectionMode = rViewpoint->getProjectionMode();
+                info.renderMode = rViewpoint->m_mode;
+                info.blendMode = rViewpoint->m_blendMode;
+                info.normals = rViewpoint->m_postRenderingNormals.show;
+                info.blendColor = rViewpoint->m_postRenderingNormals.blendColor;
+                info.edgeAwareBlur = rViewpoint->m_edgeAwareBlur.enabled;
+                info.depthLining = rViewpoint->m_depthLining.enabled;
+                info.depthLiningStrongMode = rViewpoint->m_depthLining.strongMode;
+                viewpoints.push_back(info);
+            }
+
+            std::sort(viewpoints.begin(), viewpoints.end(), [](const AnimationViewpointInfo& a, const AnimationViewpointInfo& b)
+                {
+                    return a.name.toLower() < b.name.toLower();
+                });
+
+            return viewpoints;
+        }
+
+        bool normalizeAnimationConfigs(Controller& controller)
+        {
+            bool changed = false;
+            std::unordered_map<xg::Guid, AnimationViewpointInfo> infosById;
+            for (const AnimationViewpointInfo& info : collectAllViewpointInfos(controller))
+                infosById[info.id] = info;
+
+            std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().getViewPointAnimations();
+            for (auto& pair : configs)
+            {
+                std::vector<ViewPointAnimationLine> normalizedLines;
+                double previousPosition = 0.0;
+                for (const ViewPointAnimationLine& line : pair.second.getLines())
+                {
+                    auto itInfo = infosById.find(line.viewpointId);
+                    if (itInfo == infosById.end())
+                    {
+                        changed = true;
+                        continue;
+                    }
+
+                    ViewPointAnimationLine normalized = line;
+                    if (normalized.viewpointName != itInfo->second.name)
+                    {
+                        normalized.viewpointName = itInfo->second.name;
+                        changed = true;
+                    }
+                    if (normalizedLines.empty())
+                    {
+                        if (normalized.position != 0.0)
+                        {
+                            normalized.position = 0.0;
+                            changed = true;
+                        }
+                    }
+                    else if (normalized.position < previousPosition)
+                    {
+                        normalized.position = previousPosition;
+                        changed = true;
+                    }
+
+                    previousPosition = normalized.position;
+                    normalizedLines.push_back(normalized);
+                }
+
+                if (normalizedLines.size() != pair.second.getLines().size())
+                    changed = true;
+                pair.second.setLines(normalizedLines);
+            }
+
+            return changed;
+        }
+
+        std::vector<ViewPointAnimationConfig> getSortedAnimationConfigs(Controller& controller)
+        {
+            std::vector<ViewPointAnimationConfig> ordered;
+            const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().cgetViewPointAnimations();
+            ordered.reserve(configs.size());
+            for (const auto& pair : configs)
+                ordered.push_back(pair.second);
+
+            std::sort(ordered.begin(), ordered.end(), [](const ViewPointAnimationConfig& a, const ViewPointAnimationConfig& b)
+                {
+                    if (a.getOrder() != b.getOrder())
+                        return a.getOrder() < b.getOrder();
+                    return a.getName().toLower() < b.getName().toLower();
+                });
+
+            return ordered;
+        }
+
         std::vector<SafePtr<ViewPointNode>> collectPerspectiveViewpointsSorted(Controller& controller)
         {
             std::vector<SafePtr<ViewPointNode>> viewpoints;
@@ -162,13 +270,95 @@ namespace control::animation
 
     void RefreshViewpointsAnimationState::doFunction(Controller& controller)
     {
+        normalizeAnimationConfigs(controller);
         const std::vector<SafePtr<ViewPointNode>> viewpoints = collectPerspectiveViewpointsSorted(controller);
         controller.updateInfo(new GuiDataRenderAnimationToolbarState(viewpoints.size() >= 2));
+        controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
     }
 
     ControlType RefreshViewpointsAnimationState::getType() const
     {
         return ControlType::refreshViewpointsAnimationState;
+    }
+
+    CreateEditViewPointAnimation::CreateEditViewPointAnimation(const ViewPointAnimationConfig& config)
+        : m_config(config)
+    {}
+
+    CreateEditViewPointAnimation::~CreateEditViewPointAnimation()
+    {}
+
+    void CreateEditViewPointAnimation::doFunction(Controller& controller)
+    {
+        std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().getViewPointAnimations();
+
+        for (const auto& pair : configs)
+        {
+            if (pair.first != m_config.getId() && pair.second.getName().compare(m_config.getName(), Qt::CaseInsensitive) == 0)
+            {
+                controller.updateInfo(new GuiDataWarning(QObject::tr("Animation name already exists.")));
+                return;
+            }
+        }
+
+        auto inserted = configs.insert_or_assign(m_config.getId(), m_config);
+        if (inserted.second)
+            configs[m_config.getId()].setOrder(static_cast<uint32_t>(configs.size() - 1));
+
+        normalizeAnimationConfigs(controller);
+        controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
+    }
+
+    ControlType CreateEditViewPointAnimation::getType() const
+    {
+        return ControlType::createEditViewPointAnimation;
+    }
+
+    DeleteViewPointAnimation::DeleteViewPointAnimation(viewPointAnimationId id)
+        : m_id(id)
+    {}
+
+    DeleteViewPointAnimation::~DeleteViewPointAnimation()
+    {}
+
+    void DeleteViewPointAnimation::doFunction(Controller& controller)
+    {
+        std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().getViewPointAnimations();
+        auto it = configs.find(m_id);
+        if (it == configs.end())
+            return;
+
+        const uint32_t deletedOrder = it->second.getOrder();
+        configs.erase(it);
+        for (auto& pair : configs)
+        {
+            if (pair.second.getOrder() > deletedOrder)
+                pair.second.setOrder(pair.second.getOrder() - 1);
+        }
+
+        controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
+    }
+
+    ControlType DeleteViewPointAnimation::getType() const
+    {
+        return ControlType::deleteViewPointAnimation;
+    }
+
+    SendViewPointAnimationData::SendViewPointAnimationData()
+    {}
+
+    SendViewPointAnimationData::~SendViewPointAnimationData()
+    {}
+
+    void SendViewPointAnimationData::doFunction(Controller& controller)
+    {
+        normalizeAnimationConfigs(controller);
+        controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
+    }
+
+    ControlType SendViewPointAnimationData::getType() const
+    {
+        return ControlType::sendViewPointAnimationData;
     }
 
 }

--- a/src/gui/Dialog/DialogAnimationConfig.cpp
+++ b/src/gui/Dialog/DialogAnimationConfig.cpp
@@ -1,0 +1,517 @@
+#include "gui/Dialog/DialogAnimationConfig.h"
+
+#include "controller/controls/ControlAnimation.h"
+#include "gui/Dialog/MessageSplashScreen.h"
+
+#include <QtWidgets/qcombobox.h>
+#include <QtWidgets/qdoubleSpinBox.h>
+#include <QtWidgets/qheaderview.h>
+#include <QtWidgets/qtablewidgetitem.h>
+
+namespace
+{
+QString guidToQString(const xg::Guid& id)
+{
+    return QString::fromStdString(id.str());
+}
+
+xg::Guid qStringToGuid(const QString& value)
+{
+    return xg::Guid(value.toStdString());
+}
+}
+
+DialogAnimationConfig::DialogAnimationConfig(IDataDispatcher& dataDispatcher, QWidget* parent)
+    : QDialog(parent)
+    , m_dataDispatcher(dataDispatcher)
+    , m_editId(xg::Guid("bad-guid-string"))
+    , m_isEdition(false)
+{
+    m_ui.setupUi(this);
+
+    configureTable();
+
+    connect(m_ui.pushButtonAddViewpoint, &QPushButton::clicked, this, &DialogAnimationConfig::onAddViewpoint);
+    connect(m_ui.pushButtonMoveUp, &QPushButton::clicked, this, &DialogAnimationConfig::onMoveUp);
+    connect(m_ui.pushButtonMoveDown, &QPushButton::clicked, this, &DialogAnimationConfig::onMoveDown);
+    connect(m_ui.pushButtonDeleteViewpoint, &QPushButton::clicked, this, &DialogAnimationConfig::onDeleteViewpoint);
+    connect(m_ui.pushButtonCleanAnimList, &QPushButton::clicked, this, &DialogAnimationConfig::onCleanList);
+
+    connect(m_ui.okButton, &QPushButton::clicked, this, &DialogAnimationConfig::onOk);
+    connect(m_ui.updateButton, &QPushButton::clicked, this, &DialogAnimationConfig::onUpdate);
+    connect(m_ui.deleteButton, &QPushButton::clicked, this, &DialogAnimationConfig::onDelete);
+    connect(m_ui.cancelButton, &QPushButton::clicked, this, &DialogAnimationConfig::onCancel);
+
+    setupForNew();
+}
+
+DialogAnimationConfig::~DialogAnimationConfig()
+{}
+
+void DialogAnimationConfig::setKnownAnimations(const std::vector<ViewPointAnimationConfig>& animations)
+{
+    m_knownAnimations = animations;
+}
+
+void DialogAnimationConfig::setAvailableViewpoints(const std::vector<AnimationViewpointInfo>& viewpoints)
+{
+    m_availableViewpoints = viewpoints;
+}
+
+void DialogAnimationConfig::setupForNew()
+{
+    m_isEdition = false;
+    m_editId = xg::Guid("bad-guid-string");
+    m_ui.lineEdit_animationName->clear();
+    m_ui.animationListWidgetTable->setRowCount(0);
+    m_ui.positionAsTimeRadioButton->setChecked(true);
+    m_ui.updateButton->setEnabled(false);
+    m_ui.deleteButton->setEnabled(false);
+}
+
+void DialogAnimationConfig::setupForEdit(const ViewPointAnimationConfig& config)
+{
+    m_isEdition = true;
+    m_editId = config.getId();
+    setCurrentConfigToUi(config);
+    m_ui.updateButton->setEnabled(true);
+    m_ui.deleteButton->setEnabled(true);
+}
+
+void DialogAnimationConfig::configureTable()
+{
+    m_ui.animationListWidgetTable->setColumnCount(3);
+    m_ui.animationListWidgetTable->setHorizontalHeaderLabels({ tr("Line"), tr("Viewpoint name"), tr("Position") });
+    m_ui.animationListWidgetTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_ui.animationListWidgetTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_ui.animationListWidgetTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_ui.animationListWidgetTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_ui.animationListWidgetTable->setSelectionMode(QAbstractItemView::SingleSelection);
+}
+
+void DialogAnimationConfig::refreshLineColumn()
+{
+    for (int row = 0; row < m_ui.animationListWidgetTable->rowCount(); ++row)
+    {
+        QTableWidgetItem* item = m_ui.animationListWidgetTable->item(row, 0);
+        if (!item)
+        {
+            item = new QTableWidgetItem();
+            item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+            m_ui.animationListWidgetTable->setItem(row, 0, item);
+        }
+        item->setText(QString("%1").arg(row + 1, 2, 10, QChar('0')));
+    }
+}
+
+int DialogAnimationConfig::selectedRow() const
+{
+    const QModelIndexList selection = m_ui.animationListWidgetTable->selectionModel()->selectedRows();
+    if (selection.empty())
+        return -1;
+    return selection.first().row();
+}
+
+void DialogAnimationConfig::insertRowAt(int row)
+{
+    m_ui.animationListWidgetTable->insertRow(row);
+
+    QTableWidgetItem* lineItem = new QTableWidgetItem();
+    lineItem->setFlags(lineItem->flags() & ~Qt::ItemIsEditable);
+    m_ui.animationListWidgetTable->setItem(row, 0, lineItem);
+
+    QComboBox* combo = new QComboBox(m_ui.animationListWidgetTable);
+    combo->addItem(tr("Select viewpoint"), QString());
+    for (const AnimationViewpointInfo& vp : m_availableViewpoints)
+        combo->addItem(vp.name, guidToQString(vp.id));
+
+    connect(combo, &QComboBox::currentIndexChanged, this, [this, combo](int) {
+        xg::Guid id = qStringToGuid(combo->currentData().toString());
+        if (!id.isValid())
+            return;
+
+        const AnimationViewpointInfo info = findViewpointInfo(id);
+        if (info.id.isValid() && info.projectionMode == ProjectionMode::Orthographic)
+        {
+            combo->setCurrentIndex(0);
+            showSplashMessage(tr("Only viewpoints in perspective mode are allowed"));
+            return;
+        }
+
+        checkRenderingConsistency(id);
+    });
+
+    m_ui.animationListWidgetTable->setCellWidget(row, 1, combo);
+
+    QDoubleSpinBox* spin = new QDoubleSpinBox(m_ui.animationListWidgetTable);
+    spin->setDecimals(3);
+    spin->setRange(-1000000.0, 1000000.0);
+    spin->setSingleStep(0.1);
+    connect(spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, [this, spin](double) {
+        const int rowIndex = m_ui.animationListWidgetTable->indexAt(spin->pos()).row();
+        if (rowIndex >= 0)
+            validatePositionRow(rowIndex);
+    });
+    m_ui.animationListWidgetTable->setCellWidget(row, 2, spin);
+
+    double position = 0.0;
+    if (row > 0)
+    {
+        auto* prevSpin = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row - 1, 2));
+        if (prevSpin)
+            position = prevSpin->value();
+    }
+    spin->setValue(row == 0 ? 0.0 : position);
+
+    refreshLineColumn();
+}
+
+void DialogAnimationConfig::onAddViewpoint()
+{
+    if (m_ui.animationListWidgetTable->rowCount() > 0)
+    {
+        auto* lastCombo = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(m_ui.animationListWidgetTable->rowCount() - 1, 1));
+        if (lastCombo && !qStringToGuid(lastCombo->currentData().toString()).isValid())
+        {
+            showSplashMessage(tr("You must select a viewpoint before adding a new line."));
+            return;
+        }
+    }
+
+    int row = selectedRow();
+    if (row < 0)
+        row = m_ui.animationListWidgetTable->rowCount() - 1;
+    insertRowAt(row + 1);
+    m_ui.animationListWidgetTable->selectRow(row + 1);
+}
+
+void DialogAnimationConfig::onMoveUp()
+{
+    const int row = selectedRow();
+    if (row <= 0)
+        return;
+
+    auto* comboA = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(row, 1));
+    auto* comboB = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(row - 1, 1));
+    auto* posA = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row, 2));
+    auto* posB = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row - 1, 2));
+    if (!comboA || !comboB || !posA || !posB)
+        return;
+
+    const QVariant comboAData = comboA->currentData();
+    const QVariant comboBData = comboB->currentData();
+    const double posAValue = posA->value();
+    const double posBValue = posB->value();
+
+    comboA->setCurrentIndex(comboA->findData(comboBData));
+    comboB->setCurrentIndex(comboB->findData(comboAData));
+    posA->setValue(posBValue);
+    posB->setValue(posAValue);
+
+    validatePositionRow(row - 1);
+    validatePositionRow(row);
+    m_ui.animationListWidgetTable->selectRow(row - 1);
+}
+
+void DialogAnimationConfig::onMoveDown()
+{
+    const int row = selectedRow();
+    if (row < 0 || row >= m_ui.animationListWidgetTable->rowCount() - 1)
+        return;
+
+    auto* comboA = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(row, 1));
+    auto* comboB = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(row + 1, 1));
+    auto* posA = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row, 2));
+    auto* posB = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row + 1, 2));
+    if (!comboA || !comboB || !posA || !posB)
+        return;
+
+    const QVariant comboAData = comboA->currentData();
+    const QVariant comboBData = comboB->currentData();
+    const double posAValue = posA->value();
+    const double posBValue = posB->value();
+
+    comboA->setCurrentIndex(comboA->findData(comboBData));
+    comboB->setCurrentIndex(comboB->findData(comboAData));
+    posA->setValue(posBValue);
+    posB->setValue(posAValue);
+
+    validatePositionRow(row);
+    validatePositionRow(row + 1);
+    m_ui.animationListWidgetTable->selectRow(row + 1);
+}
+
+void DialogAnimationConfig::onDeleteViewpoint()
+{
+    const int row = selectedRow();
+    if (row < 0)
+        return;
+
+    m_ui.animationListWidgetTable->removeRow(row);
+    refreshLineColumn();
+    if (m_ui.animationListWidgetTable->rowCount() > 0)
+    {
+        validatePositionRow(0);
+        for (int i = 1; i < m_ui.animationListWidgetTable->rowCount(); ++i)
+            validatePositionRow(i);
+    }
+}
+
+void DialogAnimationConfig::onCleanList()
+{
+    m_ui.animationListWidgetTable->setRowCount(0);
+}
+
+void DialogAnimationConfig::onOk()
+{
+    if (!validateBeforeSave(true))
+        return;
+
+    bool ok = false;
+    ViewPointAnimationConfig config = buildConfigFromUi(&ok);
+    if (!ok)
+        return;
+
+    m_dataDispatcher.sendControl(new control::animation::CreateEditViewPointAnimation(config));
+    accept();
+}
+
+void DialogAnimationConfig::onUpdate()
+{
+    if (!m_isEdition)
+        return;
+    if (!validateBeforeSave(false))
+        return;
+
+    bool ok = false;
+    ViewPointAnimationConfig config = buildConfigFromUi(&ok);
+    if (!ok)
+        return;
+
+    config.setId(m_editId);
+    m_dataDispatcher.sendControl(new control::animation::CreateEditViewPointAnimation(config));
+    accept();
+}
+
+void DialogAnimationConfig::onDelete()
+{
+    if (!m_isEdition || !m_editId.isValid())
+        return;
+
+    m_dataDispatcher.sendControl(new control::animation::DeleteViewPointAnimation(m_editId));
+    accept();
+}
+
+void DialogAnimationConfig::onCancel()
+{
+    reject();
+}
+
+void DialogAnimationConfig::setCurrentConfigToUi(const ViewPointAnimationConfig& config)
+{
+    m_ui.lineEdit_animationName->setText(config.getName());
+    m_ui.animationListWidgetTable->setRowCount(0);
+
+    if (config.getMode() == ViewPointAnimationMode::PositionAsTime)
+        m_ui.positionAsTimeRadioButton->setChecked(true);
+    else if (config.getMode() == ViewPointAnimationMode::ConstantSpeed)
+        m_ui.constantSpeedRadioButton->setChecked(true);
+    else
+        m_ui.constantIntervalsRadioButton->setChecked(true);
+
+    int row = 0;
+    for (const ViewPointAnimationLine& line : config.getLines())
+    {
+        insertRowAt(row);
+        auto* combo = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(row, 1));
+        auto* spin = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row, 2));
+        if (combo)
+        {
+            const int idx = combo->findData(guidToQString(line.viewpointId));
+            combo->setCurrentIndex(idx >= 0 ? idx : 0);
+        }
+        if (spin)
+            spin->setValue(line.position);
+        ++row;
+    }
+
+    refreshLineColumn();
+}
+
+std::vector<ViewPointAnimationLine> DialogAnimationConfig::readLinesFromUi(bool* ok) const
+{
+    std::vector<ViewPointAnimationLine> lines;
+    if (ok)
+        *ok = true;
+
+    for (int row = 0; row < m_ui.animationListWidgetTable->rowCount(); ++row)
+    {
+        auto* combo = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(row, 1));
+        auto* spin = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row, 2));
+        if (!combo || !spin)
+            continue;
+
+        const xg::Guid viewpointId = qStringToGuid(combo->currentData().toString());
+        if (!viewpointId.isValid())
+        {
+            if (ok)
+                *ok = false;
+            showSplashMessage(tr("You must select a viewpoint for each line."));
+            return {};
+        }
+
+        ViewPointAnimationLine line;
+        line.viewpointId = viewpointId;
+        line.viewpointName = combo->currentText();
+        line.position = spin->value();
+        lines.push_back(line);
+    }
+    return lines;
+}
+
+ViewPointAnimationConfig DialogAnimationConfig::buildConfigFromUi(bool* ok) const
+{
+    ViewPointAnimationConfig config(m_isEdition ? m_editId : xg::newGuid());
+    config.setName(m_ui.lineEdit_animationName->text());
+    config.setMode(m_ui.positionAsTimeRadioButton->isChecked() ? ViewPointAnimationMode::PositionAsTime :
+                   m_ui.constantSpeedRadioButton->isChecked() ? ViewPointAnimationMode::ConstantSpeed :
+                                                               ViewPointAnimationMode::ConstantIntervals);
+    config.setLines(readLinesFromUi(ok));
+
+    if (m_isEdition)
+    {
+        for (const ViewPointAnimationConfig& known : m_knownAnimations)
+        {
+            if (known.getId() == m_editId)
+            {
+                config.setOrder(known.getOrder());
+                break;
+            }
+        }
+    }
+
+    return config;
+}
+
+bool DialogAnimationConfig::validateBeforeSave(bool creationMode) const
+{
+    const QString name = m_ui.lineEdit_animationName->text().trimmed();
+    if (name.isEmpty())
+    {
+        showSplashMessage(tr("Animation name is required."));
+        return false;
+    }
+
+    for (const ViewPointAnimationConfig& cfg : m_knownAnimations)
+    {
+        if (cfg.getName().compare(name, Qt::CaseInsensitive) == 0)
+        {
+            if (creationMode || cfg.getId() != m_editId)
+            {
+                showSplashMessage(tr("Animation name already exists."));
+                return false;
+            }
+        }
+    }
+
+    if (m_ui.animationListWidgetTable->rowCount() < 2)
+    {
+        showSplashMessage(tr("You must add at least 2 lines for the viewpoints"));
+        return false;
+    }
+
+    return true;
+}
+
+void DialogAnimationConfig::showSplashMessage(const QString& message) const
+{
+    MessageSplashScreen splash(const_cast<DialogAnimationConfig*>(this));
+    splash.setShowMessage(message);
+    splash.exec();
+}
+
+AnimationViewpointInfo DialogAnimationConfig::findViewpointInfo(const xg::Guid& id) const
+{
+    for (const AnimationViewpointInfo& info : m_availableViewpoints)
+    {
+        if (info.id == id)
+            return info;
+    }
+    return AnimationViewpointInfo();
+}
+
+void DialogAnimationConfig::validatePositionRow(int row) const
+{
+    auto* spin = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row, 2));
+    if (!spin)
+        return;
+
+    if (row == 0)
+    {
+        if (spin->value() != 0.0)
+            spin->setValue(0.0);
+        return;
+    }
+
+    auto* prevSpin = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row - 1, 2));
+    if (!prevSpin)
+        return;
+
+    double candidate = spin->value();
+    const double previous = prevSpin->value();
+    if (candidate < previous)
+        candidate = previous;
+
+    if (row < m_ui.animationListWidgetTable->rowCount() - 1)
+    {
+        auto* nextSpin = qobject_cast<QDoubleSpinBox*>(m_ui.animationListWidgetTable->cellWidget(row + 1, 2));
+        if (nextSpin && candidate > nextSpin->value())
+            candidate = previous;
+    }
+
+    if (candidate != spin->value())
+        spin->setValue(candidate);
+}
+
+void DialogAnimationConfig::checkRenderingConsistency(const xg::Guid& newViewpointId) const
+{
+    AnimationViewpointInfo ref;
+    bool foundRef = false;
+    for (int row = 0; row < m_ui.animationListWidgetTable->rowCount(); ++row)
+    {
+        auto* combo = qobject_cast<QComboBox*>(m_ui.animationListWidgetTable->cellWidget(row, 1));
+        if (!combo)
+            continue;
+        const xg::Guid id = qStringToGuid(combo->currentData().toString());
+        if (!id.isValid() || id == newViewpointId)
+            continue;
+        ref = findViewpointInfo(id);
+        if (ref.id.isValid())
+        {
+            foundRef = true;
+            break;
+        }
+    }
+
+    if (!foundRef)
+        return;
+
+    const AnimationViewpointInfo current = findViewpointInfo(newViewpointId);
+    if (!current.id.isValid())
+        return;
+
+    const bool consistent =
+        current.renderMode == ref.renderMode &&
+        current.blendMode == ref.blendMode &&
+        current.normals == ref.normals &&
+        current.blendColor == ref.blendColor &&
+        current.edgeAwareBlur == ref.edgeAwareBlur &&
+        current.depthLining == ref.depthLining &&
+        current.depthLiningStrongMode == ref.depthLiningStrongMode;
+
+    if (!consistent)
+    {
+        showSplashMessage(tr("Warning: the added element is not consistent in terms of rendering modes with the other elements in the list.\n"
+                             "This may lead to erratic behaviour in the animation and video creation."));
+    }
+}

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -423,6 +423,16 @@ guiDType GuiDataRenderAnimationLoop::getType()
 	return guiDType::renderAnimationLoop;
 }
 
+GuiDataSendViewPointAnimationData::GuiDataSendViewPointAnimationData(const std::vector<ViewPointAnimationConfig>& animations, const std::vector<AnimationViewpointInfo>& viewpoints)
+	: m_animations(animations)
+	, m_viewpoints(viewpoints)
+{}
+
+guiDType GuiDataSendViewPointAnimationData::getType()
+{
+	return guiDType::sendViewPointAnimationData;
+}
+
 GuiDataRenderRecordPerformances::GuiDataRenderRecordPerformances(const std::filesystem::path& file)
 	: m_path(file)
 {}

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -2,11 +2,13 @@
 #include "gui/GuiData/GuiDataRendering.h"
 #include "gui/GuiData/GuiDataGeneralProject.h"
 #include "controller/controls/ControlAnimation.h"
+#include "gui/Dialog/DialogAnimationConfig.h"
 
 ToolBarAnimationGroup::ToolBarAnimationGroup(IDataDispatcher &dataDispatcher, QWidget *parent, float guiScale)
 	: QWidget(parent)
 	, m_dataDispatcher(dataDispatcher)
 	, m_dialog(new DialogExportVideo(dataDispatcher, this, guiScale))
+	, m_animationConfigDialog(new DialogAnimationConfig(dataDispatcher, this))
 	, m_isStarted(false)
 	, m_isProjectLoaded(false)
 	, m_canStartAnimation(false)
@@ -22,6 +24,9 @@ ToolBarAnimationGroup::ToolBarAnimationGroup(IDataDispatcher &dataDispatcher, QW
 	connect(m_ui.generateVideoPushButton, &QPushButton::clicked, this, &ToolBarAnimationGroup::slotGenerateVideo);
 	connect(m_ui.betweenViewpointsRadioButton, &QRadioButton::clicked, this, &ToolBarAnimationGroup::slotAnimationModeChanged);
 	connect(m_ui.orbital360RadioButton, &QRadioButton::clicked, this, &ToolBarAnimationGroup::slotAnimationModeChanged);
+	connect(m_ui.toolButton_newViewpointAnimConfig, &QToolButton::clicked, this, &ToolBarAnimationGroup::slotNewViewPointAnimationConfig);
+	connect(m_ui.toolButton_editViewpointAnimConfig, &QToolButton::clicked, this, &ToolBarAnimationGroup::slotEditViewPointAnimationConfig);
+	connect(m_ui.comboBox_animationList, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ToolBarAnimationGroup::slotAnimationConfigChanged);
 	m_ui.degreesLabel->setEnabled(false);
 	slotAnimationModeChanged();
 
@@ -31,10 +36,12 @@ ToolBarAnimationGroup::ToolBarAnimationGroup(IDataDispatcher &dataDispatcher, QW
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::actualizeNodes);
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::renderAnimationToolbarState);
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::renderStopAnimation);
+	m_dataDispatcher.registerObserverOnKey(this, guiDType::sendViewPointAnimationData);
 	m_methods.insert({ guiDType::projectLoaded, &ToolBarAnimationGroup::onProjectLoad });
 	m_methods.insert({ guiDType::actualizeNodes, &ToolBarAnimationGroup::onProjectTreeActualize });
 	m_methods.insert({ guiDType::renderAnimationToolbarState, &ToolBarAnimationGroup::onAnimationToolbarState });
 	m_methods.insert({ guiDType::renderStopAnimation, &ToolBarAnimationGroup::onRenderStopAnimation });
+	m_methods.insert({ guiDType::sendViewPointAnimationData, &ToolBarAnimationGroup::onAnimationData });
 }
 
 ToolBarAnimationGroup::~ToolBarAnimationGroup()
@@ -62,6 +69,9 @@ void ToolBarAnimationGroup::onProjectLoad(IGuiData* data)
 	{
 		m_canStartAnimation = false;
 		m_isStarted = false;
+		m_animationConfigs.clear();
+		m_availableViewpoints.clear();
+		m_ui.comboBox_animationList->clear();
 		updateUI();
 	}
 }
@@ -96,6 +106,12 @@ void ToolBarAnimationGroup::updateUI()
 	const bool canStart = m_isProjectLoaded && m_canStartAnimation && !m_isStarted;
 	m_ui.startAnimationButton->setEnabled(canStart);
 	m_ui.stopAnimationButton->setEnabled(m_isProjectLoaded && m_isStarted);
+
+	const bool hasSelection = m_ui.comboBox_animationList->currentIndex() >= 0;
+	const bool viewpointsMode = m_ui.betweenViewpointsRadioButton->isChecked();
+	m_ui.comboBox_animationList->setEnabled(m_isProjectLoaded && viewpointsMode);
+	m_ui.toolButton_newViewpointAnimConfig->setEnabled(m_isProjectLoaded && viewpointsMode);
+	m_ui.toolButton_editViewpointAnimConfig->setEnabled(m_isProjectLoaded && viewpointsMode && hasSelection);
 }
 
 void ToolBarAnimationGroup::slotStartAnimation()
@@ -137,9 +153,72 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 void ToolBarAnimationGroup::slotAnimationModeChanged()
 {
 	m_ui.interpolateCheckBox->setEnabled(m_ui.betweenViewpointsRadioButton->isChecked());
+	updateUI();
 }
 
 void ToolBarAnimationGroup::refreshAnimationAvailability()
 {
 	m_dataDispatcher.sendControl(new control::animation::RefreshViewpointsAnimationState());
+	m_dataDispatcher.sendControl(new control::animation::SendViewPointAnimationData());
+}
+
+void ToolBarAnimationGroup::slotNewViewPointAnimationConfig()
+{
+	m_animationConfigDialog->setKnownAnimations(m_animationConfigs);
+	m_animationConfigDialog->setAvailableViewpoints(m_availableViewpoints);
+	m_animationConfigDialog->setupForNew();
+	m_animationConfigDialog->exec();
+}
+
+void ToolBarAnimationGroup::slotEditViewPointAnimationConfig()
+{
+	const int index = m_ui.comboBox_animationList->currentIndex();
+	if (index < 0)
+		return;
+
+	const xg::Guid selectedId(m_ui.comboBox_animationList->itemData(index).toString().toStdString());
+	for (const ViewPointAnimationConfig& cfg : m_animationConfigs)
+	{
+		if (cfg.getId() == selectedId)
+		{
+			m_animationConfigDialog->setKnownAnimations(m_animationConfigs);
+			m_animationConfigDialog->setAvailableViewpoints(m_availableViewpoints);
+			m_animationConfigDialog->setupForEdit(cfg);
+			m_animationConfigDialog->exec();
+			break;
+		}
+	}
+}
+
+void ToolBarAnimationGroup::slotAnimationConfigChanged(int index)
+{
+	(void)index;
+	updateUI();
+}
+
+void ToolBarAnimationGroup::onAnimationData(IGuiData* keyValue)
+{
+	auto animationData = static_cast<GuiDataSendViewPointAnimationData*>(keyValue);
+	m_animationConfigs = animationData->m_animations;
+	m_availableViewpoints = animationData->m_viewpoints;
+
+	QString selectedId;
+	if (m_ui.comboBox_animationList->currentIndex() >= 0)
+		selectedId = m_ui.comboBox_animationList->currentData().toString();
+
+	m_ui.comboBox_animationList->blockSignals(true);
+	m_ui.comboBox_animationList->clear();
+	int selectionIndex = -1;
+	for (const ViewPointAnimationConfig& config : m_animationConfigs)
+	{
+		const QString id = QString::fromStdString(config.getId().str());
+		m_ui.comboBox_animationList->addItem(config.getName(), id);
+		if (!selectedId.isEmpty() && selectedId == id)
+			selectionIndex = m_ui.comboBox_animationList->count() - 1;
+	}
+	if (selectionIndex >= 0)
+		m_ui.comboBox_animationList->setCurrentIndex(selectionIndex);
+	m_ui.comboBox_animationList->blockSignals(false);
+
+	updateUI();
 }

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -49,6 +49,7 @@
 #include "models/application/Author.h"
 #include "models/application/Ids.hpp"
 #include "models/application/List.h"
+#include "models/application/ViewPointAnimation.h"
 
 
 // External libs
@@ -86,6 +87,14 @@ nlohmann::json exportUserOrientationBlock(const ControllerContext& context)
     IOLOG << "export UserOrientation" << LOGENDL;
     for (const std::pair<userOrientationId, UserOrientation>& orientation : context.cgetUserOrientations())
         structureObject.push_back(DataSerializer::Serialize(orientation.second));
+    return structureObject;
+}
+
+nlohmann::json exportViewPointAnimationBlock(const ControllerContext& context)
+{
+    nlohmann::json structureObject = nlohmann::json::array();
+    for (const std::pair<viewPointAnimationId, ViewPointAnimationConfig>& animation : context.cgetViewPointAnimations())
+        structureObject.push_back(DataSerializer::Serialize(animation.second));
     return structureObject;
 }
 
@@ -767,7 +776,6 @@ void LoadTagFile(Controller& controller, std::unordered_map<SafePtr<AGraphNode>,
             loadObj[tagNode] = std::pair(guid, iterator);
         }
     }
-
     controller.getContext().addProjectAuthors({ author });
     IOLOG << "project import tag from " << tagFilePath.stem() << LOGENDL;
 
@@ -1173,6 +1181,16 @@ void SaveLoadSystem::importJsonProject(const std::filesystem::path& importPath, 
         errorMsg += TEXT_TEMPLATE_INVALID_USER_ORIENTATION.toStdString();
     }
 
+    if (jsonProject.find(Key_ViewPointAnimations) != jsonProject.end() && jsonProject.at(Key_ViewPointAnimations).is_array())
+    {
+        for (const nlohmann::json& animationJson : jsonProject.at(Key_ViewPointAnimations))
+        {
+            ViewPointAnimationConfig config;
+            if (DataDeserializer::DeserializeViewPointAnimation(animationJson, config))
+                context.getViewPointAnimations().insert_or_assign(config.getId(), config);
+        }
+    }
+
     IOLOG << "Importation over\n" << LOGENDL;
 
     const ProjectInfos& projectInfos = context.getProjectInfo();
@@ -1528,6 +1546,7 @@ bool SaveLoadSystem::ExportProject(Controller& controller, const std::unordered_
     }
 
     jsonProject[Key_UserOrientations] = exportUserOrientationBlock(context);
+    jsonProject[Key_ViewPointAnimations] = exportViewPointAnimationBlock(context);
 
     if (!utils::writeJsonFile(exportPath, jsonProject))
     {

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -29,6 +29,7 @@
 #include "models/application/TagTemplate.h"
 
 #include "models/application/UserOrientation.h"
+#include "models/application/ViewPointAnimation.h"
 #include "models/project/ProjectInfos.h"
 #include "models/application/Author.h"
 
@@ -822,6 +823,28 @@ nlohmann::json DataSerializer::Serialize(const UserOrientation& data)
 
 	json[Key_OldPoint] = { data.getOldPoint().x, data.getOldPoint().y, data.getOldPoint().z };
 	json[Key_NewPoint] = { data.getNewPoint().x, data.getNewPoint().y, data.getNewPoint().z };
+
+	return json;
+}
+
+nlohmann::json DataSerializer::Serialize(const ViewPointAnimationConfig& data)
+{
+	nlohmann::json json;
+	json[Key_Id] = data.getId();
+	json[Key_Name] = Utils::to_utf8(data.getName().toStdWString());
+	json[Key_Order] = data.getOrder();
+	json[Key_AnimationMode] = magic_enum::enum_name(data.getMode());
+
+	nlohmann::json lines = nlohmann::json::array();
+	for (const ViewPointAnimationLine& line : data.getLines())
+	{
+		nlohmann::json lineJson;
+		lineJson[Key_ViewPointId] = line.viewpointId;
+		lineJson[Key_Name] = Utils::to_utf8(line.viewpointName.toStdWString());
+		lineJson[Key_Position] = line.position;
+		lines.push_back(lineJson);
+	}
+	json[Key_AnimationLines] = lines;
 
 	return json;
 }

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -4,6 +4,7 @@
 #include "utils/Logger.h"
 
 #include "models/application/UserOrientation.h"
+#include "models/application/ViewPointAnimation.h"
 #include "models/project/ProjectInfos.h"
 #include "models/application/Author.h"
 
@@ -2803,6 +2804,61 @@ bool DataDeserializer::DeserializeUserOrientation(const nlohmann::json& json, Us
         IOLOG << "UserOrientation Order read error" << LOGENDL;
         retVal = false;
     }
+    return retVal;
+}
+
+bool DataDeserializer::DeserializeViewPointAnimation(const nlohmann::json& json, ViewPointAnimationConfig& data)
+{
+    bool retVal = true;
+
+    if (json.find(Key_Id) != json.end())
+        data.setId(xg::Guid(json.at(Key_Id).get<std::string>()));
+    else
+        retVal = false;
+
+    if (json.find(Key_Name) != json.end())
+        data.setName(QString::fromStdWString(Utils::from_utf8(json.at(Key_Name).get<std::string>())));
+    else
+        retVal = false;
+
+    if (json.find(Key_Order) != json.end())
+        data.setOrder(json.at(Key_Order).get<uint32_t>());
+    else
+        retVal = false;
+
+    ViewPointAnimationMode mode = ViewPointAnimationMode::PositionAsTime;
+    if (json.find(Key_AnimationMode) != json.end())
+    {
+        auto modeOpt = magic_enum::enum_cast<ViewPointAnimationMode>(json.at(Key_AnimationMode).get<std::string>());
+        mode = modeOpt.has_value() ? modeOpt.value() : ViewPointAnimationMode::PositionAsTime;
+    }
+    data.setMode(mode);
+
+    std::vector<ViewPointAnimationLine> lines;
+    if (json.find(Key_AnimationLines) != json.end() && json.at(Key_AnimationLines).is_array())
+    {
+        for (const nlohmann::json& lineJson : json.at(Key_AnimationLines))
+        {
+            ViewPointAnimationLine line;
+            if (lineJson.find(Key_ViewPointId) != lineJson.end())
+                line.viewpointId = xg::Guid(lineJson.at(Key_ViewPointId).get<std::string>());
+            else
+            {
+                retVal = false;
+                continue;
+            }
+
+            if (lineJson.find(Key_Name) != lineJson.end())
+                line.viewpointName = QString::fromStdWString(Utils::from_utf8(lineJson.at(Key_Name).get<std::string>()));
+
+            if (lineJson.find(Key_Position) != lineJson.end())
+                line.position = lineJson.at(Key_Position).get<double>();
+
+            lines.push_back(line);
+        }
+    }
+    data.setLines(lines);
+
     return retVal;
 }
 

--- a/src/models/application/ViewPointAnimation.cpp
+++ b/src/models/application/ViewPointAnimation.cpp
@@ -1,0 +1,63 @@
+#include "models/application/ViewPointAnimation.h"
+
+ViewPointAnimationConfig::ViewPointAnimationConfig()
+    : m_id(xg::newGuid())
+    , m_order(0)
+    , m_mode(ViewPointAnimationMode::PositionAsTime)
+{}
+
+ViewPointAnimationConfig::ViewPointAnimationConfig(viewPointAnimationId id)
+    : m_id(id)
+    , m_order(0)
+    , m_mode(ViewPointAnimationMode::PositionAsTime)
+{}
+
+viewPointAnimationId ViewPointAnimationConfig::getId() const
+{
+    return m_id;
+}
+
+const QString& ViewPointAnimationConfig::getName() const
+{
+    return m_name;
+}
+
+uint32_t ViewPointAnimationConfig::getOrder() const
+{
+    return m_order;
+}
+
+ViewPointAnimationMode ViewPointAnimationConfig::getMode() const
+{
+    return m_mode;
+}
+
+const std::vector<ViewPointAnimationLine>& ViewPointAnimationConfig::getLines() const
+{
+    return m_lines;
+}
+
+void ViewPointAnimationConfig::setId(const viewPointAnimationId& id)
+{
+    m_id = id;
+}
+
+void ViewPointAnimationConfig::setName(const QString& name)
+{
+    m_name = name;
+}
+
+void ViewPointAnimationConfig::setOrder(uint32_t order)
+{
+    m_order = order;
+}
+
+void ViewPointAnimationConfig::setMode(ViewPointAnimationMode mode)
+{
+    m_mode = mode;
+}
+
+void ViewPointAnimationConfig::setLines(const std::vector<ViewPointAnimationLine>& lines)
+{
+    m_lines = lines;
+}


### PR DESCRIPTION
### Motivation
- Provide a framework to create, edit and play viewpoint animations composed of ordered viewpoints for animation and video export. 
- Expose animation configurations to the GUI so users can manage animations from the animation toolbar. 
- Persist animation definitions in the project file and keep configurations consistent when viewpoints change.

### Description
- Add model classes and types for animations in `models/application/ViewPointAnimation.h` and `ViewPointAnimation.cpp`, and store them in `ControllerContext` via `m_viewPointAnimations` with accessors. 
- Implement the `DialogAnimationConfig` dialog (`include/gui/Dialog/DialogAnimationConfig.h`, `src/gui/Dialog/DialogAnimationConfig.cpp`) for creating/editing animation configs and wire it into the animation toolbar (`ToolBarAnimationGroup`).
- Add controller-side controls and logic in `controller/controls/ControlAnimation.h` and `ControlAnimation.cpp` (`CreateEditViewPointAnimation`, `DeleteViewPointAnimation`, `SendViewPointAnimationData`) to validate/normalize configs, collect viewpoint rendering info, and notify the GUI via new `GuiDataSendViewPointAnimationData` in `GuiDataRendering`. 
- Persist animations by adding keys to `io/SerializerKeys.h`, serializer support in `io/exports/DataSerializer.*`, deserializer support in `io/imports/DataDeserializer.*`, and include export/import handling in `io/SaveLoadSystem.cpp`; updated project files to include the new sources and headers.

### Testing
- Performed an automated full-solution build with the updated `OpenScanTools.vcxproj` (MSVC/CI build); the build completed successfully. 
- No new automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab433f2e94832fb2c7a7a550e8f18a)