### PR TITLE
Export video: add ViewPointAnimation support and orbital degrees option

### DIFF
--- a/include/controller/functionSystem/ContextExportVideoHD.h
+++ b/include/controller/functionSystem/ContextExportVideoHD.h
@@ -4,6 +4,7 @@
 #include "controller/functionSystem/AContext.h"
 #include "io/exports/ExportParameters.hpp"
 #include "pointCloudEngine/RenderingTypes.h"
+#include "models/application/ViewPointAnimation.h"
 #include <optional>
 
 class ContextExportVideoHD : public AContext
@@ -53,6 +54,10 @@ private:
 	float m_addAlpha = 0.f;
 
 	double m_addFovy = 0.;
+	bool m_usePreparedViewpointAnimation = false;
+	ViewPointAnimationMode m_preparedAnimationMode = ViewPointAnimationMode::ConstantSpeed;
+	std::vector<SafePtr<ViewPointNode>> m_preparedAnimationViewpoints;
+	std::vector<double> m_preparedControlTimes;
 
 	std::chrono::steady_clock::time_point m_tpStart;
 	DecimationOptions m_precedentOptions;

--- a/include/gui/Dialog/DialogExportVideo.h
+++ b/include/gui/Dialog/DialogExportVideo.h
@@ -4,6 +4,7 @@
 #include "ui_DialogExportVideo.h"
 #include "gui/Dialog/ADialog.h"
 #include "io/exports/ExportParameters.hpp"
+#include "models/application/ViewPointAnimation.h"
 #include <optional>
 #include <utility>
 
@@ -20,9 +21,6 @@ public:
     void closeEvent(QCloseEvent* event);
 
 private:
-    void onViewpoint1Click();
-    void onViewpoint2Click();
-
     void onSelectOutFolder();
 	void onSelectOutFile();
 
@@ -38,15 +36,20 @@ public:
     void setAnimationMode(VideoAnimationMode mode);
     void setLength(int length);
     void setInterpolateRenderings(bool interpolate);
+    void setOrbitalDegrees(int degrees);
+    void setSelectedAnimation(const viewPointAnimationId& animationId, ViewPointAnimationMode animationMode, size_t viewpointCount);
 
 private:
     Ui::DialogExportVideo m_ui;
     QString m_openPath;
 
-    int m_viewpointToEdit = -1;
 	VideoExportParameters m_parameters;
 	VideoAnimationMode m_animationMode = VideoAnimationMode::BETWEENVIEWPOINTS;
+	viewPointAnimationId m_selectedAnimationId;
+	ViewPointAnimationMode m_selectedAnimationMode = ViewPointAnimationMode::ConstantSpeed;
+	size_t m_selectedAnimationViewpointCount = 0;
 	int m_length = 30;
+	int m_orbitalDegrees = 360;
 	bool m_interpolateRenderings = false;
 
     static constexpr uint64_t MAX_MP4_PIXELS = 8294400;

--- a/include/io/exports/ExportParameters.hpp
+++ b/include/io/exports/ExportParameters.hpp
@@ -5,6 +5,7 @@
 #include "io/FileUtils.h"
 #include "tls_def.h"
 #include "models/OpenScanToolsModelEssentials.h"
+#include "models/application/ViewPointAnimation.h"
 
 // NOTE - The enums are used for combo box indexes
 //  (*) They must start at 0 and the values increase "naturally".
@@ -71,6 +72,9 @@ struct VideoExportParameters
     VideoAnimationMode animMode = VideoAnimationMode::NONE;
     SafePtr<ViewPointNode> start;
     SafePtr<ViewPointNode> finish;
+    viewPointAnimationId animationId;
+    ViewPointAnimationMode animationMode = ViewPointAnimationMode::ConstantSpeed;
+    int orbitalDegrees = 360;
     bool interpolateRenderingBetweenViewpoints = false;
     bool openFolderAfterExport = false;
 

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <algorithm>
 #include <filesystem>
+#include <limits>
 #include <QtCore/QProcess>
 #include <QtCore/QStringList>
 #include "utils/Config.h"
