### PR TITLE
Add pause/resume and orbital animation support with control-point timing for viewpoint animations

### DIFF
--- a/include/controller/controls/ControlAnimation.h
+++ b/include/controller/controls/ControlAnimation.h
@@ -35,10 +35,13 @@ namespace control::animation
     class PrepareViewpointsAnimation : public AControl
     {
     public:
-        PrepareViewpointsAnimation();
+        PrepareViewpointsAnimation(const viewPointAnimationId& animationId, int lengthSeconds);
         ~PrepareViewpointsAnimation();
         void doFunction(Controller& controller) override;
         ControlType getType() const override;
+    private:
+        viewPointAnimationId m_animationId;
+        int m_lengthSeconds;
     };
 
     class RefreshViewpointsAnimationState : public AControl

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -377,8 +377,24 @@ public:
 class GuiDataRenderStartAnimation : public IGuiData
 {
 public:
-	GuiDataRenderStartAnimation() {}
+	GuiDataRenderStartAnimation(bool isOrbital = false, double durationSeconds = 0.0, bool resume = false)
+		: m_isOrbital(isOrbital)
+		, m_durationSeconds(durationSeconds)
+		, m_resume(resume)
+	{}
 	~GuiDataRenderStartAnimation() {}
+	virtual guiDType getType() override;
+
+	const bool m_isOrbital;
+	const double m_durationSeconds;
+	const bool m_resume;
+};
+
+class GuiDataRenderPauseAnimation : public IGuiData
+{
+public:
+	GuiDataRenderPauseAnimation() {}
+	~GuiDataRenderPauseAnimation() {}
 	virtual guiDType getType() override;
 };
 

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -51,6 +51,7 @@ enum class guiDType
 	renderDistanceRampValues,
 	renderDisplayAllMarkersTexts,
 	renderStartAnimation,
+	renderPauseAnimation,
 	renderStopAnimation,
 	renderCleanAnimationList,
 	renderAnimationSpeed,

--- a/include/gui/texts/ContextTexts.hpp
+++ b/include/gui/texts/ContextTexts.hpp
@@ -149,6 +149,7 @@
 
 //ContextAnimation
 #define TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS QObject::tr("At least two perspective viewpoints are required to start the animation.")
+#define TEXT_CONTEXT_ANIMATION_INCONSISTENT_TIMES QObject::tr("The table of viewpoints contains inconsistent time values. Times must be increasing. Example: if you have entered 5 in the Position field for a row in the table, then you must enter a higher value in the next row, for example 6.")
 
 //ContextMoveManip
 #define TEXT_MOVE_MANIP_START QObject::tr("Select a temporary position for the manipulator.")

--- a/include/gui/toolBars/ToolBarAnimationGroup.h
+++ b/include/gui/toolBars/ToolBarAnimationGroup.h
@@ -31,10 +31,12 @@ private:
 	void onRenderStopAnimation(IGuiData* keyValue);
 	void updateUI();
 	void refreshAnimationAvailability();
+	const ViewPointAnimationConfig* getSelectedAnimationConfig() const;
 
 private slots:
 	void slotStartAnimation();
 	void slotStopAnimation();
+	void slotPauseAnimation();
 	void slotGenerateVideo();
 	void slotAnimationModeChanged();
 	void slotNewViewPointAnimationConfig();
@@ -50,6 +52,8 @@ private:
 	DialogAnimationConfig* m_animationConfigDialog;
 	QButtonGroup m_animationModeButtons;
 	bool m_isStarted;
+	bool m_isPaused;
+	bool m_isOrbitalRunning;
 	bool m_isProjectLoaded;
 	bool m_canStartAnimation;
 	std::vector<ViewPointAnimationConfig> m_animationConfigs;

--- a/include/gui/viewport/VulkanViewport.h
+++ b/include/gui/viewport/VulkanViewport.h
@@ -11,6 +11,7 @@
 
 #include "glm/glm.hpp"
 
+#include <chrono>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -181,6 +182,7 @@ protected:
     void onRenderAnimationSpeed(IGuiData* data); // FIXME - Move to CameraNode
     void onRenderAnimationLoop(IGuiData* data);  // FIXME - Move to CameraNode
     void onRenderStartAnimation(IGuiData* data);  // FIXME - Move to CameraNode
+    void onRenderPauseAnimation(IGuiData* data);  // FIXME - Move to CameraNode
     void onRenderStopAnimation(IGuiData* data);  // FIXME - Move to CameraNode
     void onRenderCleanAnimationList(IGuiData* data);  // FIXME - Move to CameraNode
     void onUserOrientation(IGuiData* data); // FIXME - Move to CameraNode
@@ -293,6 +295,13 @@ private:
 
     // Animation
     bool m_saveImagesAnim;
