### PR TITLE
Add queue API mutex, defer SimpleBuffer frees, and track VMA allocation sizes

### DIFF
--- a/include/pointCloudEngine/SmartBuffer.h
+++ b/include/pointCloudEngine/SmartBuffer.h
@@ -22,8 +22,10 @@ class SimpleBuffer
 public:
     VmaAllocation alloc = VK_NULL_HANDLE;
     VkBuffer buffer = VK_NULL_HANDLE;
-    // TODO - Remove and use the VmaAllocationInfo
+    // Logical VkBuffer size (buffer creation size)
     VkDeviceSize size = 0;
+    // Real allocation size returned by VMA (can be greater than `size`)
+    VkDeviceSize allocationSize = 0;
     bool isLocalMem = false;
 };
 

--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <future>
 #include <type_traits>
+#include <vector>
 
 #include "vulkan/vulkan.h"
 #include "vulkan/VulkanFunctions.h"
@@ -155,6 +156,7 @@ public:
     void submitVirtualFramebuffer(TlFramebuffer fb);
     void waitIdle();
     void waitForStreamingIdle();
+    static std::mutex& getQueueApiMutex();
 
     uint32_t getCurrentFrameIndex() const;
     // For all the frame index inferior or equal to the "safe frame index" it is guaranted
@@ -316,6 +318,7 @@ private:
     // Memory utilities
     void checkAllocations();
     void defragmentMemory();
+    void collectDeferredSimpleBufferFrees(bool force = false);
 
     // Cleanup Functions
     void cleanupAll();
@@ -411,6 +414,17 @@ private:
     std::mutex m_mutexBufferAllocated;
     std::unordered_set<SmartBuffer*> m_smartBufferAllocated;
     std::unordered_set<SimpleBuffer*> m_simpleBufferAllocated;
+
+    struct DeferredSimpleBufferFree
+    {
+        VkBuffer buffer = VK_NULL_HANDLE;
+        VmaAllocation allocation = VK_NULL_HANDLE;
+        VkDeviceSize allocationSize = 0;
+        bool isLocalMem = false;
+        uint32_t safeFrameIndex = 0;
+    };
+    std::mutex m_mutexDeferredSimpleFrees;
+    std::vector<DeferredSimpleBufferFree> m_deferredSimpleFrees;
     
     VkDeviceSize m_pointsDevicePoolUsed = 0;
     VkDeviceSize m_pointsHostPoolUsed = 0;