@@ -43,6 +44,24 @@ QString resolveFfmpegExecutable()
     }
     return QStringLiteral("ffmpeg");
 }
+
+std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> collectPerspectiveViewpointsById(Controller& controller)
+{
+    std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> byId;
+    const std::unordered_set<SafePtr<AGraphNode>> allViewpoints = controller.getGraphManager().getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+    byId.reserve(allViewpoints.size());
+
+    for (const SafePtr<AGraphNode>& node : allViewpoints)
+    {
+        SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(node);
+        ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+        if (!rViewpoint || rViewpoint->getProjectionMode() != ProjectionMode::Perspective)
+            continue;
+        byId.insert_or_assign(rViewpoint->getId(), viewpoint);
+    }
+
+    return byId;
+}
 }
 
 ContextExportVideoHD::ContextExportVideoHD(const ContextId& id)
@@ -60,6 +79,10 @@ ContextState ContextExportVideoHD::start(Controller& controller)
     DecimationOptions noDecimation = m_precedentOptions;
     noDecimation.mode = DecimationMode::None;
     controller.updateInfo(new GuiDataRenderDecimationOptions(noDecimation));
+    m_exportState = 0;
+    m_usePreparedViewpointAnimation = false;
+    m_preparedAnimationViewpoints.clear();
+    m_preparedControlTimes.clear();
     return m_state = ContextState::waiting_for_input;
 }
 
@@ -107,9 +130,6 @@ ContextState ContextExportVideoHD::feedMessage(IMessage* message, Controller& co
 
 ContextState ContextExportVideoHD::launch(Controller& controller)
 {
-    if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && m_parameters.start == m_parameters.finish)
-        return abort(controller);
-
     //Start - Move to start position
     if (m_exportState == 0)
     {
@@ -123,8 +143,59 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
-            wCam->moveToData(m_parameters.start);
-            return m_state = ContextState::waiting_for_input;
+            m_usePreparedViewpointAnimation = true;
+            m_preparedAnimationMode = m_parameters.animationMode;
+            m_preparedAnimationViewpoints.clear();
+            m_preparedControlTimes.clear();
+
+            const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().cgetViewPointAnimations();
+            auto itConfig = configs.find(m_parameters.animationId);
+            if (itConfig == configs.end())
+                return abort(controller);
+
+            m_preparedAnimationMode = itConfig->second.getMode();
+
+            std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> perspectiveById = collectPerspectiveViewpointsById(controller);
+            double previousTime = -std::numeric_limits<double>::infinity();
+            for (const ViewPointAnimationLine& line : itConfig->second.getLines())
+            {
+                auto itVp = perspectiveById.find(line.viewpointId);
+                if (itVp == perspectiveById.end())
+                    continue;
+
+                if (m_preparedAnimationMode == ViewPointAnimationMode::PositionAsTime)
+                {
+                    if (line.position <= previousTime)
+                        return abort(controller);
+                    previousTime = line.position;
+                }
+
+                m_preparedAnimationViewpoints.push_back(itVp->second);
+                m_preparedControlTimes.push_back(line.position);
+            }
+
+            if (m_preparedAnimationViewpoints.size() < 2)
+                return abort(controller);
+
+            wCam->cleanAnimation();
+            wCam->setLoop(false);
+            wCam->setSpeed(1);
+
+            const double firstTime = m_preparedControlTimes.empty() ? 0.0 : m_preparedControlTimes.front();
+            for (double& time : m_preparedControlTimes)
+                time -= firstTime;
+
+            double durationSeconds = static_cast<double>(m_parameters.length);
+            if (m_preparedAnimationMode == ViewPointAnimationMode::PositionAsTime && !m_preparedControlTimes.empty())
+                durationSeconds = std::max(0.0, m_preparedControlTimes.back());
+
+            wCam->setAnimationTiming(m_preparedAnimationMode, durationSeconds, m_preparedControlTimes);
+            for (const SafePtr<ViewPointNode>& viewpoint : m_preparedAnimationViewpoints)
+                wCam->AddViewPoint(viewpoint);
+
+            wCam->moveToData(m_preparedAnimationViewpoints.front());
+            if (!wCam->startAnimation(true, static_cast<uint64_t>(std::max(1, m_parameters.fps))))
+                return abort(controller);
         }
 
     }