+    bool m_isOrbitalAnimationActive = false;
+    bool m_isOrbitalAnimationPaused = false;
+    bool m_orbitalUsesExamine = false;
+    double m_orbitalDurationSeconds = 0.0;
+    double m_orbitalElapsedSeconds = 0.0;
+    std::chrono::steady_clock::time_point m_orbitalStartTime;
+    std::chrono::steady_clock::time_point m_orbitalPauseTime;
 };
 
 #endif // VULKAN_VIEWPORT_H_

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -11,8 +11,11 @@
 
 #include "models/3d/RenderingParameters.h"
 #include "pointCloudEngine/RenderingTypes.h"
+#include "models/application/ViewPointAnimation.h"
 
 #include <deque>
+#include <chrono>
+#include <vector>
 
 class ViewPointNode;
 class PointCloudNode;
@@ -90,9 +93,12 @@ public:
     void AddViewPoint1(SafePtr<ViewPointNode> vp, const InterpolationValueWithPreviousAnimation& interpolation = InterpolationValueWithPreviousAnimation::NONE);
     bool startAnimation(const bool& isOffline = false, const uint64_t& step = 1000);
     bool endAnimation();
+    bool pauseAnimation();
+    bool resumeAnimation();
     void cleanAnimation();
     void setSpeed(const int& speed);
     void setLoop(const bool& loop);
+    void setAnimationTiming(ViewPointAnimationMode mode, double durationSeconds, const std::vector<double>& controlPointTimesSec);
 
     // Orientation as Euler angles
     void yaw(double _amount);
@@ -182,6 +188,8 @@ private:
     void buildComplexAnimationPlaybackPath();
     void buildLinearPlaybackPathFromTrajectory();
     void buildCatmullRomPlaybackPathFromTrajectory();
+    void applyPlaybackTimingFromControlPoints();
+    static double smoothstep01(double t);
     static glm::dvec3 evaluateCentripetalCatmullRom(
         const glm::dvec3& p0,
         const glm::dvec3& p1,
@@ -292,6 +300,7 @@ private:
     double m_speed = 0.0;
     bool m_isAnimated = false;
     bool m_isOfflineRendering = false;
+    bool m_isAnimationPaused = false;
     bool m_loop = false;
     AnimationMode m_animMode = AnimationMode::Simple;
 
@@ -307,6 +316,11 @@ private:
     uint64_t m_animFrames = 0;
     double m_offlineAnimStep = 0.0;
     std::chrono::steady_clock::time_point m_startTrajectoryTime;
+    std::chrono::steady_clock::time_point m_pauseTrajectoryTime;
+    double m_totalPausedDurationSeconds = 0.0;
+    ViewPointAnimationMode m_viewPointAnimationMode = ViewPointAnimationMode::ConstantSpeed;
+    double m_animationDurationSeconds = 0.0;
+    std::vector<double> m_controlPointTimesSeconds;
     SimpleAnimation m_simpleAnimation = SimpleAnimation();
     bool m_pendingComplexAnimationStart = false;
     uint64_t m_pendingComplexAnimationStep = 1000;

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -12,6 +12,7 @@
 #include "gui/texts/ContextTexts.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <qobject.h>
 
 
@@ -229,7 +230,9 @@ namespace control::animation
         return ControlType::addScansAnimationKeyPoint;
     }
 
-    PrepareViewpointsAnimation::PrepareViewpointsAnimation()
+    PrepareViewpointsAnimation::PrepareViewpointsAnimation(const viewPointAnimationId& animationId, int lengthSeconds)
+        : m_animationId(animationId)
+        , m_lengthSeconds(lengthSeconds)
     {}
 
     PrepareViewpointsAnimation::~PrepareViewpointsAnimation()
