### PR TITLE
Refactor viewpoint animation playback and add one-frame input lock when starting animations

### DIFF
--- a/include/gui/viewport/VulkanViewport.h
+++ b/include/gui/viewport/VulkanViewport.h
@@ -297,6 +297,9 @@ private:
     bool m_saveImagesAnim;
     bool m_isOrbitalAnimationActive = false;
     bool m_isOrbitalAnimationPaused = false;
+    // One-frame guard to avoid applying stale user input on the same frame
+    // as a viewpoints animation start.
+    bool m_viewpointStartInputLockArmed = false;
     bool m_orbitalUsesExamine = false;
     double m_orbitalDurationSeconds = 0.0;
     double m_orbitalElapsedSeconds = 0.0;

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -46,7 +46,7 @@ enum class InterpolationValueWithPreviousAnimation { NONE, BEZIER/*, LINEAR*/ };
 class CameraNode : public AGraphNode, public IPanel, public RenderingParameters
 {
 private:
-    enum class AnimationMode { Simple, Complex/*, HorizontalExamine*/ };
+    enum class AnimationMode { Simple, Viewpoint/*, HorizontalExamine*/ };
 
 public:
     CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher);
@@ -87,7 +87,7 @@ public:
     void lookAt(double endTheta, double endPhi, double dt_sec);
     void translateTo(glm::dvec3 endPoint, double dt_sec);
 
-    //Complex animation
+    // Viewpoints animation
 
     void AddViewPoint(SafePtr<ViewPointNode> vp, const InterpolationValueWithPreviousAnimation& interpolation = InterpolationValueWithPreviousAnimation::NONE);
     void AddViewPoint1(SafePtr<ViewPointNode> vp, const InterpolationValueWithPreviousAnimation& interpolation = InterpolationValueWithPreviousAnimation::NONE);
@@ -181,11 +181,11 @@ private:
 
     void startPlayTrajectory(const uint64_t& animationStep);
     bool animateSimpleTrajectory();
-    bool animateComplexTrajectory();
-    // Build the trajectory played by complex animation:
+    bool animateViewpointTrajectory();
+    // Build the trajectory played by viewpoints animation:
     // - linear fallback for 2 viewpoints
     // - centripetal Catmull-Rom sampling for 3+ viewpoints
-    void buildComplexAnimationPlaybackPath();
+    void buildViewpointAnimationPlaybackPath();
     void buildLinearPlaybackPathFromTrajectory();
     void buildCatmullRomPlaybackPathFromTrajectory();
     void applyPlaybackTimingFromControlPoints();
@@ -322,10 +322,6 @@ private:
     double m_animationDurationSeconds = 0.0;
     std::vector<double> m_controlPointTimesSeconds;
     SimpleAnimation m_simpleAnimation = SimpleAnimation();
-    bool m_pendingComplexAnimationStart = false;
-    uint64_t m_pendingComplexAnimationStep = 1000;
-    SafePtr<ViewPointNode> m_animationStartViewpoint;
-
     // Uniform for projection and view matrix (separated)
     VkMultiUniform m_uniProjView;
     // Uniform view Matrix 

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -187,6 +187,7 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
 
     if (startData->m_isOrbital)
     {
+        m_viewpointStartInputLockArmed = false;
         if (startData->m_resume && m_isOrbitalAnimationActive && m_isOrbitalAnimationPaused)
         {
             m_orbitalStartTime = std::chrono::steady_clock::now();
@@ -206,9 +207,17 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
     }
 
     if (startData->m_resume)
+    {
+        m_viewpointStartInputLockArmed = false;
         wCam->resumeAnimation();
+    }
     else
-        wCam->startAnimation(m_saveImagesAnim);
+    {
+        const bool started = wCam->startAnimation(m_saveImagesAnim);
+        m_viewpointStartInputLockArmed = started;
+        if (started)
+            m_MI.resetDeltas();
+    }
 }
 
 void VulkanViewport::onRenderPauseAnimation(IGuiData* data)
@@ -237,6 +246,7 @@ void VulkanViewport::onRenderStopAnimation(IGuiData* data)
 
     m_isOrbitalAnimationActive = false;
     m_isOrbitalAnimationPaused = false;
+    m_viewpointStartInputLockArmed = false;
     m_orbitalElapsedSeconds = 0.0;
     m_orbitalAppliedAngle = 0.0;
     m_orbitalTotalAngleRad = 0.0;
