### PR TITLE
Add thread-safe Vulkan queue wrappers, track VMA allocation sizes, and shader fixes

### DIFF
--- a/include/pointCloudEngine/SmartBuffer.h
+++ b/include/pointCloudEngine/SmartBuffer.h
@@ -24,6 +24,8 @@ public:
     VkBuffer buffer = VK_NULL_HANDLE;
     // TODO - Remove and use the VmaAllocationInfo
     VkDeviceSize size = 0;
+    // Actual allocated bytes in the memory allocator (can be larger than size).
+    VkDeviceSize allocationSize = 0;
     bool isLocalMem = false;
 };
 

--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -92,6 +92,10 @@ public:
     void startTransferThread();
     void waitForRenderFence();
 
+    VkResult queueSubmitThreadSafe(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) const;
+    VkResult queuePresentThreadSafe(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) const;
+    VkResult queueWaitIdleThreadSafe(VkQueue queue) const;
+
     // Framebuffer management
     bool initFramebuffer(TlFramebuffer& framebuffer, uint64_t winId, int _width, int _height, bool preciseColor);
     void destroyFramebuffer(TlFramebuffer& framebuffer);
@@ -396,6 +400,9 @@ private:
 
     // Synchronization Objects
     std::array<VkFence, MAX_FRAMES_IN_FLIGHT> m_renderFences{};
+    // Thread-safe external synchronization for VkQueue host access.
+    mutable std::mutex m_queueSubmitMutex;
+
 
     // Vulkan Memory Allocator
     VmaPool m_hostPool = VK_NULL_HANDLE;

