### PR TITLE
Support viewpoint animation selection and deterministic offline camera animation for HD video export

### DIFF
--- a/include/controller/functionSystem/ContextExportVideoHD.h
+++ b/include/controller/functionSystem/ContextExportVideoHD.h
@@ -4,6 +4,7 @@
 #include "controller/functionSystem/AContext.h"
 #include "io/exports/ExportParameters.hpp"
 #include "pointCloudEngine/RenderingTypes.h"
+#include "models/application/ViewPointAnimation.h"
 #include <optional>
 
 class ContextExportVideoHD : public AContext
@@ -25,9 +26,18 @@ public:
 	virtual ContextType getType() const override;
 
 private:
+	struct PreparedAnimation
+	{
+		std::vector<SafePtr<ViewPointNode>> viewpoints;
+		ViewPointAnimationMode mode = ViewPointAnimationMode::ConstantSpeed;
+		std::vector<double> controlTimes;
+		double durationSeconds = 0.0;
+	};
+
 	bool encodeVideo();
 	std::optional<std::filesystem::path> firstFrameFilepath() const;
 	void cleanupFrames();
+	std::optional<PreparedAnimation> prepareViewpointAnimation(Controller& controller) const;
 
 	VideoExportParameters m_parameters;
 	std::filesystem::path m_exportPath;
@@ -53,6 +63,8 @@ private:
 	float m_addAlpha = 0.f;
 
 	double m_addFovy = 0.;
+	bool m_usePreparedCameraAnimation = false;
+	PreparedAnimation m_preparedAnimation;
 
 	std::chrono::steady_clock::time_point m_tpStart;
 	DecimationOptions m_precedentOptions;

--- a/include/gui/Dialog/DialogExportVideo.h
+++ b/include/gui/Dialog/DialogExportVideo.h
@@ -4,6 +4,7 @@
 #include "ui_DialogExportVideo.h"
 #include "gui/Dialog/ADialog.h"
 #include "io/exports/ExportParameters.hpp"
+#include "models/application/ViewPointAnimation.h"
 #include <optional>
 #include <utility>
 
@@ -38,6 +39,8 @@ public:
     void setAnimationMode(VideoAnimationMode mode);
     void setLength(int length);
     void setInterpolateRenderings(bool interpolate);
+    void setOrbitalDegrees(int degrees);
+    void setAnimationSelection(const viewPointAnimationId& animationId);
 
 private:
     Ui::DialogExportVideo m_ui;
@@ -47,6 +50,8 @@ private:
 	VideoExportParameters m_parameters;
 	VideoAnimationMode m_animationMode = VideoAnimationMode::BETWEENVIEWPOINTS;
 	int m_length = 30;
+	int m_orbitalDegrees = 360;
+	viewPointAnimationId m_animationId;
 	bool m_interpolateRenderings = false;
 
     static constexpr uint64_t MAX_MP4_PIXELS = 8294400;

--- a/include/io/exports/ExportParameters.hpp
+++ b/include/io/exports/ExportParameters.hpp
@@ -5,6 +5,7 @@
 #include "io/FileUtils.h"
 #include "tls_def.h"
 #include "models/OpenScanToolsModelEssentials.h"
+#include "models/application/ViewPointAnimation.h"
 
 // NOTE - The enums are used for combo box indexes
 //  (*) They must start at 0 and the values increase "naturally".
@@ -69,6 +70,8 @@ struct VideoExportParameters
     int bitrateKbps = 5000;
     std::filesystem::path outputFilePath;
     VideoAnimationMode animMode = VideoAnimationMode::NONE;
+    viewPointAnimationId animationId;
+    int orbitalDegrees = 360;
     SafePtr<ViewPointNode> start;
     SafePtr<ViewPointNode> finish;
     bool interpolateRenderingBetweenViewpoints = false;

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -78,6 +78,7 @@ public:
 
     bool updateAnimation();
     bool isAnimated() const;
+    bool isOfflineRenderingAnimation() const;
 
     glm::dvec3 getViewAxis() const; // or front axis ?
     void adjustToScene(const BoundingBoxD& sceneBBox);

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -24,6 +24,7 @@
 #include "utils/math/basic_define.h"
 #include <cmath>
 #include <algorithm>
+#include <limits>
 #include <filesystem>
 #include <QtCore/QProcess>
 #include <QtCore/QStringList>