@@ -133,10 +204,14 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
     if (m_exportState == 1)
     {
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
-        ReadPtr<CameraNode> rCam = cam.cget();
-        if (!rCam)
+        if (!cam.cget())
             return abort(controller);
-        m_totalFrames = (long)m_parameters.length * (long)m_parameters.fps;
+        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && m_preparedAnimationMode == ViewPointAnimationMode::PositionAsTime && !m_preparedControlTimes.empty())
+            m_totalFrames = static_cast<long>(std::ceil(std::max(0.0, m_preparedControlTimes.back()) * static_cast<double>(m_parameters.fps)));
+        else
+            m_totalFrames = (long)m_parameters.length * (long)m_parameters.fps;
+        if (m_totalFrames <= 0)
+            return abort(controller);
         m_animFrame = 1;
         m_frameDigits = std::max<uint8_t>(1, (uint8_t)(std::log10(std::max<long>(1, m_totalFrames)) + 1));
 
@@ -145,58 +220,43 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
-            ReadPtr<ViewPointNode> rStart;
-            ReadPtr<ViewPointNode> rFinish;
-            multi_cget(m_parameters.start, m_parameters.finish, rStart, rFinish);
-            if (!rStart || !rFinish)
-                return abort(controller);
-
-            glm::dvec3 finishLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFinish->getInverseTransformation();
-
-            double endTheta;
-            if (finishLookDir.x == 0.0 && finishLookDir.y == 0.0)   // Must we change the test to x < epsilon ?
-                endTheta = 0.;
-            else
-                endTheta = atan2(-finishLookDir.x, finishLookDir.y);
-
-            double normXY = sqrt(finishLookDir.x * finishLookDir.x + finishLookDir.y * finishLookDir.y);
-            double endPhi = atan2(-normXY, finishLookDir.z);
-
-            CameraNode::modulo2Pi(rCam->getTheta(), endTheta);
-
-            m_addPosition = (rFinish->getCenter() - rStart->getCenter()) / (double)m_totalFrames;
-            m_addTheta = (endTheta - rCam->getTheta()) / m_totalFrames;
-            m_addPhi = (endPhi - rCam->getPhi()) / m_totalFrames;
-
-            if (rStart->m_blendMode == rFinish->m_blendMode &&
-                rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
-                rStart->m_postRenderingNormals.blendColor == rFinish->m_postRenderingNormals.blendColor &&
-                rStart->m_postRenderingNormals.inverseTone == rFinish->m_postRenderingNormals.inverseTone &&
-                rStart->m_mode == rFinish->m_mode &&
-                rStart->m_negativeEffect == rFinish->m_negativeEffect &&
-                rStart->m_reduceFlash == rFinish->m_reduceFlash &&
-                rStart->m_flashAdvanced == rFinish->m_flashAdvanced &&
-                rStart->m_flashControl == rFinish->m_flashControl
-                )
+            if (m_parameters.interpolateRenderingBetweenViewpoints && m_preparedAnimationViewpoints.size() == 2)
             {
-                m_addTransp = (rFinish->m_transparency - rStart->m_transparency) / m_totalFrames;
+                ReadPtr<ViewPointNode> rStart;
+                ReadPtr<ViewPointNode> rFinish;
+                multi_cget(m_preparedAnimationViewpoints.front(), m_preparedAnimationViewpoints.back(), rStart, rFinish);
+                if (!rStart || !rFinish)
+                    return abort(controller);
 
-                m_addNStren = (rFinish->m_postRenderingNormals.normalStrength - rStart->m_postRenderingNormals.normalStrength) / m_totalFrames;
-                m_addNGloss = (rFinish->m_postRenderingNormals.gloss - rStart->m_postRenderingNormals.gloss) / m_totalFrames;
+                if (rStart->m_blendMode == rFinish->m_blendMode &&
+                    rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
+                    rStart->m_postRenderingNormals.blendColor == rFinish->m_postRenderingNormals.blendColor &&
+                    rStart->m_postRenderingNormals.inverseTone == rFinish->m_postRenderingNormals.inverseTone &&
+                    rStart->m_mode == rFinish->m_mode &&
+                    rStart->m_negativeEffect == rFinish->m_negativeEffect &&
+                    rStart->m_reduceFlash == rFinish->m_reduceFlash &&
+                    rStart->m_flashAdvanced == rFinish->m_flashAdvanced &&
+                    rStart->m_flashControl == rFinish->m_flashControl)
+                {
+                    m_addTransp = (rFinish->m_transparency - rStart->m_transparency) / m_totalFrames;
 
-                m_addHue = (rFinish->m_hue - rStart->m_hue) / m_totalFrames;
+                    m_addNStren = (rFinish->m_postRenderingNormals.normalStrength - rStart->m_postRenderingNormals.normalStrength) / m_totalFrames;
+                    m_addNGloss = (rFinish->m_postRenderingNormals.gloss - rStart->m_postRenderingNormals.gloss) / m_totalFrames;
 
-                m_addBright = (rFinish->m_brightness - rStart->m_brightness) / m_totalFrames;
-                m_addSatur = (rFinish->m_saturation - rStart->m_saturation) / m_totalFrames;
-                m_addLumi = (rFinish->m_luminance - rStart->m_luminance) / m_totalFrames;
-                m_addContr = (rFinish->m_contrast - rStart->m_contrast) / m_totalFrames;
-                m_addAlpha = (rFinish->m_alphaObject - rStart->m_alphaObject) / m_totalFrames;
+                    m_addHue = (rFinish->m_hue - rStart->m_hue) / m_totalFrames;
 
-                m_addFovy = (rFinish->getFovy() - rStart->getFovy()) / m_totalFrames;
+                    m_addBright = (rFinish->m_brightness - rStart->m_brightness) / m_totalFrames;
+                    m_addSatur = (rFinish->m_saturation - rStart->m_saturation) / m_totalFrames;
+                    m_addLumi = (rFinish->m_luminance - rStart->m_luminance) / m_totalFrames;
+                    m_addContr = (rFinish->m_contrast - rStart->m_contrast) / m_totalFrames;
+                    m_addAlpha = (rFinish->m_alphaObject - rStart->m_alphaObject) / m_totalFrames;
+
+                    m_addFovy = (rFinish->getFovy() - rStart->getFovy()) / m_totalFrames;
+                }
             }
         }
         else