--- a/src/pointCloudEngine/TlStreamer.cpp
+++ b/src/pointCloudEngine/TlStreamer.cpp
@@ -302,10 +302,13 @@ void TlStreamer::submitVulkanTransfers(const std::vector<TlStagedTransferInfo>& 
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &m_tsfCmdBuf;
 
-    h_pfn->vkQueueSubmit(h_tsfQueue, 1, &submitInfo, m_transferFence);
+    {
+        std::lock_guard<std::mutex> lock(VulkanManager::getQueueApiMutex());
+        h_pfn->vkQueueSubmit(h_tsfQueue, 1, &submitInfo, m_transferFence);
 
-    // TODO - try to remove the wait -> a fence should suffice
-    h_pfn->vkQueueWaitIdle(h_tsfQueue);
+        // TODO - try to remove the wait -> a fence should suffice
+        h_pfn->vkQueueWaitIdle(h_tsfQueue);
+    }
 
     for (uint32_t i = 0; i < _stagedTransfers.size(); i++)
     {

--- a/src/vulkan/Renderers/MarkerRenderer.cpp
+++ b/src/vulkan/Renderers/MarkerRenderer.cpp
@@ -280,12 +280,15 @@ void MarkerRenderer::createDescriptorSet_storageBuffers()
     err = h_pfn->vkAllocateDescriptorSets(h_device, &ds_allocInfo, &m_ds_storageBuffers);
     check_vk_result(err, "Allocate Descriptor Sets");
 
+    assert(m_vertPosBuf.size <= m_vertPosBuf.allocationSize);
+    assert(m_vertUVBuf.size <= m_vertUVBuf.allocationSize);
+
     // Update Descriptor Set
     VkDescriptorBufferInfo storageBufferInfo[] = {
         {
             m_vertPosBuf.buffer, // buffer
             0,  // offset
-            m_vertPosBuf.size // range
+            m_vertPosBuf.size // range (logical VkBuffer size)
         },
         {
             m_vertUVBuf.buffer,

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -33,6 +33,11 @@
             log << " ";\
         log << blank;
 
+namespace
+{
+    std::mutex g_vulkanQueueApiMutex;
+}
+
 void deleteCharPP(uint32_t _count, char* const* _cstringList)
 {
     for (uint32_t i = 0; i < _count; i++) {
@@ -758,6 +763,8 @@ std::vector<uint32_t> VulkanManager::sampleIndexList(TlFramebuffer _fb, uint32_t
 
 void VulkanManager::startNextFrame()
 {
+    collectDeferredSimpleBufferFrees(false);
+
     if (m_missedDeviceAllocations > 0)
         VKM_WARNING << m_missedDeviceAllocations << " device allocations failed during frame " << m_currentFrameIndex << Logger::endl;
     if (m_missedHostAllocations > 0)
@@ -1264,7 +1271,10 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
 
         submitInfos.push_back(submitInfo);
     }
-    err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), (uint32_t)submitInfos.size(), submitInfos.data(), renderFence);
+    {
+        std::lock_guard<std::mutex> lock(getQueueApiMutex());
+        err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), (uint32_t)submitInfos.size(), submitInfos.data(), renderFence);
+    }
     check_vk_result(err, "Submit Graphic Queue");
 
     for (TlFramebuffer fb : fbs)
@@ -1277,7 +1287,10 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
         presentInfo.pSwapchains = &fb->swapchain;
         presentInfo.pImageIndices = &fb->currentImage;
         // FIXME - Utiliser la bonne queue si la presentation se fait sur une queue diffÃ©rente.
-        err = m_pfnDev->vkQueuePresentKHR(getQueue(m_graphicsQID), &presentInfo);
+        {
+            std::lock_guard<std::mutex> lock(getQueueApiMutex());
+            err = m_pfnDev->vkQueuePresentKHR(getQueue(m_graphicsQID), &presentInfo);
+        }
         if (err == VK_ERROR_OUT_OF_DATE_KHR || err == VK_SUBOPTIMAL_KHR) {
             VKM_INFO << "Out of date swapchain (end render pass)\n" << Logger::endl;
             fb->mustRecreateSwapchain.store(true);
@@ -1311,7 +1324,10 @@ void VulkanManager::submitVirtualFramebuffer(TlFramebuffer fb)
     submitInfo.signalSemaphoreCount = 0;
     submitInfo.pSignalSemaphores = nullptr;
 
-    err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), 1, &submitInfo, renderFence);
+    {
+        std::lock_guard<std::mutex> lock(getQueueApiMutex());
+        err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), 1, &submitInfo, renderFence);
+    }
     check_vk_result(err, "Submit Graphic Queue");
 }
 
@@ -1325,6 +1341,11 @@ void VulkanManager::waitForRenderFence()
 void VulkanManager::waitIdle()
 {
     m_pfnDev->vkDeviceWaitIdle(m_device);
+}
+
+std::mutex& VulkanManager::getQueueApiMutex()
+{
+    return g_vulkanQueueApiMutex;
 }
 
 void VulkanManager::waitForStreamingIdle()
@@ -1433,8 +1454,11 @@ bool VulkanManager::loadInSimpleBuffer_local(SimpleBuffer& smpBuf, VkDeviceSize 
         submitInfo.commandBufferCount = 1;
         submitInfo.pCommandBuffers = &m_transferCmdBuf;
 
-        m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
-        m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+        {
+            std::lock_guard<std::mutex> lock(getQueueApiMutex());
+            m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+            m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+        }
         //++++++++++++++++++++++++++++
     }
     return (true);
