### PR TITLE
Use ViewPointAnimation for video export, add orbital degrees and toolbar integration

### DIFF
--- a/include/gui/Dialog/DialogExportVideo.h
+++ b/include/gui/Dialog/DialogExportVideo.h
@@ -4,6 +4,7 @@
 #include "ui_DialogExportVideo.h"
 #include "gui/Dialog/ADialog.h"
 #include "io/exports/ExportParameters.hpp"
+#include "models/application/ViewPointAnimation.h"
 #include <optional>
 #include <utility>
 
@@ -20,9 +21,6 @@ public:
     void closeEvent(QCloseEvent* event);
 
 private:
-    void onViewpoint1Click();
-    void onViewpoint2Click();
-
     void onSelectOutFolder();
 	void onSelectOutFile();
 
@@ -37,16 +35,20 @@ private:
 public:
     void setAnimationMode(VideoAnimationMode mode);
     void setLength(int length);
+    void setOrbitalDegrees(int degrees);
+    void setSelectedAnimation(const viewPointAnimationId& animationId, bool hasSelection);
     void setInterpolateRenderings(bool interpolate);
 
 private:
     Ui::DialogExportVideo m_ui;
     QString m_openPath;
 
-    int m_viewpointToEdit = -1;
 	VideoExportParameters m_parameters;
 	VideoAnimationMode m_animationMode = VideoAnimationMode::BETWEENVIEWPOINTS;
 	int m_length = 30;
+	int m_orbitalDegrees = 360;
+	viewPointAnimationId m_selectedAnimationId;
+	bool m_hasSelectedAnimation = false;
 	bool m_interpolateRenderings = false;
 
     static constexpr uint64_t MAX_MP4_PIXELS = 8294400;

--- a/include/io/exports/ExportParameters.hpp
+++ b/include/io/exports/ExportParameters.hpp
@@ -5,6 +5,7 @@
 #include "io/FileUtils.h"
 #include "tls_def.h"
 #include "models/OpenScanToolsModelEssentials.h"
+#include "models/application/ViewPointAnimation.h"
 
 // NOTE - The enums are used for combo box indexes
 //  (*) They must start at 0 and the values increase "naturally".
@@ -71,6 +72,8 @@ struct VideoExportParameters
     VideoAnimationMode animMode = VideoAnimationMode::NONE;
     SafePtr<ViewPointNode> start;
     SafePtr<ViewPointNode> finish;
+    viewPointAnimationId selectedAnimationId;
+    int orbitalDegrees = 360;
     bool interpolateRenderingBetweenViewpoints = false;
     bool openFolderAfterExport = false;
 

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -24,6 +24,7 @@
 #include "utils/math/basic_define.h"
 #include <cmath>
 #include <algorithm>
+#include <limits>
 #include <filesystem>
 #include <QtCore/QProcess>
 #include <QtCore/QStringList>
@@ -42,6 +43,93 @@ QString resolveFfmpegExecutable()
         return QString::fromStdWString(candidate.wstring());
     }
     return QStringLiteral("ffmpeg");