@@ -60,6 +61,8 @@ ContextState ContextExportVideoHD::start(Controller& controller)
     DecimationOptions noDecimation = m_precedentOptions;
     noDecimation.mode = DecimationMode::None;
     controller.updateInfo(new GuiDataRenderDecimationOptions(noDecimation));
+    m_usePreparedCameraAnimation = false;
+    m_preparedAnimation = PreparedAnimation();
     return m_state = ContextState::waiting_for_input;
 }
 
@@ -107,12 +110,39 @@ ContextState ContextExportVideoHD::feedMessage(IMessage* message, Controller& co
 
 ContextState ContextExportVideoHD::launch(Controller& controller)
 {
-    if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && m_parameters.start == m_parameters.finish)
+    if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && !m_parameters.animationId.isValid() && m_parameters.start == m_parameters.finish)
         return abort(controller);
 
     //Start - Move to start position
     if (m_exportState == 0)
     {
+        m_usePreparedCameraAnimation = false;
+        std::optional<PreparedAnimation> preparedAnimation;
+        glm::dvec3 firstCenter(0.0);
+        double firstTheta = 0.0;
+        double firstPhi = 0.0;
+
+        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
+        {
+            preparedAnimation = prepareViewpointAnimation(controller);
+            if (!preparedAnimation.has_value())
+            {
+                controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
+                return abort(controller);
+            }
+
+            ReadPtr<ViewPointNode> rFirstViewpoint = preparedAnimation->viewpoints.front().cget();
+            if (!rFirstViewpoint)
+                return abort(controller);
+
+            const glm::dvec3 firstLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFirstViewpoint->getInverseTransformation();
+            if (!(firstLookDir.x == 0.0 && firstLookDir.y == 0.0))
+                firstTheta = atan2(-firstLookDir.x, firstLookDir.y);
+            const double firstNormXY = sqrt(firstLookDir.x * firstLookDir.x + firstLookDir.y * firstLookDir.y);
+            firstPhi = atan2(-firstNormXY, firstLookDir.z);
+            firstCenter = rFirstViewpoint->getCenter();
+        }
+
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
         WritePtr<CameraNode> wCam = cam.get();
         if (!wCam)
@@ -121,10 +151,23 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
         wCam->setProjectionMode(ProjectionMode::Perspective);
         m_exportState = 1;
 
-        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
+        if (preparedAnimation.has_value())
         {
-            wCam->moveToData(m_parameters.start);
-            return m_state = ContextState::waiting_for_input;
+            m_preparedAnimation = preparedAnimation.value();
+            m_usePreparedCameraAnimation = true;
+
+            wCam->cleanAnimation();
+            wCam->setLoop(false);
+            wCam->setSpeed(1);
+            wCam->setAnimationTiming(m_preparedAnimation.mode, m_preparedAnimation.durationSeconds, m_preparedAnimation.controlTimes);
+            for (const SafePtr<ViewPointNode>& viewpoint : m_preparedAnimation.viewpoints)
+                wCam->AddViewPoint(viewpoint);
+
+            // Force a synchronous jump to the first viewpoint before frame generation.
+            // Relying on moveToData() + asynchronous ANIMATIONEND can stall the export state machine.
+            const glm::dvec3 deltaToFirst = firstCenter - wCam->getCenter();
+            wCam->moveGlobal(deltaToFirst.x, deltaToFirst.y, deltaToFirst.z);
+            wCam->setThetaAndPhi(firstTheta, firstPhi);
         }
 
     }
@@ -133,10 +176,13 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
     if (m_exportState == 1)
     {
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
-        ReadPtr<CameraNode> rCam = cam.cget();
-        if (!rCam)
+        WritePtr<CameraNode> wCam = cam.get();
+        if (!wCam)
             return abort(controller);
-        m_totalFrames = (long)m_parameters.length * (long)m_parameters.fps;
+        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && m_usePreparedCameraAnimation)
+            m_totalFrames = std::max<long>(1, static_cast<long>(std::llround(m_preparedAnimation.durationSeconds * static_cast<double>(m_parameters.fps))));
+        else
+            m_totalFrames = (long)m_parameters.length * (long)m_parameters.fps;
         m_animFrame = 1;
         m_frameDigits = std::max<uint8_t>(1, (uint8_t)(std::log10(std::max<long>(1, m_totalFrames)) + 1));
 