-            m_addTheta = 2 * M_PI / m_totalFrames;
+            m_addTheta = glm::radians(static_cast<double>(m_parameters.orbitalDegrees)) / m_totalFrames;
 
         controller.updateInfo(new GuiDataCallImage(m_parameters.hdImage, getNextFramePath()));
         m_exportState = 2;
@@ -217,9 +277,7 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
         {
             case VideoAnimationMode::BETWEENVIEWPOINTS:
             {
-                wCam->addGlobalTranslation(m_addPosition);
-                wCam->yaw(m_addTheta);
-                wCam->pitch(m_addPhi);
+                wCam->animateComplexTrajectory();
 
                 if (m_parameters.interpolateRenderingBetweenViewpoints)
                 {
@@ -270,6 +328,10 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
 ContextState ContextExportVideoHD::abort(Controller& controller)
 {
+    WritePtr<CameraNode> wCam = controller.getGraphManager().getCameraNode().get();
+    if (wCam)
+        wCam->endAnimation();
+
     controller.updateInfo(new GuiDataRenderDecimationOptions(m_precedentOptions));
 
     encodeVideo();
@@ -285,6 +347,10 @@ ContextState ContextExportVideoHD::abort(Controller& controller)
 
 ContextState ContextExportVideoHD::validate(Controller& controller)
 {
+    WritePtr<CameraNode> wCam = controller.getGraphManager().getCameraNode().get();
+    if (wCam)
+        wCam->endAnimation();
+
     controller.updateInfo(new GuiDataRenderDecimationOptions(m_precedentOptions));
 
     std::chrono::steady_clock::time_point tpEnd = std::chrono::steady_clock::now();

--- a/src/gui/Dialog/DialogExportVideo.cpp
+++ b/src/gui/Dialog/DialogExportVideo.cpp
@@ -7,9 +7,8 @@
 #include "gui/GuiData/GuiDataGeneralProject.h"
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/GuiData/GuiDataIO.h"
+#include "gui/texts/ContextTexts.hpp"
 #include "utils/Config.h"
-
-#include "models/graph/ViewPointNode.h"
 
 #include <QtWidgets/qfiledialog.h>
 #include <QtWidgets/QApplication>
@@ -45,9 +44,6 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
 
 	m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
 
-	connect(m_ui.pushButtonViewPoint1, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint1Click);
-	connect(m_ui.pushButtonViewPoint2, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint2Click);
-
     connect(m_ui.folderToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFolder);
 	connect(m_ui.fileToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFile);
 
@@ -55,7 +51,6 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
     connect(m_ui.cancelPushButton, &QPushButton::clicked, this, &DialogExportVideo::cancelGeneration);
 
     m_dataDispatcher.registerObserverOnKey(this, guiDType::projectPath);
-    m_dataDispatcher.registerObserverOnKey(this, guiDType::objectSelected);
 	this->setMinimumWidth(344 * guiScale);
 	adjustSize();
 
@@ -77,56 +72,9 @@ void DialogExportVideo::informData(IGuiData *data)
 		{
 			auto dataType = static_cast<GuiDataProjectPath*>(data);
 			m_openPath = QString::fromStdWString(dataType->m_path.wstring());
-			m_ui.lineEditViewPoint1->clear();
-			m_ui.lineEditViewPoint2->clear();
-			m_parameters.start.reset();
-			m_parameters.finish.reset();
-		}
-		break;
-		case guiDType::objectSelected:
-		{
-			if (m_viewpointToEdit != 1 && m_viewpointToEdit != 2)
-				return;
-			auto dataType = static_cast<GuiDataObjectSelected*>(data);
-			if (dataType->m_type != ElementType::ViewPoint)
-				return;
-
-			SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(dataType->m_object);
-			ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
-			if (!rViewpoint)
-				return;
-			if (rViewpoint->getProjectionMode() == ProjectionMode::Orthographic)
-			{
-				m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_ORTHO_VIEWPOINT));
-				return;
-			}
-
-			if (m_viewpointToEdit == 1)
-			{
-				m_parameters.start = viewpoint;
-				m_ui.lineEditViewPoint1->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-			else if(m_viewpointToEdit == 2)
-			{
-				m_parameters.finish = viewpoint;
-				m_ui.lineEditViewPoint2->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-
-			m_viewpointToEdit = -1;
 		}
 		break;
     }
-}
-void DialogExportVideo::onViewpoint1Click()
-{
-	m_ui.lineEditViewPoint1->clear();
-	m_viewpointToEdit = 1;
-}
-
-void DialogExportVideo::onViewpoint2Click()
-{
-	m_ui.lineEditViewPoint2->clear();
-	m_viewpointToEdit = 2;
 }
 
 void DialogExportVideo::onSelectOutFolder()
@@ -176,15 +124,9 @@ void DialogExportVideo::startGeneration()
 	m_parameters.animMode = m_animationMode;
 	if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
 	{
-		if (!m_parameters.start || !m_parameters.finish)
+		if (!m_selectedAnimationId.isValid() || m_selectedAnimationViewpointCount < 2)
 		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_MISSING_VIEWPOINTS));
-			return;
-		}
-
-		if (m_parameters.start == m_parameters.finish)
-		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_SAME_VIEWPOINTS));
+			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
 			return;
 		}
 	}