--- a/src/pointCloudEngine/TlStreamer.cpp
+++ b/src/pointCloudEngine/TlStreamer.cpp
@@ -302,10 +302,10 @@ void TlStreamer::submitVulkanTransfers(const std::vector<TlStagedTransferInfo>& 
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &m_tsfCmdBuf;
 
-    h_pfn->vkQueueSubmit(h_tsfQueue, 1, &submitInfo, m_transferFence);
+    VulkanManager::getInstance().queueSubmitThreadSafe(h_tsfQueue, 1, &submitInfo, m_transferFence);
 
     // TODO - try to remove the wait -> a fence should suffice
-    h_pfn->vkQueueWaitIdle(h_tsfQueue);
+    VulkanManager::getInstance().queueWaitIdleThreadSafe(h_tsfQueue);
 
     for (uint32_t i = 0; i < _stagedTransfers.size(); i++)
     {

--- a/src/shaders/blocks/block_point_i_main_colored_vert.glsl
+++ b/src/shaders/blocks/block_point_i_main_colored_vert.glsl
@@ -1,4 +1,5 @@
 void main() {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
 #ifdef _CLIPPING_ACTIVATED

--- a/src/shaders/blocks/block_point_i_main_fake_color_vert.glsl
+++ b/src/shaders/blocks/block_point_i_main_fake_color_vert.glsl
@@ -1,4 +1,5 @@
 void main() {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
 #ifdef _CLIPPING_ACTIVATED

--- a/src/shaders/blocks/block_point_i_main_standard_vert.glsl
+++ b/src/shaders/blocks/block_point_i_main_standard_vert.glsl
@@ -1,4 +1,5 @@
 void main() {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
 #ifdef _CLIPPING_ACTIVATED

--- a/src/shaders/blocks/block_point_main_flat_vert.glsl
+++ b/src/shaders/blocks/block_point_main_flat_vert.glsl
@@ -1,4 +1,5 @@
 void main() {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
 #ifdef _CLIPPING_ACTIVATED

--- a/src/shaders/blocks/block_point_main_ramp_vert.glsl
+++ b/src/shaders/blocks/block_point_main_ramp_vert.glsl
@@ -8,6 +8,7 @@ vec3 colorRamp(float r)
 
 void main()
 {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
 
 #ifdef ATTRIB_RGB

--- a/src/shaders/blocks/block_point_rgb_main_colored_vert.glsl
+++ b/src/shaders/blocks/block_point_rgb_main_colored_vert.glsl
@@ -1,4 +1,5 @@
 void main() {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
 #ifdef _CLIPPING_ACTIVATED

--- a/src/shaders/blocks/block_point_rgb_main_standard_vert.glsl
+++ b/src/shaders/blocks/block_point_rgb_main_standard_vert.glsl
@@ -1,4 +1,5 @@
 void main() {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
 #ifdef _CLIPPING_ACTIVATED

--- a/src/shaders/blocks/block_point_rgbi_main_standard_vert.glsl
+++ b/src/shaders/blocks/block_point_rgbi_main_standard_vert.glsl
@@ -1,4 +1,5 @@
 void main() {
+    filterReject = 0.0;
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
 #ifdef _CLIPPING_ACTIVATED

--- a/src/shaders/marker.vert
+++ b/src/shaders/marker.vert
@@ -20,7 +20,7 @@ layout(location = 2) out uint geomGraphicID;
 layout(location = 3) out uint geomTextureID;
 layout(location = 4) out uint geomFirstVertex;
 layout(location = 5) out uint geomVertexCount;
-layout(location = 6) out uint geomStyle;
+layout(location = 6) out uint geomStatus;
 layout(location = 7) out float billboardScale;
 
 layout(push_constant) uniform PC {
@@ -46,7 +46,7 @@ void main() {
     geomTextureID = textureID;
     geomFirstVertex = firstVertex;
     geomVertexCount = vertexCount;
-    geomStyle = style;
+    geomStatus = style;
 
     // Clamp the coord of the vertex (when z is too small)
     if (z <= pcst.near)

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -199,7 +199,15 @@ void VulkanManager::stopAllRendering()
 void VulkanManager::initStreaming()
 {
     if (m_streamer == nullptr)
-        m_streamer = new TlStreamer(m_device, m_pfnDev, getQueue(m_streamingQID), m_streamingQID.family, 32 * 1024 * 1024);
+    {
+        VkQueue streamingQueue = getQueue(m_streamingQID);
+        VkQueue graphicsQueue = getQueue(m_graphicsQID);
+        Logger::log(VK_LOG) << "Queue handles graphics=" << graphicsQueue << " streaming=" << streamingQueue
+                           << " graphics(family,index)= (" << m_graphicsQID.family << ", " << m_graphicsQID.index << ")"
+                           << " streaming(family,index)= (" << m_streamingQID.family << ", " << m_streamingQID.index << ")"
+                           << Logger::endl;
+        m_streamer = new TlStreamer(m_device, m_pfnDev, streamingQueue, m_streamingQID.family, 32 * 1024 * 1024);
+    }
     else
         VKM_ERROR << "Try to start the streaming module more than one time." << Logger::endl;
 
@@ -1264,7 +1272,7 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
 
         submitInfos.push_back(submitInfo);
     }
-    err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), (uint32_t)submitInfos.size(), submitInfos.data(), renderFence);
+    err = queueSubmitThreadSafe(getQueue(m_graphicsQID), (uint32_t)submitInfos.size(), submitInfos.data(), renderFence);
     check_vk_result(err, "Submit Graphic Queue");
 
     for (TlFramebuffer fb : fbs)
@@ -1277,7 +1285,7 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
         presentInfo.pSwapchains = &fb->swapchain;
         presentInfo.pImageIndices = &fb->currentImage;
         // FIXME - Utiliser la bonne queue si la presentation se fait sur une queue diffÃ©rente.
-        err = m_pfnDev->vkQueuePresentKHR(getQueue(m_graphicsQID), &presentInfo);
+        err = queuePresentThreadSafe(getQueue(m_graphicsQID), &presentInfo);
         if (err == VK_ERROR_OUT_OF_DATE_KHR || err == VK_SUBOPTIMAL_KHR) {
             VKM_INFO << "Out of date swapchain (end render pass)\n" << Logger::endl;
             fb->mustRecreateSwapchain.store(true);
@@ -1311,7 +1319,7 @@ void VulkanManager::submitVirtualFramebuffer(TlFramebuffer fb)
     submitInfo.signalSemaphoreCount = 0;
     submitInfo.pSignalSemaphores = nullptr;
 
-    err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), 1, &submitInfo, renderFence);
+    err = queueSubmitThreadSafe(getQueue(m_graphicsQID), 1, &submitInfo, renderFence);
     check_vk_result(err, "Submit Graphic Queue");
 }
 
@@ -1336,6 +1344,25 @@ uint32_t VulkanManager::getCurrentFrameIndex() const
 {
     return m_currentFrameIndex.load();
 }
+
+VkResult VulkanManager::queueSubmitThreadSafe(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) const
+{
+    std::lock_guard<std::mutex> lock(m_queueSubmitMutex);
+    return m_pfnDev->vkQueueSubmit(queue, submitCount, pSubmits, fence);
+}
+
+VkResult VulkanManager::queuePresentThreadSafe(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) const
+{
+    std::lock_guard<std::mutex> lock(m_queueSubmitMutex);
+    return m_pfnDev->vkQueuePresentKHR(queue, pPresentInfo);
+}
+
+VkResult VulkanManager::queueWaitIdleThreadSafe(VkQueue queue) const
+{
+    std::lock_guard<std::mutex> lock(m_queueSubmitMutex);
+    return m_pfnDev->vkQueueWaitIdle(queue);
+}
+
 
 uint32_t VulkanManager::getSafeFrameIndex()
 {
@@ -1433,8 +1460,8 @@ bool VulkanManager::loadInSimpleBuffer_local(SimpleBuffer& smpBuf, VkDeviceSize 
         submitInfo.commandBufferCount = 1;
         submitInfo.pCommandBuffers = &m_transferCmdBuf;
 
-        m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
-        m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+        queueSubmitThreadSafe(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+        queueWaitIdleThreadSafe(getQueue(m_transferQID));
         //++++++++++++++++++++++++++++
     }
     return (true);
@@ -1603,8 +1630,8 @@ bool VulkanManager::downloadSimpleBuffer_async(const SimpleBuffer& smpBuf, void*
             submitInfo.commandBufferCount = 1;
             submitInfo.pCommandBuffers = &m_transferCmdBuf;
 
-            m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
-            m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+            queueSubmitThreadSafe(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+            queueWaitIdleThreadSafe(getQueue(m_transferQID));
             //++++++++++++++++++++++++++++
 
             VkMappedMemoryRange range = {};
@@ -1823,16 +1850,16 @@ VkResult VulkanManager::allocSmartBuffer(VkDeviceSize dataSize, SmartBuffer& sbu
     // Actualize the buffer size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_smartBufferAllocated.insert(&sbuf);
     }
     if (isLocal)
-        m_pointsDevicePoolUsed += sbuf.size;
+        m_pointsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed += sbuf.size;
+        m_pointsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1877,7 +1904,7 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
     // Actualize the buffer size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
@@ -1885,9 +1912,9 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
     }
 
     if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed += sbuf.size;
+        m_objectsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_objectsHostPoolUsed += sbuf.size;
+        m_objectsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1985,21 +2012,25 @@ void VulkanManager::freeAllocation(SmartBuffer& sbuf)
     if (sbuf.alloc == VK_NULL_HANDLE)
         return;
 
+    if (m_pfnDev && m_device != VK_NULL_HANDLE)
+        m_pfnDev->vkDeviceWaitIdle(m_device);
+
     vmaDestroyBuffer(m_allocator, sbuf.buffer, sbuf.alloc);
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_smartBufferAllocated.erase(&sbuf);
     }
     if (sbuf.isLocalMem)
-        m_pointsDevicePoolUsed -= sbuf.size;
+        m_pointsDevicePoolUsed -= sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed -= sbuf.size;
+        m_pointsHostPoolUsed -= sbuf.allocationSize;
 
     sbuf.lastUseFrameIndex.store(0);
     sbuf.ongoingProcesses.store(0);
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
 }
 
 void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
@@ -2008,20 +2039,25 @@ void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
         return;
 
     assert(sbuf.buffer != VK_NULL_HANDLE && sbuf.size != 0);
+
+    if (m_pfnDev && m_device != VK_NULL_HANDLE)
+        m_pfnDev->vkDeviceWaitIdle(m_device);
+
     vmaDestroyBuffer(m_allocator, sbuf.buffer, sbuf.alloc);
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_simpleBufferAllocated.erase(&sbuf);
     }
     if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed -= sbuf.size;
+        m_objectsDevicePoolUsed -= sbuf.allocationSize;
     else
-        m_objectsHostPoolUsed -= sbuf.size;
+        m_objectsHostPoolUsed -= sbuf.allocationSize;
 
 
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
 }
 
 bool VulkanManager::freeDeviceMemory(VkDeviceSize minMemoryNeeded)
@@ -3676,8 +3712,8 @@ void VulkanManager::endTransferCommand(VkCommandBuffer _cmdBuffer)
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &_cmdBuffer;
 
-    m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
-    m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+    queueSubmitThreadSafe(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+    queueWaitIdleThreadSafe(getQueue(m_transferQID));
 
     m_pfnDev->vkFreeCommandBuffers(m_device, m_transferCmdPool, 1, &_cmdBuffer);
 }


### PR DESCRIPTION
### Motivation

- Prevent race conditions when multiple threads submit or present to Vulkan queues and ensure correct accounting of actual allocation sizes from the Vulkan Memory Allocator (VMA).
- Initialize a shader-side `filterReject` value to avoid undefined behavior in several point/vertex shaders.
- Rename a marker vertex output to match downstream usage and add useful queue logging when starting streaming.

### Description

- Added `allocationSize` to `SimpleBuffer`/`SmartBuffer` and updated allocation bookkeeping to use the actual VMA allocation size instead of prior `size` where appropriate, and reset `allocationSize` on free.
- Introduced `m_queueSubmitMutex` and three thread-safe wrapper methods `queueSubmitThreadSafe`, `queuePresentThreadSafe`, and `queueWaitIdleThreadSafe` in `VulkanManager`, and replaced direct `vkQueueSubmit`, `vkQueuePresentKHR`, and `vkQueueWaitIdle` calls with these wrappers across the codebase.
- Ensured `vkDeviceWaitIdle` is called (when possible) before destroying buffers to avoid races during free, and added a log message with queue handles when initializing streaming and creating the streamer.
- Updated many vertex shader files to initialize `filterReject` to `0.0` and changed the `marker.vert` output `geomStyle` to `geomStatus` to align the passed data name.

### Testing

- Project build was validated locally using the standard build (`cmake` / `cmake --build`) and the build completed successfully.
- Automated tests were run with `ctest` and the test suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5972c7934832fb5a4db67d6aff9aa)