@@ -237,7 +240,51 @@ namespace control::animation
 
     void PrepareViewpointsAnimation::doFunction(Controller& controller)
     {
-        const std::vector<SafePtr<ViewPointNode>> viewpoints = collectPerspectiveViewpointsSorted(controller);
+        const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().cgetViewPointAnimations();
+        auto itConfig = configs.find(m_animationId);
+        if (itConfig == configs.end())
+        {
+            controller.updateInfo(new GuiDataRenderAnimationToolbarState(false));
+            controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
+            return;
+        }
+
+        std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> perspectiveById;
+        for (const SafePtr<ViewPointNode>& viewpoint : collectPerspectiveViewpointsSorted(controller))
+        {
+            ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+            if (!rViewpoint)
+                continue;
+            perspectiveById.insert_or_assign(rViewpoint->getId(), viewpoint);
+        }
+
+        std::vector<SafePtr<ViewPointNode>> viewpoints;
+        std::vector<double> controlTimes;
+        viewpoints.reserve(itConfig->second.getLines().size());
+        controlTimes.reserve(itConfig->second.getLines().size());
+
+        double previousTime = -std::numeric_limits<double>::infinity();
+        for (const ViewPointAnimationLine& line : itConfig->second.getLines())
+        {
+            auto itVp = perspectiveById.find(line.viewpointId);
+            if (itVp == perspectiveById.end())
+                continue;
+
+            viewpoints.push_back(itVp->second);
+            controlTimes.push_back(line.position);
+
+            if (itConfig->second.getMode() == ViewPointAnimationMode::PositionAsTime)
+            {
+                if (line.position <= previousTime)
+                {
+                    controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_INCONSISTENT_TIMES));
+                    controller.updateInfo(new GuiDataRenderAnimationToolbarState(false));
+                    return;
+                }
+                previousTime = line.position;
+            }
+        }
+
         const bool canStart = viewpoints.size() >= 2;
         controller.updateInfo(new GuiDataRenderAnimationToolbarState(canStart));
 
@@ -253,7 +300,8 @@ namespace control::animation
 
         wCam->cleanAnimation();
         wCam->setLoop(false);
-        wCam->setSpeed(3);
+        wCam->setSpeed(1);
+        wCam->setAnimationTiming(itConfig->second.getMode(), static_cast<double>(m_lengthSeconds), controlTimes);
         for (const SafePtr<ViewPointNode>& viewpoint : viewpoints)
             wCam->AddViewPoint(viewpoint);
     }

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -386,6 +386,11 @@ guiDType GuiDataRenderStartAnimation::getType()
 	return guiDType::renderStartAnimation;
 }
 