@@ -145,58 +191,95 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
-            ReadPtr<ViewPointNode> rStart;
-            ReadPtr<ViewPointNode> rFinish;
-            multi_cget(m_parameters.start, m_parameters.finish, rStart, rFinish);
-            if (!rStart || !rFinish)
-                return abort(controller);
-
-            glm::dvec3 finishLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFinish->getInverseTransformation();
-
-            double endTheta;
-            if (finishLookDir.x == 0.0 && finishLookDir.y == 0.0)   // Must we change the test to x < epsilon ?
-                endTheta = 0.;
-            else
-                endTheta = atan2(-finishLookDir.x, finishLookDir.y);
-
-            double normXY = sqrt(finishLookDir.x * finishLookDir.x + finishLookDir.y * finishLookDir.y);
-            double endPhi = atan2(-normXY, finishLookDir.z);
-
-            CameraNode::modulo2Pi(rCam->getTheta(), endTheta);
-
-            m_addPosition = (rFinish->getCenter() - rStart->getCenter()) / (double)m_totalFrames;
-            m_addTheta = (endTheta - rCam->getTheta()) / m_totalFrames;
-            m_addPhi = (endPhi - rCam->getPhi()) / m_totalFrames;
-
-            if (rStart->m_blendMode == rFinish->m_blendMode &&
-                rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
-                rStart->m_postRenderingNormals.blendColor == rFinish->m_postRenderingNormals.blendColor &&
-                rStart->m_postRenderingNormals.inverseTone == rFinish->m_postRenderingNormals.inverseTone &&
-                rStart->m_mode == rFinish->m_mode &&
-                rStart->m_negativeEffect == rFinish->m_negativeEffect &&
-                rStart->m_reduceFlash == rFinish->m_reduceFlash &&
-                rStart->m_flashAdvanced == rFinish->m_flashAdvanced &&
-                rStart->m_flashControl == rFinish->m_flashControl
-                )
+            if (!m_usePreparedCameraAnimation)
             {
-                m_addTransp = (rFinish->m_transparency - rStart->m_transparency) / m_totalFrames;
+                ReadPtr<ViewPointNode> rStart;
+                ReadPtr<ViewPointNode> rFinish;
+                multi_cget(m_parameters.start, m_parameters.finish, rStart, rFinish);
+                if (!rStart || !rFinish)
+                    return abort(controller);
 
-                m_addNStren = (rFinish->m_postRenderingNormals.normalStrength - rStart->m_postRenderingNormals.normalStrength) / m_totalFrames;
-                m_addNGloss = (rFinish->m_postRenderingNormals.gloss - rStart->m_postRenderingNormals.gloss) / m_totalFrames;
+                glm::dvec3 finishLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFinish->getInverseTransformation();
 
-                m_addHue = (rFinish->m_hue - rStart->m_hue) / m_totalFrames;
+                double endTheta;
+                if (finishLookDir.x == 0.0 && finishLookDir.y == 0.0)
+                    endTheta = 0.;
+                else
+                    endTheta = atan2(-finishLookDir.x, finishLookDir.y);
 
-                m_addBright = (rFinish->m_brightness - rStart->m_brightness) / m_totalFrames;
-                m_addSatur = (rFinish->m_saturation - rStart->m_saturation) / m_totalFrames;
-                m_addLumi = (rFinish->m_luminance - rStart->m_luminance) / m_totalFrames;
-                m_addContr = (rFinish->m_contrast - rStart->m_contrast) / m_totalFrames;
-                m_addAlpha = (rFinish->m_alphaObject - rStart->m_alphaObject) / m_totalFrames;
+                double normXY = sqrt(finishLookDir.x * finishLookDir.x + finishLookDir.y * finishLookDir.y);
+                double endPhi = atan2(-normXY, finishLookDir.z);
 
-                m_addFovy = (rFinish->getFovy() - rStart->getFovy()) / m_totalFrames;
+                CameraNode::modulo2Pi(wCam->getTheta(), endTheta);
+
+                m_addPosition = (rFinish->getCenter() - rStart->getCenter()) / (double)m_totalFrames;
+                m_addTheta = (endTheta - wCam->getTheta()) / m_totalFrames;
+                m_addPhi = (endPhi - wCam->getPhi()) / m_totalFrames;
+
+                if (rStart->m_blendMode == rFinish->m_blendMode &&
+                    rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
+                    rStart->m_postRenderingNormals.blendColor == rFinish->m_postRenderingNormals.blendColor &&
+                    rStart->m_postRenderingNormals.inverseTone == rFinish->m_postRenderingNormals.inverseTone &&
+                    rStart->m_mode == rFinish->m_mode &&
+                    rStart->m_negativeEffect == rFinish->m_negativeEffect &&
+                    rStart->m_reduceFlash == rFinish->m_reduceFlash &&
+                    rStart->m_flashAdvanced == rFinish->m_flashAdvanced &&
+                    rStart->m_flashControl == rFinish->m_flashControl
+                    )
+                {
+                    m_addTransp = (rFinish->m_transparency - rStart->m_transparency) / m_totalFrames;
+
+                    m_addNStren = (rFinish->m_postRenderingNormals.normalStrength - rStart->m_postRenderingNormals.normalStrength) / m_totalFrames;
+                    m_addNGloss = (rFinish->m_postRenderingNormals.gloss - rStart->m_postRenderingNormals.gloss) / m_totalFrames;
+
+                    m_addHue = (rFinish->m_hue - rStart->m_hue) / m_totalFrames;
+
+                    m_addBright = (rFinish->m_brightness - rStart->m_brightness) / m_totalFrames;
+                    m_addSatur = (rFinish->m_saturation - rStart->m_saturation) / m_totalFrames;
+                    m_addLumi = (rFinish->m_luminance - rStart->m_luminance) / m_totalFrames;
+                    m_addContr = (rFinish->m_contrast - rStart->m_contrast) / m_totalFrames;
+                    m_addAlpha = (rFinish->m_alphaObject - rStart->m_alphaObject) / m_totalFrames;
+
+                    m_addFovy = (rFinish->getFovy() - rStart->getFovy()) / m_totalFrames;
+                }
+            }
+            else
+            {
+                if (!wCam->startAnimation(true, static_cast<uint64_t>(std::max(1, m_parameters.fps))))
+                    return abort(controller);
+
+                if (m_preparedAnimation.viewpoints.size() == 2 && m_parameters.interpolateRenderingBetweenViewpoints)
+                {
+                    ReadPtr<ViewPointNode> rStart;
+                    ReadPtr<ViewPointNode> rFinish;
+                    multi_cget(m_preparedAnimation.viewpoints.front(), m_preparedAnimation.viewpoints.back(), rStart, rFinish);
+                    if (rStart && rFinish &&
+                        rStart->m_blendMode == rFinish->m_blendMode &&
+                        rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
+                        rStart->m_postRenderingNormals.blendColor == rFinish->m_postRenderingNormals.blendColor &&
+                        rStart->m_postRenderingNormals.inverseTone == rFinish->m_postRenderingNormals.inverseTone &&
+                        rStart->m_mode == rFinish->m_mode &&
+                        rStart->m_negativeEffect == rFinish->m_negativeEffect &&
+                        rStart->m_reduceFlash == rFinish->m_reduceFlash &&
+                        rStart->m_flashAdvanced == rFinish->m_flashAdvanced &&
+                        rStart->m_flashControl == rFinish->m_flashControl)
+                    {
+                        m_addTransp = (rFinish->m_transparency - rStart->m_transparency) / m_totalFrames;
+                        m_addNStren = (rFinish->m_postRenderingNormals.normalStrength - rStart->m_postRenderingNormals.normalStrength) / m_totalFrames;
+                        m_addNGloss = (rFinish->m_postRenderingNormals.gloss - rStart->m_postRenderingNormals.gloss) / m_totalFrames;
+                        m_addHue = (rFinish->m_hue - rStart->m_hue) / m_totalFrames;
+                        m_addBright = (rFinish->m_brightness - rStart->m_brightness) / m_totalFrames;
+                        m_addSatur = (rFinish->m_saturation - rStart->m_saturation) / m_totalFrames;
+                        m_addLumi = (rFinish->m_luminance - rStart->m_luminance) / m_totalFrames;
+                        m_addContr = (rFinish->m_contrast - rStart->m_contrast) / m_totalFrames;
+                        m_addAlpha = (rFinish->m_alphaObject - rStart->m_alphaObject) / m_totalFrames;
+                        m_addFovy = (rFinish->getFovy() - rStart->getFovy()) / m_totalFrames;
+                    }
+                }
             }
         }
         else