@@ -380,8 +390,16 @@ void VulkanViewport::updateInputs(WritePtr<CameraNode>& wCam, SafePtr<Manipulato
 
     updateProjNaviMode(wCam); // here or after ?
 
+    bool skipUserInputThisFrame = false;
+    if (m_viewpointStartInputLockArmed)
+    {
+        skipUserInputThisFrame = true;
+        m_viewpointStartInputLockArmed = false;
+        m_MI.resetDeltas();
+    }
+
     // Skip inputs when in animation mode
-    if (!wCam->isAnimated() && !m_isOrbitalAnimationActive)
+    if (!skipUserInputThisFrame && !wCam->isAnimated() && !m_isOrbitalAnimationActive)
     {
         updateMouseInputEffect(wCam, manipNode);
         applyMouseInput(wCam, manipNode);

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -326,8 +326,8 @@ bool CameraNode::updateAnimation()
     case AnimationMode::Simple:
         animateSimpleTrajectory();
         break;
-    case AnimationMode::Complex:
-        animateComplexTrajectory();
+    case AnimationMode::Viewpoint:
+        animateViewpointTrajectory();
         break;
     }
 
@@ -449,6 +449,7 @@ void CameraNode::lookAt(glm::dvec3 _lookPoint, double _dt_sec)
 
     m_simpleAnimation = { { m_center, getTheta(), getPhi(), (double)std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()).time_since_epoch().count() },
                             { m_center, endTheta, endPhi, _dt_sec * 1000.0} };
+    m_animMode = AnimationMode::Simple;
     m_isAnimated = true;
 }
 
@@ -458,6 +459,7 @@ void CameraNode::lookAt(double endTheta, double endPhi, double dt_sec)
 
     m_simpleAnimation = { { m_center, getTheta(), getPhi(), (double)std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()).time_since_epoch().count() },
                             { m_center, endTheta, endPhi, dt_sec * 1000.0} };
+    m_animMode = AnimationMode::Simple;
     m_isAnimated = true;
 }
 
@@ -469,6 +471,7 @@ void CameraNode::translateTo(glm::dvec3 _endPoint, double _dt_sec)
 
     m_simpleAnimation = { { m_center, getTheta(), getPhi(), (double)std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()).time_since_epoch().count() },
                             { _endPoint, getTheta(), getPhi(), _dt_sec * 1000.0} };
+    m_animMode = AnimationMode::Simple;
     m_isAnimated = true;
 }
 
@@ -492,6 +495,7 @@ void CameraNode::moveTo(glm::dvec3 _endPoint, double _stopDist, double _dt_sec)
 
     m_simpleAnimation = { { m_center, getTheta(), getPhi(), (double)std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()).time_since_epoch().count() },
                             { stopPoint, endTheta, endPhi, _dt_sec * 1000.0} };
+    m_animMode = AnimationMode::Simple;
     m_isAnimated = true;
 }
 
@@ -515,6 +519,7 @@ void CameraNode::moveTo(glm::dvec3 _endPoint, double _dt_sec, glm::dvec3 _lookDi
 
     m_simpleAnimation = { { m_center, getTheta(), getPhi(), (double)std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()).time_since_epoch().count() },
                             { _endPoint, endTheta, endPhi, _dt_sec * 1000.0} };
+    m_animMode = AnimationMode::Simple;
     m_isAnimated = true;
 }
 
@@ -524,6 +529,7 @@ void CameraNode::moveTo(const glm::dvec3& endPoint, double endTheta, double endP
 
     m_simpleAnimation = { { m_center, getTheta(), getPhi(), (double)std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()).time_since_epoch().count() },
                             { endPoint, endTheta, endPhi, dt_sec * 1000.0} };
+    m_animMode = AnimationMode::Simple;
     m_isAnimated = true;
 }
 
