### PR TITLE
Add render-loop blocking primitives to VulkanManager and scope guards in RenderingEngine

### DIFF
--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -12,6 +12,7 @@
 #include <queue>
 #include <array>
 #include <future>
+#include <condition_variable>
 #include <type_traits>
 #include <vector>
 
@@ -156,6 +157,10 @@ public:
     void submitVirtualFramebuffer(TlFramebuffer fb);
     void waitIdle();
     void waitForStreamingIdle();
+    void beginQueueSubmissionBlock();
+    void endQueueSubmissionBlock();
+    void beginRenderFrameScope();
+    void endRenderFrameScope();
     static std::mutex& getQueueApiMutex();
     static void logQueueApiCall(const char* tag, VkQueue queue);
 
@@ -448,6 +453,12 @@ private:
     std::condition_variable m_transfer_cv;
     std::queue<std::function<void()>> m_transferTasks;
     std::thread m_transferThread;
+
+    // Used to suspend the render loop at frame boundaries during project close.
+    std::mutex m_renderBlockMutex;
+    std::condition_variable m_renderBlockCv;
+    bool m_queueSubmissionBlocked = false;
+    uint32_t m_renderFrameScopeCount = 0;
 
     // Use to free safely any buffers rendered on any framebuffer
     uint32_t m_maxSafeFrame = 0;

--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -159,9 +159,6 @@ public:
     static std::mutex& getQueueApiMutex();
     static void logQueueApiCall(const char* tag, VkQueue queue);
 
-    void beginQueueSubmissionBlock();
-    void endQueueSubmissionBlock();
-    bool isQueueSubmissionBlocked() const;
 
     uint32_t getCurrentFrameIndex() const;
     // For all the frame index inferior or equal to the "safe frame index" it is guaranted
@@ -440,7 +437,6 @@ private:
     uint32_t m_missedDeviceAllocations = 0;
     uint32_t m_missedHostAllocations = 0;
 
-    std::atomic<bool> m_blockQueueSubmissions = false;
 
     // Streaming Resources
     TlStreamer* m_streamer = nullptr;

--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -159,6 +159,10 @@ public:
     static std::mutex& getQueueApiMutex();
     static void logQueueApiCall(const char* tag, VkQueue queue);
 
+    void beginQueueSubmissionBlock();
+    void endQueueSubmissionBlock();
+    bool isQueueSubmissionBlocked() const;
+
     uint32_t getCurrentFrameIndex() const;
     // For all the frame index inferior or equal to the "safe frame index" it is guaranted
     // that all the command buffers are completed and the gpu resources are free to manipulate
@@ -435,6 +439,8 @@ private:
     std::atomic<bool> m_noMoreFreeMemoryForFrame_host = false;
     uint32_t m_missedDeviceAllocations = 0;
     uint32_t m_missedHostAllocations = 0;
+
+    std::atomic<bool> m_blockQueueSubmissions = false;
 
     // Streaming Resources
     TlStreamer* m_streamer = nullptr;

--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -157,6 +157,7 @@ public:
     void waitIdle();
     void waitForStreamingIdle();
     static std::mutex& getQueueApiMutex();
+    static void logQueueApiCall(const char* tag, VkQueue queue);
 
     uint32_t getCurrentFrameIndex() const;
     // For all the frame index inferior or equal to the "safe frame index" it is guaranted

--- a/src/controller/controls/ControlProject.cpp
+++ b/src/controller/controls/ControlProject.cpp
@@ -25,6 +25,7 @@
 #include "models/graph/GraphManager.h"
 
 #include "pointCloudEngine/PCE_core.h"
+#include "vulkan/VulkanManager.h"
 
 #include "utils/FilesAndFoldersDefinitions.h"
 #include "utils/Config.h"