@@ -220,7 +162,10 @@ void DialogExportVideo::startGeneration()
 	m_parameters.fps = m_ui.fpsSpinBox->value();
 	m_parameters.hdImage = m_ui.imageHDRadioButton->isChecked();
 	m_parameters.openFolderAfterExport = m_ui.openExplorerFolderCheckBox->isChecked();
-	m_parameters.interpolateRenderingBetweenViewpoints = m_interpolateRenderings;
+	m_parameters.interpolateRenderingBetweenViewpoints = (m_interpolateRenderings && m_selectedAnimationViewpointCount == 2);
+	m_parameters.animationId = m_selectedAnimationId;
+	m_parameters.animationMode = m_selectedAnimationMode;
+	m_parameters.orbitalDegrees = m_orbitalDegrees;
 
 	m_dataDispatcher.sendControl(new control::io::GenerateVideoHD(exportBasePath, m_parameters));
 
@@ -315,4 +260,16 @@ void DialogExportVideo::setLength(int length)
 void DialogExportVideo::setInterpolateRenderings(bool interpolate)
 {
 	m_interpolateRenderings = interpolate;
+}
+
+void DialogExportVideo::setOrbitalDegrees(int degrees)
+{
+	m_orbitalDegrees = degrees;
+}
+
+void DialogExportVideo::setSelectedAnimation(const viewPointAnimationId& animationId, ViewPointAnimationMode animationMode, size_t viewpointCount)
+{
+	m_selectedAnimationId = animationId;
+	m_selectedAnimationMode = animationMode;
+	m_selectedAnimationViewpointCount = viewpointCount;
 }

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -261,6 +261,13 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 	m_dialog->setAnimationMode(m_ui.betweenViewpointsRadioButton->isChecked() ? VideoAnimationMode::BETWEENVIEWPOINTS : VideoAnimationMode::ORBITAL);
 	m_dialog->setLength(m_ui.lengthSpinBox->value());
 	m_dialog->setInterpolateRenderings(m_ui.interpolateCheckBox->isChecked());