@@ -1603,8 +1627,11 @@ bool VulkanManager::downloadSimpleBuffer_async(const SimpleBuffer& smpBuf, void*
             submitInfo.commandBufferCount = 1;
             submitInfo.pCommandBuffers = &m_transferCmdBuf;
 
-            m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
-            m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+            {
+                std::lock_guard<std::mutex> lock(getQueueApiMutex());
+                m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+                m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+            }
             //++++++++++++++++++++++++++++
 
             VkMappedMemoryRange range = {};
@@ -1820,19 +1847,19 @@ VkResult VulkanManager::allocSmartBuffer(VkDeviceSize dataSize, SmartBuffer& sbu
     if ((err = tryAllocBuffer(bufferInfo, allocCI, &sbuf)) != VK_SUCCESS)
         return err;
 
-    // Actualize the buffer size after allocation
+    // Actualize the allocation size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_smartBufferAllocated.insert(&sbuf);
     }
     if (isLocal)
-        m_pointsDevicePoolUsed += sbuf.size;
+        m_pointsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed += sbuf.size;
+        m_pointsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1874,10 +1901,10 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
             return err;
     }
 
-    // Actualize the buffer size after allocation
+    // Actualize the allocation size after allocation
     VmaAllocationInfo allocInfo;
     vmaGetAllocationInfo(m_allocator, sbuf.alloc, &allocInfo);
-    sbuf.size = allocInfo.size;
+    sbuf.allocationSize = allocInfo.size;
 
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
@@ -1885,9 +1912,9 @@ VkResult VulkanManager::allocSimpleBuffer(VkDeviceSize dataSize, SimpleBuffer& s
     }
 
     if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed += sbuf.size;
+        m_objectsDevicePoolUsed += sbuf.allocationSize;
     else
-        m_objectsHostPoolUsed += sbuf.size;
+        m_objectsHostPoolUsed += sbuf.allocationSize;
 
     return err;
 }
@@ -1991,15 +2018,16 @@ void VulkanManager::freeAllocation(SmartBuffer& sbuf)
         m_smartBufferAllocated.erase(&sbuf);
     }
     if (sbuf.isLocalMem)
-        m_pointsDevicePoolUsed -= sbuf.size;
+        m_pointsDevicePoolUsed -= sbuf.allocationSize;
     else
-        m_pointsHostPoolUsed -= sbuf.size;
+        m_pointsHostPoolUsed -= sbuf.allocationSize;
 
     sbuf.lastUseFrameIndex.store(0);
     sbuf.ongoingProcesses.store(0);
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
 }
 
 void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
@@ -2008,20 +2036,66 @@ void VulkanManager::freeAllocation(SimpleBuffer& sbuf)
         return;
 
     assert(sbuf.buffer != VK_NULL_HANDLE && sbuf.size != 0);
-    vmaDestroyBuffer(m_allocator, sbuf.buffer, sbuf.alloc);
+
+    DeferredSimpleBufferFree deferredFree{};
+    deferredFree.buffer = sbuf.buffer;
+    deferredFree.allocation = sbuf.alloc;
+    deferredFree.allocationSize = sbuf.allocationSize;
+    deferredFree.isLocalMem = sbuf.isLocalMem;
+    deferredFree.safeFrameIndex = m_currentFrameIndex.load() + m_maxSafeFrame;
+
+    {
+        std::lock_guard<std::mutex> lock(m_mutexDeferredSimpleFrees);
+        m_deferredSimpleFrees.emplace_back(deferredFree);
+    }
+
     {
         std::lock_guard<std::mutex> lock(m_mutexBufferAllocated);
         m_simpleBufferAllocated.erase(&sbuf);
     }
-    if (sbuf.isLocalMem)
-        m_objectsDevicePoolUsed -= sbuf.size;
-    else
-        m_objectsHostPoolUsed -= sbuf.size;
-
 
     sbuf.alloc = VK_NULL_HANDLE;
     sbuf.buffer = VK_NULL_HANDLE;
     sbuf.size = 0;