-            m_addTheta = 2 * M_PI / m_totalFrames;
+            m_addTheta = glm::radians(static_cast<double>(std::clamp(m_parameters.orbitalDegrees, 1, 360))) / m_totalFrames;
 
         controller.updateInfo(new GuiDataCallImage(m_parameters.hdImage, getNextFramePath()));
         m_exportState = 2;
@@ -217,11 +300,16 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
         {
             case VideoAnimationMode::BETWEENVIEWPOINTS:
             {
-                wCam->addGlobalTranslation(m_addPosition);
-                wCam->yaw(m_addTheta);
-                wCam->pitch(m_addPhi);
+                if (m_usePreparedCameraAnimation)
+                    wCam->updateAnimation();
+                else
+                {
+                    wCam->addGlobalTranslation(m_addPosition);
+                    wCam->yaw(m_addTheta);
+                    wCam->pitch(m_addPhi);
+                }
 
-                if (m_parameters.interpolateRenderingBetweenViewpoints)
+                if (m_parameters.interpolateRenderingBetweenViewpoints && (!m_usePreparedCameraAnimation || m_preparedAnimation.viewpoints.size() == 2))
                 {
                     wCam->m_transparency += m_addTransp;                    
                     wCam->m_postRenderingNormals.normalStrength += m_addNStren;
@@ -252,6 +340,14 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
     if (m_exportState == 3)
     {
+        if (m_usePreparedCameraAnimation)
+        {
+            SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
+            WritePtr<CameraNode> wCam = cam.get();
+            if (wCam && wCam->isAnimated())
+                wCam->endAnimation();
+        }
+
         if (!encodeVideo())
             return abort(controller);
 
@@ -270,6 +366,14 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
 ContextState ContextExportVideoHD::abort(Controller& controller)
 {
+    if (m_usePreparedCameraAnimation)
+    {
+        SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
+        WritePtr<CameraNode> wCam = cam.get();
+        if (wCam && wCam->isAnimated())
+            wCam->endAnimation();
+    }
+
     controller.updateInfo(new GuiDataRenderDecimationOptions(m_precedentOptions));
 
     encodeVideo();
@@ -285,6 +389,14 @@ ContextState ContextExportVideoHD::abort(Controller& controller)
 
 ContextState ContextExportVideoHD::validate(Controller& controller)
 {
+    if (m_usePreparedCameraAnimation)
+    {
+        SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
+        WritePtr<CameraNode> wCam = cam.get();
+        if (wCam && wCam->isAnimated())
+            wCam->endAnimation();
+    }
+
     controller.updateInfo(new GuiDataRenderDecimationOptions(m_precedentOptions));
 
     std::chrono::steady_clock::time_point tpEnd = std::chrono::steady_clock::now();
@@ -430,4 +542,59 @@ std::filesystem::path ContextExportVideoHD::getNextFramePath()
 ContextType ContextExportVideoHD::getType() const
 {
 	return ContextType::exportVideoHD;
+}
+
+std::optional<ContextExportVideoHD::PreparedAnimation> ContextExportVideoHD::prepareViewpointAnimation(Controller& controller) const
+{
+    if (!m_parameters.animationId.isValid())
+        return std::nullopt;
+
+    const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().cgetViewPointAnimations();
+    auto itConfig = configs.find(m_parameters.animationId);
+    if (itConfig == configs.end())
+        return std::nullopt;
+
+    std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> perspectiveById;
+    const std::unordered_set<SafePtr<AGraphNode>> allViewpoints = controller.getGraphManager().getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& node : allViewpoints)
+    {
+        SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(node);
+        ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+        if (!rViewpoint || rViewpoint->getProjectionMode() == ProjectionMode::Orthographic)
+            continue;
+        perspectiveById.insert_or_assign(rViewpoint->getId(), viewpoint);
+    }
+
+    PreparedAnimation prepared;
+    prepared.mode = itConfig->second.getMode();
+
+    double previousTime = -std::numeric_limits<double>::infinity();
+    for (const ViewPointAnimationLine& line : itConfig->second.getLines())
+    {
+        auto itVp = perspectiveById.find(line.viewpointId);
+        if (itVp == perspectiveById.end())
+            continue;
+
+        prepared.viewpoints.push_back(itVp->second);
+        prepared.controlTimes.push_back(line.position);
+        if (prepared.mode == ViewPointAnimationMode::PositionAsTime)
+        {
+            if (line.position <= previousTime)
+                return std::nullopt;
+            previousTime = line.position;
+        }
+    }
+
+    if (prepared.viewpoints.size() < 2)
+        return std::nullopt;
+
+    if (prepared.mode == ViewPointAnimationMode::PositionAsTime)
+        prepared.durationSeconds = std::max(0.0, prepared.controlTimes.back() - prepared.controlTimes.front());
+    else
+        prepared.durationSeconds = std::max(0.0, static_cast<double>(m_parameters.length));
+
+    if (prepared.durationSeconds <= 0.0)
+        prepared.durationSeconds = std::max(1.0 / std::max(1, m_parameters.fps), 0.001);
+
+    return prepared;
 }

--- a/src/gui/Dialog/DialogExportVideo.cpp
+++ b/src/gui/Dialog/DialogExportVideo.cpp
@@ -176,15 +176,9 @@ void DialogExportVideo::startGeneration()
 	m_parameters.animMode = m_animationMode;
 	if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
 	{
-		if (!m_parameters.start || !m_parameters.finish)
+		if (!m_animationId.isValid())
 		{
 			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_MISSING_VIEWPOINTS));
-			return;
-		}
-
-		if (m_parameters.start == m_parameters.finish)
-		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_SAME_VIEWPOINTS));
 			return;
 		}
 	}
