### PR TITLE
Use VMA's real allocation size for accounting and add checks for descriptor buffers

### DIFF
--- a/include/pointCloudEngine/SmartBuffer.h
+++ b/include/pointCloudEngine/SmartBuffer.h
@@ -22,8 +22,10 @@ class SimpleBuffer
 public:
     VmaAllocation alloc = VK_NULL_HANDLE;
     VkBuffer buffer = VK_NULL_HANDLE;
-    // TODO - Remove and use the VmaAllocationInfo
+    // Logical VkBuffer size (buffer creation size)
     VkDeviceSize size = 0;
+    // Real allocation size returned by VMA (can be greater than `size`)
+    VkDeviceSize allocationSize = 0;
     bool isLocalMem = false;
 };
 

--- a/src/vulkan/Renderers/MarkerRenderer.cpp
+++ b/src/vulkan/Renderers/MarkerRenderer.cpp
@@ -280,12 +280,15 @@ void MarkerRenderer::createDescriptorSet_storageBuffers()
     err = h_pfn->vkAllocateDescriptorSets(h_device, &ds_allocInfo, &m_ds_storageBuffers);
     check_vk_result(err, "Allocate Descriptor Sets");
 
+    assert(m_vertPosBuf.size <= m_vertPosBuf.allocationSize);
+    assert(m_vertUVBuf.size <= m_vertUVBuf.allocationSize);
+
     // Update Descriptor Set
     VkDescriptorBufferInfo storageBufferInfo[] = {
         {
             m_vertPosBuf.buffer, // buffer
             0,  // offset
-            m_vertPosBuf.size // range
+            m_vertPosBuf.size // range (logical VkBuffer size)
         },
         {
             m_vertUVBuf.buffer,

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -1820,19 +1820,19 @@ VkResult VulkanManager::allocSmartBuffer(VkDeviceSize dataSize, SmartBuffer& sbu
     if ((err = tryAllocBuffer(bufferInfo, allocCI, &sbuf)) != VK_SUCCESS)
         return err;
 
-    // Actualize the buffer size after allocation
+    // Actualize the allocation size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_smartBufferAllocated.insert(&sbuf);
     }
     if (isLocal)
-        m_pointsDevicePoolUsed += sbuf.size;
+        m_pointsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed += sbuf.size;
+        m_pointsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1874,10 +1874,10 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
             return err;
     }
 
-    // Actualize the buffer size after allocation
+    // Actualize the allocation size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
@@ -1885,9 +1885,9 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
     }
 
     if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed += sbuf.size;
+        m_objectsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_objectsHostPoolUsed += sbuf.size;
+        m_objectsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1991,15 +1991,16 @@ void VulkanManager::freeAllocation(SmartBuffer& sbuf)
         m_smartBufferAllocated.erase(&sbuf);
     }
     if (sbuf.isLocalMem)
-        m_pointsDevicePoolUsed -= sbuf.size;
+        m_pointsDevicePoolUsed -= sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed -= sbuf.size;
+        m_pointsHostPoolUsed -= sbuf.allocationSize;
 
     sbuf.lastUseFrameIndex.store(0);
     sbuf.ongoingProcesses.store(0);
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
 }
 
 void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
@@ -2014,14 +2015,15 @@ void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
         m_simpleBufferAllocated.erase(&sbuf);
     }
     if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed -= sbuf.size;
+        m_objectsDevicePoolUsed -= sbuf.allocationSize;
     else
-        m_objectsHostPoolUsed -= sbuf.size;
+        m_objectsHostPoolUsed -= sbuf.allocationSize;
 
 
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
 }
 
 bool VulkanManager::freeDeviceMemory(VkDeviceSize minMemoryNeeded)


### PR DESCRIPTION
### Motivation
- Buffer allocations can be larger than the logical `VkBuffer` creation size due to VMA rounding/packing, so tracking only the requested buffer `size` produces incorrect pool usage accounting.
- Ensure descriptor updates use logical buffer ranges while validating that the logical size does not exceed the real allocation returned by VMA.

### Description
- Introduced `allocationSize` in `SimpleBuffer` to record the real allocation size returned by VMA and added a comment describing the distinction between logical `size` and `allocationSize`.
- Set `sbuf.allocationSize` from `vmaGetAllocationInfo(...)` in both `allocSmartBuffer` and `allocSimpleBuffer` after allocation.
- Switched all pool accounting and usage tracking to use `allocationSize` instead of the logical `size` for device/host pool counters and when freeing allocations, and clear `allocationSize` on free.
- Added runtime assertions in `MarkerRenderer::createDescriptorSet_storageBuffers()` to verify that logical buffer sizes (`m_vertPosBuf.size` and `m_vertUVBuf.size`) do not exceed the real `allocationSize`, and clarified the descriptor `range` comment to indicate it is the logical `VkBuffer` size.

### Testing
- Performed a full project build which completed successfully (no compile errors after the changes).
- Ran the repository's automated unit test suite and integration smoke tests; they passed without failures.
- Executed the descriptor allocation and buffer allocation code paths manually in a smoke run to validate the new assertions do not trigger in normal usage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ce5226a8832f8a5415091dfd7bee)