@@ -381,6 +382,16 @@ namespace control::project
     void Close::doFunction(Controller& controller)
     {
         CONTROLLOG << "control::project::Close[begin]" << LOGENDL;
+
+        VulkanManager& vkm = VulkanManager::getInstance();
+        vkm.beginQueueSubmissionBlock();
+        struct QueueSubmissionBlockGuard
+        {
+            VulkanManager& vkm;
+            ~QueueSubmissionBlockGuard() { vkm.endQueueSubmissionBlock(); }
+        } submissionBlockGuard{ vkm };
+
+        vkm.waitForRenderFence();
 
         ControllerContext& context = controller.getContext();
 

--- a/src/pointCloudEngine/RenderingEngine.cpp
+++ b/src/pointCloudEngine/RenderingEngine.cpp
@@ -282,6 +282,14 @@ VkExtent2D getViewportExtent(VulkanViewport& viewport)
 
 void RenderingEngine::update()
 {
+    VulkanManager& vkm = VulkanManager::getInstance();
+    vkm.beginRenderFrameScope();
+    struct RenderFrameScopeGuard
+    {
+        VulkanManager& vkm;
+        ~RenderFrameScopeGuard() { vkm.endRenderFrameScope(); }
+    } renderFrameScopeGuard{ vkm };
+
     //initializeManipulators();
     // Refresh the Scene
     m_renderSwapIndex = ++m_renderSwapIndex % 2;
@@ -292,7 +300,6 @@ void RenderingEngine::update()
 
     std::vector<TlFramebuffer> m_framebuffersToRender;
     // Instruct the drawing for each viewport (if necessary)
-    VulkanManager& vkm = VulkanManager::getInstance();
     vkm.startNextFrame();
     vkm.waitForRenderFence();
     // Refresh the Inputs for each viewport.

--- a/src/pointCloudEngine/TlStreamer.cpp
+++ b/src/pointCloudEngine/TlStreamer.cpp
@@ -304,9 +304,11 @@ void TlStreamer::submitVulkanTransfers(const std::vector<TlStagedTransferInfo>& 
 
     {
         std::lock_guard<std::mutex> lock(VulkanManager::getQueueApiMutex());
+        VulkanManager::logQueueApiCall("streamer_submit", h_tsfQueue);
         h_pfn->vkQueueSubmit(h_tsfQueue, 1, &submitInfo, m_transferFence);
 
         // TODO - try to remove the wait -> a fence should suffice
+        VulkanManager::logQueueApiCall("streamer_wait_idle", h_tsfQueue);
         h_pfn->vkQueueWaitIdle(h_tsfQueue);
     }
 

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -1258,11 +1258,6 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
     if (fbs.empty())
         return;
 
-    if (isQueueSubmissionBlocked())
-    {
-        logQueueApiCall("render_submit_multi_blocked", getQueue(m_graphicsQID));
-        return;
-    }
 
     const uint32_t fenceIndex = m_currentFrameIndex.load() % MAX_FRAMES_IN_FLIGHT;
     VkFence renderFence = m_renderFences[fenceIndex];
@@ -1329,11 +1324,6 @@ void VulkanManager::submitVirtualFramebuffer(TlFramebuffer fb)
 {
     VkResult err;
 
-    if (isQueueSubmissionBlocked())
-    {
-        logQueueApiCall("render_submit_virtual_blocked", getQueue(m_graphicsQID));
-        return;
-    }
     const uint32_t fenceIndex = m_currentFrameIndex.load() % MAX_FRAMES_IN_FLIGHT;
     VkFence renderFence = m_renderFences[fenceIndex];
     m_pfnDev->vkResetFences(m_device, 1, &renderFence);
@@ -1384,20 +1374,6 @@ void VulkanManager::logQueueApiCall(const char* tag, VkQueue queue)
 #endif
 }
 
-void VulkanManager::beginQueueSubmissionBlock()
-{
-    m_blockQueueSubmissions.store(true);
-}
-
-void VulkanManager::endQueueSubmissionBlock()
-{
-    m_blockQueueSubmissions.store(false);
-}
-
-bool VulkanManager::isQueueSubmissionBlocked() const
-{
-    return m_blockQueueSubmissions.load();
-}
 
 void VulkanManager::waitForStreamingIdle()
 {

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -1359,6 +1359,39 @@ void VulkanManager::waitIdle()
     m_pfnDev->vkDeviceWaitIdle(m_device);
 }
 
+void VulkanManager::beginQueueSubmissionBlock()
+{
+    std::unique_lock<std::mutex> lock(m_renderBlockMutex);
+    m_queueSubmissionBlocked = true;
+    m_renderBlockCv.wait(lock, [this]() { return m_renderFrameScopeCount == 0; });
+}
+
+void VulkanManager::endQueueSubmissionBlock()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_renderBlockMutex);
+        m_queueSubmissionBlocked = false;
+    }
+    m_renderBlockCv.notify_all();
+}
+
+void VulkanManager::beginRenderFrameScope()
+{
+    std::unique_lock<std::mutex> lock(m_renderBlockMutex);
+    m_renderBlockCv.wait(lock, [this]() { return !m_queueSubmissionBlocked; });
+    ++m_renderFrameScopeCount;
+}
+
+void VulkanManager::endRenderFrameScope()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_renderBlockMutex);
+        assert(m_renderFrameScopeCount > 0);
+        --m_renderFrameScopeCount;
+    }
+    m_renderBlockCv.notify_all();
+}
+
 std::mutex& VulkanManager::getQueueApiMutex()
 {
     return g_vulkanQueueApiMutex;

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -1258,6 +1258,12 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
     if (fbs.empty())
         return;
 
+    if (isQueueSubmissionBlocked())
+    {
+        logQueueApiCall("render_submit_multi_blocked", getQueue(m_graphicsQID));
+        return;
+    }
+
     const uint32_t fenceIndex = m_currentFrameIndex.load() % MAX_FRAMES_IN_FLIGHT;
     VkFence renderFence = m_renderFences[fenceIndex];
     m_pfnDev->vkResetFences(m_device, 1, &renderFence);
@@ -1322,6 +1328,12 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
 void VulkanManager::submitVirtualFramebuffer(TlFramebuffer fb)
 {
     VkResult err;
+
+    if (isQueueSubmissionBlocked())
+    {
+        logQueueApiCall("render_submit_virtual_blocked", getQueue(m_graphicsQID));
+        return;
+    }
     const uint32_t fenceIndex = m_currentFrameIndex.load() % MAX_FRAMES_IN_FLIGHT;
     VkFence renderFence = m_renderFences[fenceIndex];
     m_pfnDev->vkResetFences(m_device, 1, &renderFence);
@@ -1370,6 +1382,21 @@ void VulkanManager::logQueueApiCall(const char* tag, VkQueue queue)
     (void)tag;
     (void)queue;
 #endif
+}
+
+void VulkanManager::beginQueueSubmissionBlock()
+{
+    m_blockQueueSubmissions.store(true);
+}
+
+void VulkanManager::endQueueSubmissionBlock()
+{
+    m_blockQueueSubmissions.store(false);
+}
+
+bool VulkanManager::isQueueSubmissionBlocked() const
+{
+    return m_blockQueueSubmissions.load();
 }
 
 void VulkanManager::waitForStreamingIdle()

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -36,6 +36,17 @@
 namespace
 {
     std::mutex g_vulkanQueueApiMutex;
+
+#ifndef NDEBUG
+    inline void logQueueCallDebug(const char* tag, VkQueue queue)
+    {
+        Logger::log(LoggerMode::VKLog)
+            << "QueueDiag ; tag=" << tag
+            << " ; thread=" << std::this_thread::get_id()
+            << " ; queue=" << queue
+            << Logger::endl;
+    }
+#endif
 }
 
 void deleteCharPP(uint32_t _count, char* const* _cstringList)
@@ -1273,6 +1284,7 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
     }
     {
         std::lock_guard<std::mutex> lock(getQueueApiMutex());
+        logQueueApiCall("render_submit_multi", getQueue(m_graphicsQID));
         err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), (uint32_t)submitInfos.size(), submitInfos.data(), renderFence);
     }
     check_vk_result(err, "Submit Graphic Queue");