+	m_dialog->setOrbitalDegrees(m_ui.degreesSpinBox->value());
+
+	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+	if (selectedConfig)
+		m_dialog->setSelectedAnimation(selectedConfig->getId(), selectedConfig->getMode(), selectedConfig->getLines().size());
+	else
+		m_dialog->setSelectedAnimation(viewPointAnimationId(), ViewPointAnimationMode::ConstantSpeed, 0);
 	m_dialog->show();
 }
 


### PR DESCRIPTION
### Motivation
- Enable exporting HD videos from saved viewpoint animations and allow orbital degree customization for orbital exports.
- Remove ad-hoc manual viewpoint selection in the export dialog and rely on configured animations to drive BETWEENVIEWPOINTS exports.

### Description
- Added support for viewpoint animations in `ContextExportVideoHD` by collecting perspective viewpoints, preparing animation control times, configuring camera animation (`setAnimationTiming`, `AddViewPoint`, `startAnimation`) and using `animateComplexTrajectory`; also compute `m_totalFrames` from `PositionAsTime` timings and stop animations cleanly (`endAnimation`).
- Extended `VideoExportParameters` with `animationId`, `animationMode`, and `orbitalDegrees`, and wired these through the GUI by updating `DialogExportVideo` to send the selected animation, mode and degrees; removed manual viewpoint selection UI and related handlers.
- Adjusted interpolation logic so rendering interpolation is applied only when exactly two viewpoints are used, and replaced fixed 360-degree orbital step with configurable `orbitalDegrees` converted to radians per frame.
- Updated `ToolBarAnimationGroup` to pass `orbitalDegrees` and the selected `ViewPointAnimationConfig` info into the export dialog, and added helper `collectPerspectiveViewpointsById` in the context implementation.

### Testing
- Project build completed successfully after the changes (debug and release configurations).
- Ran the existing automated unit test suite and CI checks; all tests and checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4873503e8832f8dfeab9bbd4e70c3)