@@ -217,6 +211,8 @@ void DialogExportVideo::startGeneration()
     }
 
 	m_parameters.length = m_length;
+	m_parameters.animationId = m_animationId;
+	m_parameters.orbitalDegrees = m_orbitalDegrees;
 	m_parameters.fps = m_ui.fpsSpinBox->value();
 	m_parameters.hdImage = m_ui.imageHDRadioButton->isChecked();
 	m_parameters.openFolderAfterExport = m_ui.openExplorerFolderCheckBox->isChecked();
@@ -312,7 +308,17 @@ void DialogExportVideo::setLength(int length)
 	m_length = length;
 }
 
+void DialogExportVideo::setOrbitalDegrees(int degrees)
+{
+	m_orbitalDegrees = degrees;
+}
+
 void DialogExportVideo::setInterpolateRenderings(bool interpolate)
 {
 	m_interpolateRenderings = interpolate;
+}
+
+void DialogExportVideo::setAnimationSelection(const viewPointAnimationId& animationId)
+{
+	m_animationId = animationId;
 }

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -260,7 +260,11 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 
 	m_dialog->setAnimationMode(m_ui.betweenViewpointsRadioButton->isChecked() ? VideoAnimationMode::BETWEENVIEWPOINTS : VideoAnimationMode::ORBITAL);
 	m_dialog->setLength(m_ui.lengthSpinBox->value());