@@ -1289,6 +1301,7 @@ void VulkanManager::submitMultipleFramebuffer(std::vector<TlFramebuffer> fbs)
         // FIXME - Utiliser la bonne queue si la presentation se fait sur une queue diffÃ©rente.
         {
             std::lock_guard<std::mutex> lock(getQueueApiMutex());
+            logQueueApiCall("render_present", getQueue(m_graphicsQID));
             err = m_pfnDev->vkQueuePresentKHR(getQueue(m_graphicsQID), &presentInfo);
         }
         if (err == VK_ERROR_OUT_OF_DATE_KHR || err == VK_SUBOPTIMAL_KHR) {
@@ -1326,6 +1339,7 @@ void VulkanManager::submitVirtualFramebuffer(TlFramebuffer fb)
 
     {
         std::lock_guard<std::mutex> lock(getQueueApiMutex());
+        logQueueApiCall("render_submit_virtual", getQueue(m_graphicsQID));
         err = m_pfnDev->vkQueueSubmit(getQueue(m_graphicsQID), 1, &submitInfo, renderFence);
     }
     check_vk_result(err, "Submit Graphic Queue");
@@ -1346,6 +1360,16 @@ void VulkanManager::waitIdle()
 std::mutex& VulkanManager::getQueueApiMutex()
 {
     return g_vulkanQueueApiMutex;
+}
+
+void VulkanManager::logQueueApiCall(const char* tag, VkQueue queue)
+{
+#ifndef NDEBUG
+    logQueueCallDebug(tag, queue);
+#else
+    (void)tag;
+    (void)queue;
+#endif
 }
 
 void VulkanManager::waitForStreamingIdle()
@@ -1456,7 +1480,9 @@ bool VulkanManager::loadInSimpleBuffer_local(SimpleBuffer& smpBuf, VkDeviceSize 
 
         {
             std::lock_guard<std::mutex> lock(getQueueApiMutex());
+            logQueueApiCall("transfer_submit_load_local", getQueue(m_transferQID));
             m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+            logQueueApiCall("transfer_wait_idle_load_local", getQueue(m_transferQID));
             m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
         }
         //++++++++++++++++++++++++++++
@@ -1629,7 +1655,9 @@ bool VulkanManager::downloadSimpleBuffer_async(const SimpleBuffer& smpBuf, void*
 
             {
                 std::lock_guard<std::mutex> lock(getQueueApiMutex());
+                logQueueApiCall("transfer_submit_download", getQueue(m_transferQID));
                 m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+                logQueueApiCall("transfer_wait_idle_download", getQueue(m_transferQID));
                 m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
             }
             //++++++++++++++++++++++++++++
@@ -3752,7 +3780,9 @@ void VulkanManager::endTransferCommand(VkCommandBuffer _cmdBuffer)
 
     {
         std::lock_guard<std::mutex> lock(getQueueApiMutex());
+        logQueueApiCall("transfer_submit_texture", getQueue(m_transferQID));
         m_pfnDev->vkQueueSubmit(getQueue(m_transferQID), 1, &submitInfo, VK_NULL_HANDLE);
+        logQueueApiCall("transfer_wait_idle_texture", getQueue(m_transferQID));
         m_pfnDev->vkQueueWaitIdle(getQueue(m_transferQID));
     }
 


### PR DESCRIPTION
### Motivation
- Introduce a mechanism to suspend queue submissions at safe frame boundaries to allow project close or resource cleanup without racing with the render loop. 
- Prevent new render-frame submissions while waiting for all active frame scopes to finish, ensuring GPU resources can be freed safely.

### Description
- Added condition variable support and new public APIs on `VulkanManager`: `beginQueueSubmissionBlock`, `endQueueSubmissionBlock`, `beginRenderFrameScope`, and `endRenderFrameScope` to coordinate blocking and scoped frames. 
- Added synchronization members `m_renderBlockMutex`, `m_renderBlockCv`, `m_queueSubmissionBlocked`, and `m_renderFrameScopeCount` to `VulkanManager` and implemented the blocking/wait semantics in `VulkanManager.cpp`. 
- Instrumented the render loop in `RenderingEngine::update` to call `beginRenderFrameScope` at frame start and used an RAII scope guard to ensure `endRenderFrameScope` is called on exit.

### Testing
- Built the project with `cmake --build` and the build completed successfully. 
- Ran automated tests via `ctest --output-on-failure` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ef3e5c60832f8fb8bfdf46f0b442)