@@ -540,26 +546,7 @@ bool CameraNode::animateSimpleTrajectory()
     if (progress > 1.0 || !m_simpleAnimation.end.dtime_arrival)
     {
         m_center = m_simpleAnimation.end.point;
-        if (m_pendingComplexAnimationStart)
-        {
-            ReadPtr<ViewPointNode> rVp = m_animationStartViewpoint.cget();
-            if (rVp)
-            {
-                static_cast<DisplayParameters&>(*this) = *&rVp;
-                applyProjection(*&rVp);
-                m_quaternion = rVp->getOrientation();
-                m_dataDispatcher.sendControl(new control::viewpoint::UpdateStatesFromViewpoint(m_animationStartViewpoint));
-            }
-
-            m_pendingComplexAnimationStart = false;
-            m_animationStartViewpoint.reset();
-            m_animMode = AnimationMode::Complex;
-            startPlayTrajectory(m_pendingComplexAnimationStep);
-            m_dataDispatcher.updateInformation(new GuiDataRenderAnimationPlaybackStart());
-            m_isAnimated = (m_trajectory.size() >= 2);
-            return m_isAnimated;
-        }
-        else if (!m_animation.empty())
+        if (!m_animation.empty())
         {
             //Note(Aurélien) #363 do stuff
             ReadPtr<ViewPointNode> rVp = m_animation.begin()->cget();
@@ -652,7 +639,13 @@ bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
         return false;
     }
 
-    buildComplexAnimationPlaybackPath();
+    buildViewpointAnimationPlaybackPath();
+
+    if (m_trajectory.size() < 2)
+    {
+        m_isAnimated = false;
+        return false;
+    }
 
     SafePtr<ViewPointNode> firstViewpoint = m_animationPlaylist.front();
     ReadPtr<ViewPointNode> rFirstViewpoint = firstViewpoint.cget();
@@ -662,27 +655,18 @@ bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
         return false;
     }
 
-    const glm::dvec3 startPoint = rFirstViewpoint->getCenter();
-    const glm::dvec3 startLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFirstViewpoint->getInverseTransformation();
-    const bool needMoveToFirstViewpoint = glm::distance(getCenter(), startPoint) > 0.001;
-
-    if (needMoveToFirstViewpoint)
-    {
-        m_animMode = AnimationMode::Simple;
-        m_pendingComplexAnimationStart = true;
-        m_pendingComplexAnimationStep = step;
-        m_animationStartViewpoint = firstViewpoint;
-        moveTo(startPoint, 1.0, startLookDir, glm::dvec3(0.0, 0.0, 1.0));
-        m_isAnimated = true;
-        return true;
-    }
-
     static_cast<DisplayParameters&>(*this) = *&rFirstViewpoint;
     applyProjection(*&rFirstViewpoint);
-    m_quaternion = rFirstViewpoint->getOrientation();
+
+    setPosition(m_trajectory.front().point);
+    if (m_orientationTrajectory.size() == m_trajectory.size())
+        m_quaternion = glm::normalize(m_orientationTrajectory.front().orientation);
+    else
+        setThetaAndPhi(m_trajectory.front().theta, m_trajectory.front().phi);
+
     m_dataDispatcher.sendControl(new control::viewpoint::UpdateStatesFromViewpoint(firstViewpoint));
 
-    m_animMode = AnimationMode::Complex;
+    m_animMode = AnimationMode::Viewpoint;
     startPlayTrajectory(step);
     m_dataDispatcher.updateInformation(new GuiDataRenderAnimationPlaybackStart());
     m_isAnimated = (m_trajectory.size() >= 2);
@@ -696,8 +680,6 @@ bool CameraNode::endAnimation()
     m_isAnimationPaused = false;
     m_animMode = AnimationMode::Simple;
     m_animation.clear();
-    m_pendingComplexAnimationStart = false;
-    m_animationStartViewpoint.reset();
     m_trajectory.clear();
     m_orientationTrajectory.clear();
     m_currentKeyPoint = 0;
@@ -738,8 +720,6 @@ void CameraNode::cleanAnimation()
 {
     m_animationPlaylist.clear();
     m_initialAnimationPlaylist.clear();
-    m_pendingComplexAnimationStart = false;
-    m_animationStartViewpoint.reset();
     m_trajectory.clear();
     m_orientationTrajectory.clear();
     m_currentKeyPoint = 0;
@@ -1313,7 +1293,7 @@ void CameraNode::startPlayTrajectory(const uint64_t& animationStep)
         m_startTrajectoryTime = std::chrono::steady_clock::now();
 }
 