+	m_dialog->setOrbitalDegrees(m_ui.degreesSpinBox->value());
 	m_dialog->setInterpolateRenderings(m_ui.interpolateCheckBox->isChecked());
+
+	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+	m_dialog->setAnimationSelection(selectedConfig ? selectedConfig->getId() : viewPointAnimationId());
 	m_dialog->show();
 }
 

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -348,8 +348,11 @@ void VulkanViewport::updateInputs(WritePtr<CameraNode>& wCam, SafePtr<Manipulato
     // Reset the selection rectangle
     m_selectionRect = { {-1, -1}, {-1, -1} };
 
-    // Update automatic animation already running
-    wCam->updateAnimation();
+    // Update automatic animation already running.
+    // Offline export animations are explicitly advanced by ContextExportVideoHD
+    // once per exported frame to keep deterministic camera progression.
+    if (!(wCam->isAnimated() && wCam->isOfflineRenderingAnimation()))
+        wCam->updateAnimation();
 
     if (m_isOrbitalAnimationActive && !m_isOrbitalAnimationPaused)
     {

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -335,6 +335,11 @@ bool CameraNode::updateAnimation()
     return true;
 }
 
+bool CameraNode::isOfflineRenderingAnimation() const
+{
+    return m_isOfflineRendering;
+}
+
 glm::dvec3 CameraNode::getViewAxis() const
 {
     return (glm::mat3_cast(m_quaternion) * glm::dvec3(0, 0, 1));
@@ -1316,9 +1321,15 @@ void CameraNode::startPlayTrajectory(const uint64_t& animationStep)
 bool CameraNode::animateComplexTrajectory()
 {
     // Get time elapsed since the start of the trajectory
-    double dtime((double)m_animFrames);
+    double dtime(0.0);
     if (m_isOfflineRendering)
-        dtime = (dtime += m_speed) / m_offlineAnimStep;
+    {
+        // Offline playback must advance deterministically on each generated frame.
+        // Without incrementing m_animFrames, dtime stays nearly constant and the
+        // camera remains stuck near the first sampled pose.
+        ++m_animFrames;
+        dtime = (static_cast<double>(m_animFrames) * std::max(m_speed, 1.0)) / m_offlineAnimStep;
+    }
     else
     {
         const double elapsedSeconds = std::chrono::duration<double, std::ratio<1>>(std::chrono::steady_clock::now() - m_startTrajectoryTime).count() - m_totalPausedDurationSeconds;
@@ -1356,6 +1367,23 @@ bool CameraNode::animateComplexTrajectory()
     }
     else if (m_currentKeyPoint + 1 < m_trajectory.size())
     {
+        // During offline export, camera progression must be deterministic frame-by-frame.
+        // Avoid recursive catch-up here: it can skip many keypoints in one exported frame
+        // when timing samples are dense, which produces apparent jumps to the end pose.
+        if (m_isOfflineRendering)
+        {
+            m_currentKeyPoint++;
+            const KeyPoint& kPt = m_trajectory[m_currentKeyPoint];
+            m_center = kPt.point;
+
+            if (m_orientationTrajectory.size() == m_trajectory.size())
+                m_quaternion = glm::normalize(m_orientationTrajectory[m_currentKeyPoint].orientation);
+            else
+                setThetaAndPhi(kPt.theta, kPt.phi);
+
+            return true;
+        }
+
         m_currentKeyPoint++;
         return animateComplexTrajectory();
     }
@@ -1584,6 +1612,22 @@ void CameraNode::applyPlaybackTimingFromControlPoints()
             }
         }
     }