+guiDType GuiDataRenderPauseAnimation::getType()
+{
+	return guiDType::renderPauseAnimation;
+}
+
 guiDType GuiDataRenderStopAnimation::getType()
 {
 	return guiDType::renderStopAnimation;

--- a/src/gui/forms/toolbar_animationgroup.ui
+++ b/src/gui/forms/toolbar_animationgroup.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>739</width>
+    <width>800</width>
     <height>139</height>
    </rect>
   </property>
@@ -164,6 +164,16 @@
     </widget>
    </item>
    <item row="1" column="7">
+    <widget class="QPushButton" name="pauseAnimationButton">
+     <property name="text">
+      <string>Pause</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="8">
     <widget class="QPushButton" name="stopAnimationButton">
      <property name="text">
       <string>Stop</string>
@@ -173,7 +183,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="6" colspan="2">
+   <item row="2" column="6" colspan="3">
     <widget class="QPushButton" name="generateVideoPushButton">
      <property name="toolTip">
       <string>Video generation. Please make sure you are in perspective mode and that you selected a frame in the image section.</string>

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -10,6 +10,8 @@ ToolBarAnimationGroup::ToolBarAnimationGroup(IDataDispatcher &dataDispatcher, QW
 	, m_dialog(new DialogExportVideo(dataDispatcher, this, guiScale))
 	, m_animationConfigDialog(new DialogAnimationConfig(dataDispatcher, this))
 	, m_isStarted(false)
+	, m_isPaused(false)
+	, m_isOrbitalRunning(false)
 	, m_isProjectLoaded(false)
 	, m_canStartAnimation(false)
 {
@@ -20,6 +22,7 @@ ToolBarAnimationGroup::ToolBarAnimationGroup(IDataDispatcher &dataDispatcher, QW
 	m_animationModeButtons.addButton(m_ui.betweenViewpointsRadioButton);
 
 	connect(m_ui.startAnimationButton, &QPushButton::pressed, this, &ToolBarAnimationGroup::slotStartAnimation); 
+	connect(m_ui.pauseAnimationButton, &QPushButton::pressed, this, &ToolBarAnimationGroup::slotPauseAnimation);
 	connect(m_ui.stopAnimationButton, &QPushButton::pressed, this, &ToolBarAnimationGroup::slotStopAnimation); 
 	connect(m_ui.generateVideoPushButton, &QPushButton::clicked, this, &ToolBarAnimationGroup::slotGenerateVideo);
 	connect(m_ui.betweenViewpointsRadioButton, &QRadioButton::clicked, this, &ToolBarAnimationGroup::slotAnimationModeChanged);
@@ -69,6 +72,8 @@ void ToolBarAnimationGroup::onProjectLoad(IGuiData* data)
 	{
 		m_canStartAnimation = false;
 		m_isStarted = false;
+		m_isPaused = false;
+		m_isOrbitalRunning = false;
 		m_animationConfigs.clear();
 		m_availableViewpoints.clear();
 		m_ui.comboBox_animationList->clear();
@@ -90,6 +95,8 @@ void ToolBarAnimationGroup::onAnimationToolbarState(IGuiData* data)
 	m_canStartAnimation = state->m_canStart;
 	if (!m_canStartAnimation)
 		m_isStarted = false;
+	if (!m_canStartAnimation)
+		m_isPaused = false;
 	updateUI();
 }
 
@@ -97,44 +104,86 @@ void ToolBarAnimationGroup::onRenderStopAnimation(IGuiData* data)
 {
 	(void)data;
 	m_isStarted = false;
+	m_isPaused = false;
+	m_isOrbitalRunning = false;
 	refreshAnimationAvailability();
 	updateUI();
 }
 
 void ToolBarAnimationGroup::updateUI()
 {
-	const bool canStart = m_isProjectLoaded && m_canStartAnimation && !m_isStarted;
-	m_ui.startAnimationButton->setEnabled(canStart);
-	m_ui.stopAnimationButton->setEnabled(m_isProjectLoaded && m_isStarted);
-
-	const bool hasSelection = m_ui.comboBox_animationList->currentIndex() >= 0;
 	const bool viewpointsMode = m_ui.betweenViewpointsRadioButton->isChecked();
-	m_ui.comboBox_animationList->setEnabled(m_isProjectLoaded && viewpointsMode);
-	m_ui.toolButton_newViewpointAnimConfig->setEnabled(m_isProjectLoaded && viewpointsMode);
-	m_ui.toolButton_editViewpointAnimConfig->setEnabled(m_isProjectLoaded && viewpointsMode && hasSelection);
+	const bool hasSelection = m_ui.comboBox_animationList->currentIndex() >= 0;
+	const bool canPrepareBetween = m_canStartAnimation && viewpointsMode && hasSelection;
+	const bool canStart = m_isProjectLoaded && !m_isStarted && ((viewpointsMode && (canPrepareBetween || m_isPaused)) || (!viewpointsMode));
+	m_ui.startAnimationButton->setEnabled(canStart);
+	m_ui.pauseAnimationButton->setEnabled(m_isProjectLoaded && m_isStarted);
+	m_ui.stopAnimationButton->setEnabled(m_isProjectLoaded && (m_isStarted || m_isPaused));
+
+	const bool canEditViewpoints = m_isProjectLoaded && viewpointsMode;
+	m_ui.comboBox_animationList->setEnabled(canEditViewpoints);
+	m_ui.toolButton_newViewpointAnimConfig->setEnabled(canEditViewpoints);
+	m_ui.toolButton_editViewpointAnimConfig->setEnabled(canEditViewpoints && hasSelection);
+	m_ui.interpolateCheckBox->setEnabled(canEditViewpoints);
+
+	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+	const bool usesPositionAsTime = selectedConfig && selectedConfig->getMode() == ViewPointAnimationMode::PositionAsTime;
+	m_ui.lengthSpinBox->setEnabled(m_isProjectLoaded && (!viewpointsMode || !usesPositionAsTime));
 }
 
 void ToolBarAnimationGroup::slotStartAnimation()
 {
-	if (!m_isProjectLoaded || !m_canStartAnimation)
+	if (!m_isProjectLoaded)
 		return;
 
-	m_dataDispatcher.sendControl(new control::animation::PrepareViewpointsAnimation());
-	if (!m_canStartAnimation)
+	const bool viewpointsMode = m_ui.betweenViewpointsRadioButton->isChecked();
+	if (m_isPaused)
+	{
+		m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), true));
+		m_isStarted = true;
+		m_isPaused = false;
+		updateUI();
 		return;
+	}
 
-	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation());
+	if (viewpointsMode)
+	{
+		const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+		if (!selectedConfig)
+			return;
+
+		m_dataDispatcher.sendControl(new control::animation::PrepareViewpointsAnimation(selectedConfig->getId(), m_ui.lengthSpinBox->value()));
+		if (!m_canStartAnimation)
+			return;
+	}
+
+	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), false));
 	m_isStarted = true;
+	m_isPaused = false;
+	m_isOrbitalRunning = !viewpointsMode;
+	updateUI();
+}
+
+void ToolBarAnimationGroup::slotPauseAnimation()
+{
+	if (!m_isStarted)
+		return;
+
+	m_dataDispatcher.updateInformation(new GuiDataRenderPauseAnimation());
+	m_isStarted = false;
+	m_isPaused = true;
 	updateUI();
 }
 
 void ToolBarAnimationGroup::slotStopAnimation()
 {
-	if (!m_isStarted)
+	if (!m_isStarted && !m_isPaused)
 		return;
 
 	m_dataDispatcher.updateInformation(new GuiDataRenderStopAnimation());
 	m_isStarted = false;
+	m_isPaused = false;
+	m_isOrbitalRunning = false;
 	refreshAnimationAvailability();
 	updateUI();
 }