-bool CameraNode::animateComplexTrajectory()
+bool CameraNode::animateViewpointTrajectory()
 {
     // Get time elapsed since the start of the trajectory
     double dtime((double)m_animFrames);
@@ -1333,7 +1313,20 @@ bool CameraNode::animateComplexTrajectory()
         KeyPoint kPt0 = m_trajectory[m_currentKeyPoint - 1];
         KeyPoint kPt1 = m_trajectory[m_currentKeyPoint];
 
-        double progress = (dtime - kPt0.dtime_arrival) / (kPt1.dtime_arrival - kPt0.dtime_arrival);
+        const double segmentDuration = kPt1.dtime_arrival - kPt0.dtime_arrival;
+        if (segmentDuration <= 1e-9)
+        {
+            if (m_currentKeyPoint + 1 < m_trajectory.size())
+            {
+                m_currentKeyPoint++;
+                return animateViewpointTrajectory();
+            }
+            dtime = kPt1.dtime_arrival;
+        }
+
+        const double safeSegmentDuration = std::max(kPt1.dtime_arrival - kPt0.dtime_arrival, 1e-9);
+        double progress = (dtime - kPt0.dtime_arrival) / safeSegmentDuration;
+        progress = std::clamp(progress, 0.0, 1.0);
 
         m_center = (kPt1.point * progress + kPt0.point * (1 - progress));
 
@@ -1357,7 +1350,7 @@ bool CameraNode::animateComplexTrajectory()
     else if (m_currentKeyPoint + 1 < m_trajectory.size())
     {
         m_currentKeyPoint++;
-        return animateComplexTrajectory();
+        return animateViewpointTrajectory();
     }
     else
     {
@@ -1386,6 +1379,7 @@ bool CameraNode::animateComplexTrajectory()
             }
             m_animationPlaylist = m_initialAnimationPlaylist;
             m_isAnimated = false;
+            m_animMode = AnimationMode::Simple;
             m_dataDispatcher.updateInformation(new GuiDataRenderStopAnimation());
             return true;
         }
@@ -1404,7 +1398,7 @@ bool CameraNode::animateComplexTrajectory()
     return true;
 }
 
-void CameraNode::buildComplexAnimationPlaybackPath()
+void CameraNode::buildViewpointAnimationPlaybackPath()
 {
     if (m_trajectory.size() < 2 || m_orientationTrajectory.size() != m_trajectory.size())
         return;
@@ -2270,8 +2264,6 @@ void CameraNode::moveToData(const SafePtr<AGraphNode>& data)
 
         lookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * cli->getInverseTransformation();
         m_animation.clear();
-        m_pendingComplexAnimationStart = false;
-        m_animationStartViewpoint.reset();
         m_trajectory.clear();
         m_orientationTrajectory.clear();
         m_currentKeyPoint = 0;


### PR DESCRIPTION
### Motivation
- Clarify and simplify the multi-viewpoint (playlist) animation path by renaming "Complex" animation to a dedicated "Viewpoint" mode and removing outdated pending-start plumbing. 
- Fix robustness issues in viewpoint trajectory evaluation for zero-length segments and avoid applying stale user input on the same frame an animation starts.

### Description
- Renamed `AnimationMode::Complex` to `AnimationMode::Viewpoint` and replaced references to `animateComplexTrajectory`/`buildComplexAnimationPlaybackPath` with `animateViewpointTrajectory`/`buildViewpointAnimationPlaybackPath`.
- Removed pending-start fields and logic (`m_pendingComplexAnimationStart`, `m_pendingComplexAnimationStep`, `m_animationStartViewpoint`) and the associated deferred-start code path; the viewpoint playlist now initializes camera pose immediately and starts playback via `startPlayTrajectory`.
- Hardened `animateViewpointTrajectory` against zero/near-zero segment durations by skipping degenerate segments and clamping progress, ensuring stable interpolation across control points.
- Ensured simple animations set `m_animMode = AnimationMode::Simple` in the various `lookAt`/`moveTo`/`translateTo` entry points.
- Added a one-frame input lock (`m_viewpointStartInputLockArmed`) in `VulkanViewport` that is armed when a viewpoint playlist animation actually starts and prevents user input from being applied the same frame; the lock is cleared after one frame (and on resume/stop) and resets mouse deltas via `m_MI.resetDeltas()`.

### Testing
- Built the project after changes; the build completed successfully.
- Ran existing automated animation and viewport unit tests; animation-related tests and viewport input tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b575091fd0832faa13fc6788d02fd7)