### PR TITLE
Add render-pause protocol to VulkanManager and use it during project close and render loop

### DIFF
--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -12,6 +12,7 @@
 #include <queue>
 #include <array>
 #include <future>
+#include <chrono>
 #include <type_traits>
 #include <vector>
 
@@ -156,6 +157,9 @@ public:
     void submitVirtualFramebuffer(TlFramebuffer fb);
     void waitIdle();
     void waitForStreamingIdle();
+    bool requestRenderPauseAndWait(std::chrono::milliseconds timeout);
+    void resumeRender();
+    void waitIfRenderPauseRequested();
     static std::mutex& getQueueApiMutex();
 
     uint32_t getCurrentFrameIndex() const;
@@ -445,6 +449,12 @@ private:
     std::condition_variable m_transfer_cv;
     std::queue<std::function<void()>> m_transferTasks;
     std::thread m_transferThread;
+
+    // Render loop pause protocol (used during project close/load)
+    std::mutex m_renderPauseMutex;
+    std::condition_variable m_renderPauseCv;
+    bool m_renderPauseRequested = false;
+    bool m_renderPauseAck = false;
 
     // Use to free safely any buffers rendered on any framebuffer
     uint32_t m_maxSafeFrame = 0;

--- a/src/controller/controls/ControlProject.cpp
+++ b/src/controller/controls/ControlProject.cpp
@@ -25,6 +25,7 @@
 #include "models/graph/GraphManager.h"
 
 #include "pointCloudEngine/PCE_core.h"
+#include "vulkan/VulkanManager.h"
 
 #include "utils/FilesAndFoldersDefinitions.h"
 #include "utils/Config.h"
@@ -386,6 +387,11 @@ namespace control::project
 
         controller.updateInfo(new GuiDataSplashScreenStart(TEXT_PROJECT_CLOSING, GuiDataSplashScreenStart::SplashScreenType::Display));
 
+        constexpr auto kRenderPauseTimeout = std::chrono::milliseconds(2000);
+        bool renderPaused = VulkanManager::getInstance().requestRenderPauseAndWait(kRenderPauseTimeout);
+        if (!renderPaused)
+            CONTROLLOG << "control::project::Close render pause ack timeout" << LOGENDL;
+
         // Close all project info in the Gui
         controller.getGraphManager().cleanProjectObjects();
         controller.updateInfo(new GuiDataUndoRedoAble(false, false));
@@ -404,6 +410,8 @@ namespace control::project
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             counter++;
         }
+
+        VulkanManager::getInstance().resumeRender();
         controller.updateInfo(new GuiDataSplashScreenEnd(GuiDataSplashScreenEnd::SplashScreenType::Display));
 
         CONTROLLOG << "control::project::Close[end]" << LOGENDL;

--- a/src/pointCloudEngine/RenderingEngine.cpp
+++ b/src/pointCloudEngine/RenderingEngine.cpp
@@ -260,6 +260,10 @@ void RenderingEngine::run()
 
     while (m_stopEngine.load() == false)
     {
+        VulkanManager::getInstance().waitIfRenderPauseRequested();
+        if (m_stopEngine.load() == true)
+            break;
+
         // Introduit une pause possible dans le rendu pour faire autre chose (image HD)
         if (m_doHDRender.load() == true)
             updateHD();

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -1343,6 +1343,50 @@ void VulkanManager::waitIdle()
     m_pfnDev->vkDeviceWaitIdle(m_device);
 }
 
+bool VulkanManager::requestRenderPauseAndWait(std::chrono::milliseconds timeout)
+{
+    {
+        std::lock_guard<std::mutex> lock(m_renderPauseMutex);
+        m_renderPauseRequested = true;
+    }
+    m_renderPauseCv.notify_all();
+
+    std::unique_lock<std::mutex> lock(m_renderPauseMutex);
+    const bool paused = m_renderPauseCv.wait_for(lock, timeout, [this]() {
+        return m_renderPauseAck;
+    });
+
+    if (!paused)
+        VKM_WARNING << "Timeout while waiting render pause acknowledgement." << Logger::endl;
+
+    return paused;
+}
+
+void VulkanManager::resumeRender()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_renderPauseMutex);
+        m_renderPauseRequested = false;
+    }
+    m_renderPauseCv.notify_all();
+}
+
+void VulkanManager::waitIfRenderPauseRequested()
+{
+    std::unique_lock<std::mutex> lock(m_renderPauseMutex);
+    if (!m_renderPauseRequested)
+        return;
+
+    m_renderPauseAck = true;
+    m_renderPauseCv.notify_all();
+
+    m_renderPauseCv.wait(lock, [this]() {
+        return !m_renderPauseRequested;
+    });
+
+    m_renderPauseAck = false;
+}
+
 std::mutex& VulkanManager::getQueueApiMutex()
 {
     return g_vulkanQueueApiMutex;


### PR DESCRIPTION
### Motivation
- Prevent rendering work from racing with project close/load operations by allowing the render loop to be paused and resumed in a controlled way.

### Description
- Adds a render-pause protocol to `VulkanManager` including members `m_renderPauseMutex`, `m_renderPauseCv`, `m_renderPauseRequested`, and `m_renderPauseAck` and includes `<chrono>` for timeout support.
- Implements `requestRenderPauseAndWait(std::chrono::milliseconds)`, `resumeRender()`, and `waitIfRenderPauseRequested()` in `VulkanManager.cpp` and declares them in `VulkanManager.h`.
- Integrates the pause protocol into the render loop by calling `VulkanManager::getInstance().waitIfRenderPauseRequested()` at the top of `RenderingEngine::run()`.
- Uses the pause protocol in project close flow by calling `VulkanManager::getInstance().requestRenderPauseAndWait(kRenderPauseTimeout)` before project cleanup and `VulkanManager::getInstance().resumeRender()` afterwards, with a 2s timeout and a warning log on timeout.

### Testing
- No new automated tests were added for this change.
- The existing automated test suite and build were executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f4e457c8832f8fdf222d6bc9ac6a)