+}
+
+struct PreparedBetweenAnimation
+{
+    std::vector<SafePtr<ViewPointNode>> viewpoints;
+    std::vector<double> controlTimes;
+    ViewPointAnimationMode mode = ViewPointAnimationMode::ConstantSpeed;
+    double durationSeconds = 0.0;
+};
+
+enum class PrepareBetweenAnimationError
+{
+    MissingAnimation,
+    InconsistentTimes,
+    NotEnoughViewpoints,
+    InvalidDuration
+};
+
+bool prepareBetweenAnimationForExport(Controller& controller, const VideoExportParameters& parameters, PreparedBetweenAnimation& prepared, PrepareBetweenAnimationError& error)
+{
+    const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().cgetViewPointAnimations();
+    auto itConfig = configs.find(parameters.selectedAnimationId);
+    if (itConfig == configs.end())
+    {
+        error = PrepareBetweenAnimationError::MissingAnimation;
+        return false;
+    }
+
+    std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> perspectiveById;
+    const std::unordered_set<SafePtr<AGraphNode>> allViewpoints = controller.getGraphManager().getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& node : allViewpoints)
+    {
+        SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(node);
+        ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+        if (!rViewpoint || rViewpoint->getProjectionMode() != ProjectionMode::Perspective)
+            continue;
+        perspectiveById.insert_or_assign(rViewpoint->getId(), viewpoint);
+    }
+
+    prepared.viewpoints.clear();
+    prepared.controlTimes.clear();
+    prepared.mode = itConfig->second.getMode();
+    prepared.viewpoints.reserve(itConfig->second.getLines().size());
+    prepared.controlTimes.reserve(itConfig->second.getLines().size());
+
+    double previousTime = -std::numeric_limits<double>::infinity();
+    for (const ViewPointAnimationLine& line : itConfig->second.getLines())
+    {
+        auto itVp = perspectiveById.find(line.viewpointId);
+        if (itVp == perspectiveById.end())
+            continue;
+
+        if (prepared.mode == ViewPointAnimationMode::PositionAsTime)
+        {
+            if (line.position <= previousTime)
+            {
+                error = PrepareBetweenAnimationError::InconsistentTimes;
+                return false;
+            }
+            previousTime = line.position;
+        }
+
+        prepared.viewpoints.push_back(itVp->second);
+        prepared.controlTimes.push_back(line.position);
+    }
+
+    if (prepared.viewpoints.size() < 2)
+    {
+        error = PrepareBetweenAnimationError::NotEnoughViewpoints;
+        return false;
+    }
+
+    if (prepared.mode == ViewPointAnimationMode::PositionAsTime)
+    {
+        prepared.durationSeconds = prepared.controlTimes.back();
+        if (prepared.durationSeconds <= 0.0)
+        {
+            error = PrepareBetweenAnimationError::InvalidDuration;
+            return false;
+        }
+    }
+    else
+    {
+        prepared.durationSeconds = std::max(0.001, static_cast<double>(parameters.length));
+    }
+
+    return true;
 }
 }
 
@@ -107,9 +195,6 @@ ContextState ContextExportVideoHD::feedMessage(IMessage* message, Controller& co
 
 ContextState ContextExportVideoHD::launch(Controller& controller)
 {
-    if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && m_parameters.start == m_parameters.finish)
-        return abort(controller);
-
     //Start - Move to start position
     if (m_exportState == 0)
     {
@@ -119,13 +204,46 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             return abort(controller);
 
         wCam->setProjectionMode(ProjectionMode::Perspective);
-        m_exportState = 1;
-
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
-            wCam->moveToData(m_parameters.start);
+            PreparedBetweenAnimation prepared;
+            PrepareBetweenAnimationError prepareError = PrepareBetweenAnimationError::NotEnoughViewpoints;
+            if (!prepareBetweenAnimationForExport(controller, m_parameters, prepared, prepareError))
+            {
+                if (prepareError == PrepareBetweenAnimationError::InconsistentTimes)
+                    controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_INCONSISTENT_TIMES));
+                else
+                    controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
+                return abort(controller);
+            }
+
+            wCam->cleanAnimation();
+            wCam->setLoop(false);
+            wCam->setSpeed(1);
+            wCam->setAnimationTiming(prepared.mode, prepared.durationSeconds, prepared.controlTimes);
+            for (const SafePtr<ViewPointNode>& viewpoint : prepared.viewpoints)
+                wCam->AddViewPoint(viewpoint);
+
+            ReadPtr<ViewPointNode> rStart = prepared.viewpoints.front().cget();
+            if (!rStart)
+                return abort(controller);
+
+            m_parameters.start = prepared.viewpoints.front();
+            m_parameters.finish = prepared.viewpoints.back();
+            m_parameters.length = static_cast<int>(std::lround(prepared.durationSeconds));
+            if (m_parameters.length <= 0)
+                m_parameters.length = 1;
+            m_totalFrames = std::max<long>(1, static_cast<long>(std::lround(prepared.durationSeconds * static_cast<double>(m_parameters.fps))));
+
+            if (prepared.viewpoints.size() != 2)
+                m_parameters.interpolateRenderingBetweenViewpoints = false;
+
+            wCam->moveToData(prepared.viewpoints.front());
+            m_exportState = 1;
             return m_state = ContextState::waiting_for_input;
         }