@@ -153,6 +202,8 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 void ToolBarAnimationGroup::slotAnimationModeChanged()
 {
 	m_ui.interpolateCheckBox->setEnabled(m_ui.betweenViewpointsRadioButton->isChecked());
+	if (!m_ui.betweenViewpointsRadioButton->isChecked())
+		m_isPaused = false;
 	updateUI();
 }
 
@@ -197,6 +248,7 @@ void ToolBarAnimationGroup::slotEditViewPointAnimationConfig()
 void ToolBarAnimationGroup::slotAnimationConfigChanged(int index)
 {
 	(void)index;
+	m_dataDispatcher.sendControl(new control::animation::RefreshViewpointsAnimationState());
 	updateUI();
 }
 
@@ -225,4 +277,20 @@ void ToolBarAnimationGroup::onAnimationData(IGuiData* keyValue)
 	m_ui.comboBox_animationList->blockSignals(false);
 
 	updateUI();
+}
+
+const ViewPointAnimationConfig* ToolBarAnimationGroup::getSelectedAnimationConfig() const
+{
+	const int index = m_ui.comboBox_animationList->currentIndex();
+	if (index < 0)
+		return nullptr;
+
+	const xg::Guid selectedId(m_ui.comboBox_animationList->itemData(index).toString().toStdString());
+	for (const ViewPointAnimationConfig& cfg : m_animationConfigs)
+	{
+		if (cfg.getId() == selectedId)
+			return &cfg;
+	}
+
+	return nullptr;
 }

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -120,6 +120,7 @@ VulkanViewport::VulkanViewport(IDataDispatcher& dataDispatcher, float guiScale)
     registerGuiDataFunction(guiDType::renderAnimationSpeed, &VulkanViewport::onRenderAnimationSpeed);
     registerGuiDataFunction(guiDType::renderAnimationLoop, &VulkanViewport::onRenderAnimationLoop);
     registerGuiDataFunction(guiDType::renderStartAnimation, &VulkanViewport::onRenderStartAnimation);
+    registerGuiDataFunction(guiDType::renderPauseAnimation, &VulkanViewport::onRenderPauseAnimation);
     registerGuiDataFunction(guiDType::renderStopAnimation, &VulkanViewport::onRenderStopAnimation);
     registerGuiDataFunction(guiDType::renderCleanAnimationList, &VulkanViewport::onRenderCleanAnimationList);
     registerGuiDataFunction(guiDType::userOrientation, &VulkanViewport::onUserOrientation);
@@ -179,10 +180,51 @@ void VulkanViewport::onRenderAnimationLoop(IGuiData* data)
 
 void VulkanViewport::onRenderStartAnimation(IGuiData* data)
 {
+    auto startData = static_cast<GuiDataRenderStartAnimation*>(data);
     WritePtr<CameraNode> wCam = m_cam.get();
     if (!wCam)
         return;
-    wCam->startAnimation(m_saveImagesAnim);
+
+    if (startData->m_isOrbital)
+    {
+        if (startData->m_resume && m_isOrbitalAnimationActive && m_isOrbitalAnimationPaused)
+        {
+            m_orbitalElapsedSeconds += std::chrono::duration<double>(m_orbitalPauseTime - m_orbitalStartTime).count();
+            m_orbitalStartTime = std::chrono::steady_clock::now();
+            m_isOrbitalAnimationPaused = false;
+            return;
+        }
+
+        m_isOrbitalAnimationActive = true;
+        m_isOrbitalAnimationPaused = false;
+        m_orbitalDurationSeconds = std::max(0.001, startData->m_durationSeconds);
+        m_orbitalElapsedSeconds = 0.0;
+        m_orbitalStartTime = std::chrono::steady_clock::now();
+        m_orbitalUsesExamine = wCam->isExamineActive();
+        return;
+    }
+
+    if (startData->m_resume)
+        wCam->resumeAnimation();
+    else
+        wCam->startAnimation(m_saveImagesAnim);
+}
+
+void VulkanViewport::onRenderPauseAnimation(IGuiData* data)
+{
+    (void)data;
+    WritePtr<CameraNode> wCam = m_cam.get();
+    if (!wCam)
+        return;
+
+    if (m_isOrbitalAnimationActive && !m_isOrbitalAnimationPaused)
+    {
+        m_isOrbitalAnimationPaused = true;
+        m_orbitalPauseTime = std::chrono::steady_clock::now();
+        return;
+    }
+
+    wCam->pauseAnimation();
 }
 
 void VulkanViewport::onRenderStopAnimation(IGuiData* data)
@@ -190,6 +232,10 @@ void VulkanViewport::onRenderStopAnimation(IGuiData* data)
     WritePtr<CameraNode> wCam = m_cam.get();
     if (!wCam)
         return;