+    sbuf.allocationSize = 0;
+}
+
+void VulkanManager::collectDeferredSimpleBufferFrees(bool force)
+{
+    if (m_allocator == VK_NULL_HANDLE)
+        return;
+
+    std::vector<DeferredSimpleBufferFree> toFree;
+    {
+        std::lock_guard<std::mutex> lock(m_mutexDeferredSimpleFrees);
+        if (m_deferredSimpleFrees.empty())
+            return;
+
+        const uint32_t currentFI = m_currentFrameIndex.load();
+        auto it = m_deferredSimpleFrees.begin();
+        while (it != m_deferredSimpleFrees.end())
+        {
+            if (force || it->safeFrameIndex <= currentFI)
+            {
+                toFree.emplace_back(*it);
+                it = m_deferredSimpleFrees.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
+    for (const DeferredSimpleBufferFree& deferred : toFree)
+    {
+        vmaDestroyBuffer(m_allocator, deferred.buffer, deferred.allocation);
+
+        if (deferred.isLocalMem)
+            m_objectsDevicePoolUsed -= deferred.allocationSize;
+        else
+            m_objectsHostPoolUsed -= deferred.allocationSize;
+    }
 }
 
 bool VulkanManager::freeDeviceMemory(VkDeviceSize minMemoryNeeded)
@@ -3676,8 +3750,11 @@ void VulkanManager::endTransferCommand(VkCommandBuffer _cmdBuffer)
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &_cmdBuffer;
 
-    m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
-    m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+    {
+        std::lock_guard<std::mutex> lock(getQueueApiMutex());
+        m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+        m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
+    }
 
     m_pfnDev->vkFreeCommandBuffers(m_device, m_transferCmdPool, 1, &_cmdBuffer);
 }
@@ -4218,6 +4295,9 @@ void VulkanManager::cleanupAll()
     using namespace tls::vk;
     if (m_device && m_pfnDev)
     {
+        m_pfnDev->vkDeviceWaitIdle(m_device);
+        collectDeferredSimpleBufferFrees(true);
+
         destroyCommandPool(*m_pfnDev, m_device, m_graphicsCmdPool);
         destroyCommandPool(*m_pfnDev, m_device, m_computeCmdPool);
         freeCommandBuffer(*m_pfnDev, m_device, m_transferCmdPool, m_transferCmdBuf);
@@ -4408,6 +4488,8 @@ void VulkanManager::cleanupPermanentResources(TlFramebuffer _fb)
         freeAllocation(_fb->drawMeasureBuffers[i]);
     }
     _fb->drawMeasureBuffers.clear();
+
+    collectDeferredSimpleBufferFrees(true);
 }
 
 template<class Buffer>
@@ -4423,8 +4505,11 @@ void pushToVectors(std::unordered_set<Buffer*>& sbuffers, std::vector<SimpleBuff
 
 void VulkanManager::checkAllocations()
 {
+    collectDeferredSimpleBufferFrees(true);
+
     assert(m_smartBufferAllocated.empty());
     assert(m_simpleBufferAllocated.empty());
+    assert(m_deferredSimpleFrees.empty());
     assert(m_pointsDevicePoolUsed == 0);
     assert(m_pointsHostPoolUsed == 0);
     assert(m_objectsDevicePoolUsed == 0);


### PR DESCRIPTION
### Motivation
- Ensure thread-safe use of Vulkan queue APIs and avoid races when submitting/presenting across threads. 
- Fix incorrect accounting when VMA returns allocation sizes larger than the logical buffer size. 
- Avoid freeing VkBuffers while they may still be in use by GPU by deferring `SimpleBuffer` destruction until it is safe.

### Description
- Introduced a global queue API mutex and exposed it via `VulkanManager::getQueueApiMutex()` and wrapped `vkQueueSubmit`, `vkQueueWaitIdle` and `vkQueuePresentKHR` calls with the mutex across `VulkanManager` and `TlStreamer`.
- Added `allocationSize` to `SimpleBuffer` (and set it for smart/simple allocations from `vmaGetAllocationInfo`) and switched pool usage counters to use `allocationSize` instead of logical `size`.
- Implemented deferred free mechanism for `SimpleBuffer` by adding `DeferredSimpleBufferFree`, a `m_deferredSimpleFrees` list, `collectDeferredSimpleBufferFrees()` and changing `freeAllocation(SimpleBuffer&)` to enqueue deferred frees with a `safeFrameIndex` instead of immediate `vmaDestroyBuffer`.
- Call `collectDeferredSimpleBufferFrees()` at frame start and in cleanup paths (`startNextFrame`, `cleanupAll`, `cleanupPermanentResources`, `checkAllocations`) and provide a `force` path to flush remaining deferred frees.
- Minor safety/assert additions in `MarkerRenderer` to verify `size` does not exceed `allocationSize` when updating descriptor ranges.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ce5226a8832f8a5415091dfd7bee)