+
+        m_exportState = 1;
 
     }
 
@@ -133,10 +251,12 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
     if (m_exportState == 1)
     {
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
-        ReadPtr<CameraNode> rCam = cam.cget();
-        if (!rCam)
+        if (!cam.cget())
             return abort(controller);
-        m_totalFrames = (long)m_parameters.length * (long)m_parameters.fps;
+        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
+            m_totalFrames = std::max<long>(1, m_totalFrames);
+        else
+            m_totalFrames = std::max<long>(1, static_cast<long>(m_parameters.length) * static_cast<long>(m_parameters.fps));
         m_animFrame = 1;
         m_frameDigits = std::max<uint8_t>(1, (uint8_t)(std::log10(std::max<long>(1, m_totalFrames)) + 1));
 
@@ -145,28 +265,16 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
+            WritePtr<CameraNode> wCam = cam.get();
+            if (!wCam)
+                return abort(controller);
+            wCam->startAnimation(true, static_cast<uint64_t>(std::max(1, m_parameters.fps)));
+
             ReadPtr<ViewPointNode> rStart;
             ReadPtr<ViewPointNode> rFinish;
             multi_cget(m_parameters.start, m_parameters.finish, rStart, rFinish);
             if (!rStart || !rFinish)
                 return abort(controller);
-
-            glm::dvec3 finishLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFinish->getInverseTransformation();
-
-            double endTheta;
-            if (finishLookDir.x == 0.0 && finishLookDir.y == 0.0)   // Must we change the test to x < epsilon ?
-                endTheta = 0.;
-            else
-                endTheta = atan2(-finishLookDir.x, finishLookDir.y);
-
-            double normXY = sqrt(finishLookDir.x * finishLookDir.x + finishLookDir.y * finishLookDir.y);
-            double endPhi = atan2(-normXY, finishLookDir.z);
-
-            CameraNode::modulo2Pi(rCam->getTheta(), endTheta);
-
-            m_addPosition = (rFinish->getCenter() - rStart->getCenter()) / (double)m_totalFrames;
-            m_addTheta = (endTheta - rCam->getTheta()) / m_totalFrames;
-            m_addPhi = (endPhi - rCam->getPhi()) / m_totalFrames;
 
             if (rStart->m_blendMode == rFinish->m_blendMode &&
                 rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
@@ -196,7 +304,7 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             }
         }
         else
-            m_addTheta = 2 * M_PI / m_totalFrames;
+            m_addTheta = glm::radians(static_cast<double>(std::clamp(m_parameters.orbitalDegrees, 1, 360))) / m_totalFrames;
 
         controller.updateInfo(new GuiDataCallImage(m_parameters.hdImage, getNextFramePath()));
         m_exportState = 2;
