### PR TITLE
Track actual VMA allocation size, wait for device idle before freeing, and rename shader output

### DIFF
--- a/include/pointCloudEngine/SmartBuffer.h
+++ b/include/pointCloudEngine/SmartBuffer.h
@@ -24,6 +24,8 @@ public:
     VkBuffer buffer = VK_NULL_HANDLE;
     // TODO - Remove and use the VmaAllocationInfo
     VkDeviceSize size = 0;
+    // Actual allocated bytes in the memory allocator (can be larger than size).
+    VkDeviceSize allocationSize = 0;
     bool isLocalMem = false;
 };
 

--- a/src/shaders/marker.vert
+++ b/src/shaders/marker.vert
@@ -20,7 +20,7 @@ layout(location = 2) out uint geomGraphicID;
 layout(location = 3) out uint geomTextureID;
 layout(location = 4) out uint geomFirstVertex;
 layout(location = 5) out uint geomVertexCount;
-layout(location = 6) out uint geomStyle;
+layout(location = 6) out uint geomStatus;
 layout(location = 7) out float billboardScale;
 
 layout(push_constant) uniform PC {
@@ -46,7 +46,7 @@ void main() {
     geomTextureID = textureID;
     geomFirstVertex = firstVertex;
     geomVertexCount = vertexCount;
-    geomStyle = style;
+    geomStatus = style;
 
     // Clamp the coord of the vertex (when z is too small)
     if (z <= pcst.near)

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -1823,16 +1823,16 @@ VkResult VulkanManager::allocSmartBuffer(VkDeviceSize dataSize, SmartBuffer& sbu
     // Actualize the buffer size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_smartBufferAllocated.insert(&sbuf);
     }
     if (isLocal)
-        m_pointsDevicePoolUsed += sbuf.size;
+        m_pointsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed += sbuf.size;
+        m_pointsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1877,7 +1877,7 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
     // Actualize the buffer size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
@@ -1885,9 +1885,9 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
     }
 
     if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed += sbuf.size;
+        m_objectsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_objectsHostPoolUsed += sbuf.size;
+        m_objectsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1985,21 +1985,25 @@ void VulkanManager::freeAllocation(SmartBuffer& sbuf)
     if (sbuf.alloc == VK_NULL_HANDLE)
         return;
 
+    if (m_pfnDev && m_device != VK_NULL_HANDLE)
+        m_pfnDev->vkDeviceWaitIdle(m_device);
+
     vmaDestroyBuffer(m_allocator, sbuf.buffer, sbuf.alloc);
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_smartBufferAllocated.erase(&sbuf);
     }
     if (sbuf.isLocalMem)
-        m_pointsDevicePoolUsed -= sbuf.size;
+        m_pointsDevicePoolUsed -= sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed -= sbuf.size;
+        m_pointsHostPoolUsed -= sbuf.allocationSize;
 
     sbuf.lastUseFrameIndex.store(0);
     sbuf.ongoingProcesses.store(0);
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
 }
 
 void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
@@ -2008,20 +2012,25 @@ void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
         return;
 
     assert(sbuf.buffer != VK_NULL_HANDLE && sbuf.size != 0);
+
+    if (m_pfnDev && m_device != VK_NULL_HANDLE)
+        m_pfnDev->vkDeviceWaitIdle(m_device);
+
     vmaDestroyBuffer(m_allocator, sbuf.buffer, sbuf.alloc);
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_simpleBufferAllocated.erase(&sbuf);
     }
     if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed -= sbuf.size;
+        m_objectsDevicePoolUsed -= sbuf.allocationSize;
     else
-        m_objectsHostPoolUsed -= sbuf.size;
+        m_objectsHostPoolUsed -= sbuf.allocationSize;
 
 
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
 }
 
 bool VulkanManager::freeDeviceMemory(VkDeviceSize minMemoryNeeded)


### PR DESCRIPTION
### Motivation

- Ensure memory accounting uses the actual allocated size returned by the VMA allocator (which can be larger than the requested buffer size) and avoid under/over-reporting pool usage.
- Avoid destroying VMA buffers while the device may still be using them by waiting for device idle before freeing.
- Clarify shader output naming by renaming `geomStyle` to `geomStatus` to reflect intended semantics.

### Description

- Add `allocationSize` to `SimpleBuffer` to store the actual bytes allocated by VMA and keep `size` as the requested buffer size.
- Populate `allocationSize` from `vmaGetAllocationInfo` in `allocSmartBuffer` and `allocSimpleBuffer` and use it for pool accounting instead of `size`.
- Subtract `allocationSize` from pool usage counters and reset `allocationSize` to `0` when freeing buffers.
- Call `vkDeviceWaitIdle` via `m_pfnDev` when freeing `SimpleBuffer` and `SmartBuffer` to ensure the device is idle before `vmaDestroyBuffer`.
- Rename the geometry shader output from `geomStyle` to `geomStatus` and assign `style` into `geomStatus` in `marker.vert`.

### Testing

- Performed a full project build and shader compilation, which completed successfully.
- Executed the automated test suite available in the repository (unit/integration tests), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5972c7934832fb5a4db67d6aff9aa)