+
+    m_isOrbitalAnimationActive = false;
+    m_isOrbitalAnimationPaused = false;
+    m_orbitalElapsedSeconds = 0.0;
     wCam->endAnimation();
 }
 
@@ -301,10 +347,35 @@ void VulkanViewport::updateInputs(WritePtr<CameraNode>& wCam, SafePtr<Manipulato
     // Update automatic animation already running
     wCam->updateAnimation();
 
+    if (m_isOrbitalAnimationActive && !m_isOrbitalAnimationPaused)
+    {
+        const double elapsed = m_orbitalElapsedSeconds + std::chrono::duration<double>(std::chrono::steady_clock::now() - m_orbitalStartTime).count();
+        const double clampedElapsed = std::min(elapsed, m_orbitalDurationSeconds);
+        const double targetAngle = 2.0 * M_PI * (clampedElapsed / m_orbitalDurationSeconds);
+        const double previousAngle = 2.0 * M_PI * (m_orbitalElapsedSeconds / m_orbitalDurationSeconds);
+        const double deltaAngle = targetAngle - previousAngle;
+
+        if (deltaAngle > 0.0)
+        {
+            if (m_orbitalUsesExamine)
+                wCam->moveAroundExamine(0.0, deltaAngle, 0.0);
+            else
+                wCam->yaw(deltaAngle);
+            m_orbitalElapsedSeconds = clampedElapsed;
+        }
+
+        if (clampedElapsed >= m_orbitalDurationSeconds)
+        {
+            m_isOrbitalAnimationActive = false;
+            m_isOrbitalAnimationPaused = false;
+            m_dataDispatcher.updateInformation(new GuiDataRenderStopAnimation());
+        }
+    }
+
     updateProjNaviMode(wCam); // here or after ?
 
     // Skip inputs when in animation mode
-    if (!wCam->isAnimated())
+    if (!wCam->isAnimated() && !m_isOrbitalAnimationActive)
     {
         updateMouseInputEffect(wCam, manipNode);
         applyMouseInput(wCam, manipNode);

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -318,6 +318,9 @@ bool CameraNode::updateAnimation()
 {
     if (!m_isAnimated)
         return false;
+    if (m_isAnimationPaused)
+        return true;
+
     switch (m_animMode)
     {
     case AnimationMode::Simple:
@@ -688,6 +691,7 @@ bool CameraNode::endAnimation()
 {
     const bool wasAnimated = m_isAnimated;
     m_isAnimated = false;
+    m_isAnimationPaused = false;
     m_animMode = AnimationMode::Simple;
     m_animation.clear();
     m_pendingComplexAnimationStart = false;
@@ -696,7 +700,36 @@ bool CameraNode::endAnimation()
     m_orientationTrajectory.clear();
     m_currentKeyPoint = 0;
     m_animFrames = 0;
+    m_totalPausedDurationSeconds = 0.0;
     return wasAnimated;
+}
+
+bool CameraNode::pauseAnimation()
+{
+    if (!m_isAnimated || m_isAnimationPaused)
+        return false;
+
+    m_isAnimationPaused = true;
+    m_pauseTrajectoryTime = std::chrono::steady_clock::now();
+    return true;
+}
+
+bool CameraNode::resumeAnimation()
+{
+    if (!m_isAnimated || !m_isAnimationPaused)
+        return false;
+
+    const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    m_totalPausedDurationSeconds += std::chrono::duration<double>(now - m_pauseTrajectoryTime).count();
+    m_isAnimationPaused = false;
+    return true;
+}
+
+void CameraNode::setAnimationTiming(ViewPointAnimationMode mode, double durationSeconds, const std::vector<double>& controlPointTimesSec)
+{
+    m_viewPointAnimationMode = mode;
+    m_animationDurationSeconds = std::max(0.0, durationSeconds);
+    m_controlPointTimesSeconds = controlPointTimesSec;
 }
 
 void CameraNode::cleanAnimation()
@@ -709,6 +742,8 @@ void CameraNode::cleanAnimation()
     m_orientationTrajectory.clear();
     m_currentKeyPoint = 0;
     m_animFrames = 0;
+    m_isAnimationPaused = false;
+    m_totalPausedDurationSeconds = 0.0;
 }
 
 void CameraNode::setSpeed(const int& speed)
@@ -1262,6 +1297,8 @@ void CameraNode::startPlayTrajectory(const uint64_t& animationStep)
 {
     m_currentKeyPoint = 1;
     m_initialAnimationPlaylist = m_animationPlaylist;
+    m_isAnimationPaused = false;
+    m_totalPausedDurationSeconds = 0.0;
     if (m_trajectory.size() < 2)
         return;
 
@@ -1281,7 +1318,10 @@ bool CameraNode::animateComplexTrajectory()
     if (m_isOfflineRendering)
         dtime = (dtime += m_speed) / m_offlineAnimStep;
     else
-        dtime = std::chrono::duration<double, std::ratio<1>>(std::chrono::steady_clock::now() - m_startTrajectoryTime).count() * m_speed;
+    {
+        const double elapsedSeconds = std::chrono::duration<double, std::ratio<1>>(std::chrono::steady_clock::now() - m_startTrajectoryTime).count() - m_totalPausedDurationSeconds;
+        dtime = std::max(0.0, elapsedSeconds) * ((m_speed > 0.0) ? m_speed : 1.0);
+    }
 
     if (m_currentKeyPoint >= m_trajectory.size())
         return true;
@@ -1378,16 +1418,7 @@ void CameraNode::buildComplexAnimationPlaybackPath()
 
 void CameraNode::buildLinearPlaybackPathFromTrajectory()
 {
-    const double speedMps = (m_speed > 0.0) ? m_speed : 3.0;
-    m_trajectory[0].dtime_arrival = 0.0;
-    m_orientationTrajectory[0].dtime_arrival = 0.0;
-    for (size_t i = 1; i < m_trajectory.size(); ++i)
-    {
-        const double distance = glm::distance(m_trajectory[i - 1].point, m_trajectory[i].point);
-        const double dt = std::max(distance / speedMps, 0.001);
-        m_trajectory[i].dtime_arrival = m_trajectory[i - 1].dtime_arrival + dt;
-        m_orientationTrajectory[i].dtime_arrival = m_trajectory[i].dtime_arrival;
-    }
+    applyPlaybackTimingFromControlPoints();
 }
 
 void CameraNode::buildCatmullRomPlaybackPathFromTrajectory()
@@ -1465,19 +1496,95 @@ void CameraNode::buildCatmullRomPlaybackPathFromTrajectory()
         return;
     }
 
-    const double speedMps = (m_speed > 0.0) ? m_speed : 3.0;
-    sampledTrajectory[0].dtime_arrival = 0.0;
-    sampledOrientationTrajectory[0].dtime_arrival = 0.0;
-    for (size_t i = 1; i < sampledTrajectory.size(); ++i)
-    {
-        const double distance = glm::distance(sampledTrajectory[i - 1].point, sampledTrajectory[i].point);
-        const double dt = std::max(distance / speedMps, 0.001);
-        sampledTrajectory[i].dtime_arrival = sampledTrajectory[i - 1].dtime_arrival + dt;
-        sampledOrientationTrajectory[i].dtime_arrival = sampledTrajectory[i].dtime_arrival;
-    }
-
     m_trajectory = std::move(sampledTrajectory);
     m_orientationTrajectory = std::move(sampledOrientationTrajectory);
+    applyPlaybackTimingFromControlPoints();
+}
+
+double CameraNode::smoothstep01(double t)
+{
+    const double clamped = std::clamp(t, 0.0, 1.0);
+    return clamped * clamped * (3.0 - 2.0 * clamped);
+}
+
+void CameraNode::applyPlaybackTimingFromControlPoints()
+{
+    if (m_trajectory.size() < 2 || m_orientationTrajectory.size() != m_trajectory.size())
+        return;
+
+    std::vector<double> cumulativeDistances(m_trajectory.size(), 0.0);
+    for (size_t i = 1; i < m_trajectory.size(); ++i)
+        cumulativeDistances[i] = cumulativeDistances[i - 1] + glm::distance(m_trajectory[i - 1].point, m_trajectory[i].point);
+
+    const double totalDistance = cumulativeDistances.back();
+    const double targetDuration = std::max(m_animationDurationSeconds, 0.001);
+
+    if (m_viewPointAnimationMode == ViewPointAnimationMode::ConstantSpeed || m_controlPointTimesSeconds.size() < 2)
+    {
+        m_trajectory[0].dtime_arrival = 0.0;
+        for (size_t i = 1; i < m_trajectory.size(); ++i)
+        {
+            const double alpha = (totalDistance > 1e-9) ? cumulativeDistances[i] / totalDistance : static_cast<double>(i) / static_cast<double>(m_trajectory.size() - 1);
+            m_trajectory[i].dtime_arrival = targetDuration * alpha;
+        }
+    }
+    else
+    {
+        const double firstTime = m_controlPointTimesSeconds.front();
+        std::vector<double> controlTimes = m_controlPointTimesSeconds;
+        for (double& t : controlTimes)
+            t -= firstTime;
+
+        if (m_viewPointAnimationMode == ViewPointAnimationMode::ConstantIntervals)
+        {
+            controlTimes.resize(m_controlPointTimesSeconds.size());
+            const size_t last = controlTimes.size() - 1;
+            for (size_t i = 0; i <= last; ++i)
+                controlTimes[i] = targetDuration * static_cast<double>(i) / static_cast<double>(last);
+        }
+
+        const size_t segmentCount = controlTimes.size() - 1;
+        std::vector<size_t> segmentStartIndices(segmentCount, 0);
+        std::vector<size_t> segmentEndIndices(segmentCount, 0);
+
+        size_t cursor = 0;
+        for (size_t seg = 0; seg < segmentCount; ++seg)
+        {
+            segmentStartIndices[seg] = cursor;
+            const double segmentTarget = static_cast<double>(seg + 1) / static_cast<double>(segmentCount);
+            while (cursor + 1 < cumulativeDistances.size())
+            {
+                const double ratio = (totalDistance > 1e-9) ? cumulativeDistances[cursor + 1] / totalDistance : static_cast<double>(cursor + 1) / static_cast<double>(cumulativeDistances.size() - 1);
+                if (ratio >= segmentTarget)
+                    break;
+                ++cursor;
+            }
+            if (cursor + 1 < cumulativeDistances.size())
+                ++cursor;
+            segmentEndIndices[seg] = cursor;
+        }
+        segmentEndIndices.back() = cumulativeDistances.size() - 1;
+
+        m_trajectory[0].dtime_arrival = controlTimes[0];
+        for (size_t seg = 0; seg < segmentCount; ++seg)
+        {
+            const size_t startIdx = segmentStartIndices[seg];
+            const size_t maxIndex = cumulativeDistances.size() - 1;
+            const size_t endIdx = std::min(std::max(segmentEndIndices[seg], std::min(startIdx + 1, maxIndex)), maxIndex);
+            const double startDistance = cumulativeDistances[startIdx];
+            const double endDistance = cumulativeDistances[endIdx];
+            const double segmentDuration = std::max(0.001, controlTimes[seg + 1] - controlTimes[seg]);
+            for (size_t i = startIdx + 1; i <= endIdx; ++i)
+            {
+                const double segmentAlpha = (endDistance > startDistance) ? (cumulativeDistances[i] - startDistance) / (endDistance - startDistance) : static_cast<double>(i - startIdx) / static_cast<double>(endIdx - startIdx);
+                const double easedAlpha = smoothstep01(segmentAlpha);
+                m_trajectory[i].dtime_arrival = controlTimes[seg] + segmentDuration * easedAlpha;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < m_orientationTrajectory.size(); ++i)
+        m_orientationTrajectory[i].dtime_arrival = m_trajectory[i].dtime_arrival;
 }
 
 glm::dvec3 CameraNode::evaluateCentripetalCatmullRom(


### PR DESCRIPTION
### Motivation
- Provide pause/resume for camera animations and support orbital animations driven by toolbar controls. 
- Allow animation timing to be governed by viewpoint-configured control points (or constant/interval modes) and validate inconsistent time entries.

### Description
- Add new GUI/GUI-data changes: extended `GuiDataRenderStartAnimation` with `m_isOrbital`, `m_durationSeconds`, and `m_resume`, added `GuiDataRenderPauseAnimation`, and added `renderPauseAnimation` to `guiDType`.
- Toolbar: extended the animation toolbar UI and logic to add a `Pause` button, track `m_isPaused`/`m_isOrbitalRunning`, send `PrepareViewpointsAnimation` with selected animation id and length, and send `GuiDataRenderStartAnimation`/`GuiDataRenderPauseAnimation`/`GuiDataRenderStopAnimation` appropriately.
- Controller/prepare stage: `PrepareViewpointsAnimation` now accepts an animation id and length, looks up the `ViewPointAnimationConfig`, collects viewpoints in configured order, validates time consistency (emits `TEXT_CONTEXT_ANIMATION_INCONSISTENT_TIMES` on errors), and calls `CameraNode::setAnimationTiming` before queuing viewpoints.
- Camera & viewport behavior: `CameraNode` gained pause/resume support, timing state (`m_viewPointAnimationMode`, `m_animationDurationSeconds`, `m_controlPointTimesSeconds`) and logic to compute playback timing from control points via `applyPlaybackTimingFromControlPoints` (including easing with `smoothstep01`), and `animateComplexTrajectory` now accounts for paused durations; `VulkanViewport` supports orbital animation state (start/resume/pause/stop), applies orbital yaw/move-around logic over elapsed time, and updates UI state when orbital completes.

### Testing
- Built the project locally (`make` / IDE build) and confirmed the codebase compiles after the changes.
- Ran the existing automated unit/integration test suite and observed all tests related to animation and rendering pass (no regressions detected in these areas).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30eb78ba4832fb34513373583adf8)