+
+    // Ensure strictly monotonic timing for sampled trajectory points.
+    // Some segment repartitions can leave plateaus (or near-plateaus) in dtime_arrival,
+    // which makes offline stepping skip many points in one update and can snap to the end.
+    m_trajectory[0].dtime_arrival = std::max(0.0, m_trajectory[0].dtime_arrival);
+    const double minStep = targetDuration / std::max<size_t>(m_trajectory.size() - 1, 1);
+    for (size_t i = 1; i < m_trajectory.size(); ++i)
+    {
+        m_trajectory[i].dtime_arrival = std::max(m_trajectory[i].dtime_arrival, m_trajectory[i - 1].dtime_arrival + minStep);
+    }
+    m_trajectory.back().dtime_arrival = targetDuration;
+    for (size_t i = m_trajectory.size() - 1; i > 0; --i)
+    {
+        m_trajectory[i - 1].dtime_arrival = std::min(m_trajectory[i - 1].dtime_arrival, m_trajectory[i].dtime_arrival - minStep);
+    }
+    m_trajectory[0].dtime_arrival = 0.0;
 
     for (size_t i = 0; i < m_orientationTrajectory.size(); ++i)
         m_orientationTrajectory[i].dtime_arrival = m_trajectory[i].dtime_arrival;


### PR DESCRIPTION
### Motivation
- Enable exporting HD videos that follow saved viewpoint animations and allow orbital-degree control while ensuring deterministic, frame-by-frame camera progression during offline export.

### Description
- Added `PreparedAnimation` and related members to `ContextExportVideoHD` and implemented `prepareViewpointAnimation()` to resolve animation configs into usable viewpoint playlists. 
- Made `VideoExportParameters` carry `animationId` and `orbitalDegrees`, updated dialog (`DialogExportVideo`) and toolbar (`ToolBarAnimationGroup`) to set those values, and wired the export control to use the selected animation.
- Updated export flow in `ContextExportVideoHD::launch`/`abort`/`validate` to optionally start an offline camera animation, synchronously jump to the first pose, advance the camera per exported frame, and ensure proper cleanup with `endAnimation` on abort/validate.
- Implemented offline-deterministic animation behavior in `CameraNode` by exposing `isOfflineRenderingAnimation()`, making offline playback advance `m_animFrames` per frame, avoiding recursive catch-up in `animateComplexTrajectory`, and enforcing strictly monotonic `dtime_arrival` sampling to prevent large jumps; also changed `VulkanViewport::updateInputs` to avoid auto-advancing offline export animations.

### Testing
- Verified project builds successfully with the normal build pipeline (`cmake`/`ninja` or equivalent) and the changes compile. 
- Ran the automated unit/test suite (`ctest`) and continuous-integration build checks; they completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53c71a100832f8dea509ea64f12db)