@@ -217,9 +325,7 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
         {
             case VideoAnimationMode::BETWEENVIEWPOINTS:
             {
-                wCam->addGlobalTranslation(m_addPosition);
-                wCam->yaw(m_addTheta);
-                wCam->pitch(m_addPhi);
+                wCam->updateAnimation();
 
                 if (m_parameters.interpolateRenderingBetweenViewpoints)
                 {

--- a/src/gui/Dialog/DialogExportVideo.cpp
+++ b/src/gui/Dialog/DialogExportVideo.cpp
@@ -9,8 +9,6 @@
 #include "gui/GuiData/GuiDataIO.h"
 #include "utils/Config.h"
 
-#include "models/graph/ViewPointNode.h"
-
 #include <QtWidgets/qfiledialog.h>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QLineEdit>
@@ -45,9 +43,6 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
 
 	m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
 
-	connect(m_ui.pushButtonViewPoint1, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint1Click);
-	connect(m_ui.pushButtonViewPoint2, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint2Click);
-
     connect(m_ui.folderToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFolder);
 	connect(m_ui.fileToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFile);
 
@@ -55,7 +50,6 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
     connect(m_ui.cancelPushButton, &QPushButton::clicked, this, &DialogExportVideo::cancelGeneration);
 
     m_dataDispatcher.registerObserverOnKey(this, guiDType::projectPath);
-    m_dataDispatcher.registerObserverOnKey(this, guiDType::objectSelected);
 	this->setMinimumWidth(344 * guiScale);
 	adjustSize();
 
@@ -77,56 +71,9 @@ void DialogExportVideo::informData(IGuiData *data)
 		{
 			auto dataType = static_cast<GuiDataProjectPath*>(data);
 			m_openPath = QString::fromStdWString(dataType->m_path.wstring());
-			m_ui.lineEditViewPoint1->clear();
-			m_ui.lineEditViewPoint2->clear();
-			m_parameters.start.reset();
-			m_parameters.finish.reset();
-		}
-		break;
-		case guiDType::objectSelected:
-		{
-			if (m_viewpointToEdit != 1 && m_viewpointToEdit != 2)
-				return;
-			auto dataType = static_cast<GuiDataObjectSelected*>(data);
-			if (dataType->m_type != ElementType::ViewPoint)
-				return;
-
-			SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(dataType->m_object);
-			ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
-			if (!rViewpoint)
-				return;
-			if (rViewpoint->getProjectionMode() == ProjectionMode::Orthographic)
-			{
-				m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_ORTHO_VIEWPOINT));
-				return;
-			}
-
-			if (m_viewpointToEdit == 1)
-			{
-				m_parameters.start = viewpoint;
-				m_ui.lineEditViewPoint1->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-			else if(m_viewpointToEdit == 2)
-			{
-				m_parameters.finish = viewpoint;
-				m_ui.lineEditViewPoint2->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-
-			m_viewpointToEdit = -1;
 		}
 		break;
     }
-}
-void DialogExportVideo::onViewpoint1Click()
-{
-	m_ui.lineEditViewPoint1->clear();
-	m_viewpointToEdit = 1;
-}
-
-void DialogExportVideo::onViewpoint2Click()
-{
-	m_ui.lineEditViewPoint2->clear();
-	m_viewpointToEdit = 2;
 }
 
 void DialogExportVideo::onSelectOutFolder()
@@ -176,18 +123,15 @@ void DialogExportVideo::startGeneration()
 	m_parameters.animMode = m_animationMode;
 	if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
 	{
-		if (!m_parameters.start || !m_parameters.finish)
+		if (!m_hasSelectedAnimation || !m_selectedAnimationId.isValid())
 		{
 			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_MISSING_VIEWPOINTS));
 			return;
 		}
 
-		if (m_parameters.start == m_parameters.finish)
-		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_SAME_VIEWPOINTS));
-			return;
-		}
+		m_parameters.selectedAnimationId = m_selectedAnimationId;
 	}
+	m_parameters.orbitalDegrees = m_orbitalDegrees;
 	
     m_parameters.outputType = m_ui.mp4RadioButton->isChecked() ? VideoExportOutputType::MP4 : VideoExportOutputType::IMAGES;
     m_parameters.bitrateKbps = m_ui.bitrateSpinBox->value();
@@ -310,6 +254,17 @@ void DialogExportVideo::setAnimationMode(VideoAnimationMode mode)
 void DialogExportVideo::setLength(int length)
 {
 	m_length = length;
+}
+
+void DialogExportVideo::setOrbitalDegrees(int degrees)
+{
+	m_orbitalDegrees = degrees;
+}
+
+void DialogExportVideo::setSelectedAnimation(const viewPointAnimationId& animationId, bool hasSelection)
+{
+	m_selectedAnimationId = animationId;
+	m_hasSelectedAnimation = hasSelection;
 }
 
 void DialogExportVideo::setInterpolateRenderings(bool interpolate)

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -161,11 +161,15 @@ void ToolBarAnimationGroup::updateUI()
 	m_ui.comboBox_animationList->setEnabled(canEditViewpoints);
 	m_ui.toolButton_newViewpointAnimConfig->setEnabled(canEditViewpoints);
 	m_ui.toolButton_editViewpointAnimConfig->setEnabled(canEditViewpoints && hasSelection);
-	m_ui.interpolateCheckBox->setEnabled(canEditViewpoints);
+
+	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+	const bool hasTwoViewpoints = selectedConfig && selectedConfig->getLines().size() == 2;
+	m_ui.interpolateCheckBox->setEnabled(canEditViewpoints && hasTwoViewpoints);
+	if (!hasTwoViewpoints)
+		m_ui.interpolateCheckBox->setChecked(false);
 	m_ui.degreesLabel->setEnabled(m_isProjectLoaded && !viewpointsMode);
 	m_ui.degreesSpinBox->setEnabled(m_isProjectLoaded && !viewpointsMode);
 
-	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
 	const bool usesPositionAsTime = selectedConfig && selectedConfig->getMode() == ViewPointAnimationMode::PositionAsTime;
 	m_ui.lengthSpinBox->setEnabled(m_isProjectLoaded && (!viewpointsMode || !usesPositionAsTime));
 }
@@ -260,13 +264,17 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 
 	m_dialog->setAnimationMode(m_ui.betweenViewpointsRadioButton->isChecked() ? VideoAnimationMode::BETWEENVIEWPOINTS : VideoAnimationMode::ORBITAL);
 	m_dialog->setLength(m_ui.lengthSpinBox->value());
+	m_dialog->setOrbitalDegrees(m_ui.degreesSpinBox->value());
+	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+	m_dialog->setSelectedAnimation(selectedConfig ? selectedConfig->getId() : viewPointAnimationId(), selectedConfig != nullptr);
 	m_dialog->setInterpolateRenderings(m_ui.interpolateCheckBox->isChecked());
 	m_dialog->show();
 }
 
 void ToolBarAnimationGroup::slotAnimationModeChanged()
 {
-	m_ui.interpolateCheckBox->setEnabled(m_ui.betweenViewpointsRadioButton->isChecked());
+	if (!m_ui.betweenViewpointsRadioButton->isChecked())
+		m_ui.interpolateCheckBox->setChecked(false);
 	if (!m_ui.betweenViewpointsRadioButton->isChecked())
 		m_isPaused = false;
 	updateUI();


### PR DESCRIPTION
### Motivation
- Enable exporting videos based on saved viewpoint animations instead of manual viewpoint picking and add control over orbital rotation degrees.
- Simplify the export dialog by removing direct viewpoint selection and use the selected animation configured in the toolbar.
- Handle different animation timing modes robustly and ensure correct frame count/duration when exporting between viewpoints.

### Description
- Added `viewPointAnimationId` and `orbitalDegrees` into `VideoExportParameters` and included `models/application/ViewPointAnimation.h` to relevant headers to carry animation selection and orbital settings.
- Implemented `prepareBetweenAnimationForExport` and related data structures in `ContextExportVideoHD` to validate a `ViewPointAnimationConfig`, gather perspective viewpoints, compute control times/duration, and configure the `CameraNode` animation before export, with explicit error reporting via `GuiDataWarning` messages.
- Updated animation export flow to use prepared animation (calling `CameraNode::startAnimation`/`CameraNode::updateAnimation`), set `m_totalFrames` from prepared duration for BETWEENVIEWPOINTS, and compute orbital per-frame rotation using the new `orbitalDegrees` parameter.
- Modified `DialogExportVideo` to remove manual viewpoint selection, expose `setSelectedAnimation` and `setOrbitalDegrees` APIs, and populate `VideoExportParameters.selectedAnimationId`/`orbitalDegrees` in `startGeneration`; updated `ToolBarAnimationGroup` to pass the selected animation and degrees and to enable `interpolate` only for two-viewpoint animations.

### Testing
- Built the project (`cmake`/`make`) with the changes and the codebase compiled successfully.
- Ran the repository's automated tests and existing integration tests; all tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b462d0b8fc832faf641d6efac7d5c1)