### PR TITLE
Add optional smooth transitions for viewpoint animations with monotonic cubic timing

### DIFF
--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -180,6 +180,7 @@
 //ViewPointAnimation
 #define Key_AnimationMode "AnimationMode"
 #define Key_AnimationLines "AnimationLines"
+#define Key_SmoothTransitions "SmoothTransitions"
 #define Key_ViewPointId "ViewPointId"
 #define Key_Position "Position"
 

--- a/include/models/application/ViewPointAnimation.h
+++ b/include/models/application/ViewPointAnimation.h
@@ -34,12 +34,14 @@ public:
     const QString& getName() const;
     uint32_t getOrder() const;
     ViewPointAnimationMode getMode() const;
+    bool getSmoothTransitions() const;
     const std::vector<ViewPointAnimationLine>& getLines() const;
 
     void setId(const viewPointAnimationId& id);
     void setName(const QString& name);
     void setOrder(uint32_t order);
     void setMode(ViewPointAnimationMode mode);
+    void setSmoothTransitions(bool smoothTransitions);
     void setLines(const std::vector<ViewPointAnimationLine>& lines);
 
 private:
@@ -47,6 +49,7 @@ private:
     QString m_name;
     uint32_t m_order;
     ViewPointAnimationMode m_mode;
+    bool m_smoothTransitions;
     std::vector<ViewPointAnimationLine> m_lines;
 };
 

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -98,7 +98,7 @@ public:
     void cleanAnimation();
     void setSpeed(const int& speed);
     void setLoop(const bool& loop);
-    void setAnimationTiming(ViewPointAnimationMode mode, double durationSeconds, const std::vector<double>& controlPointTimesSec);
+    void setAnimationTiming(ViewPointAnimationMode mode, double durationSeconds, const std::vector<double>& controlPointTimesSec, bool smoothTransitions);
 
     // Orientation as Euler angles
     void yaw(double _amount);
@@ -190,6 +190,9 @@ private:
     void buildCatmullRomPlaybackPathFromTrajectory();
     void applyPlaybackTimingFromControlPoints();
     static double smoothstep01(double t);
+    static double smootherstep01(double t);
+    static std::vector<double> computeMonotonicCubicSlopes(const std::vector<double>& x, const std::vector<double>& y);
+    static double evaluateMonotonicCubicHermite(const std::vector<double>& x, const std::vector<double>& y, const std::vector<double>& slopes, double xQuery);
     static glm::dvec3 evaluateCentripetalCatmullRom(
         const glm::dvec3& p0,
         const glm::dvec3& p1,
@@ -321,6 +324,7 @@ private:
     ViewPointAnimationMode m_viewPointAnimationMode = ViewPointAnimationMode::ConstantSpeed;
     double m_animationDurationSeconds = 0.0;
     std::vector<double> m_controlPointTimesSeconds;
+    bool m_smoothViewpointTransitions = false;
     SimpleAnimation m_simpleAnimation = SimpleAnimation();
     // Uniform for projection and view matrix (separated)
     VkMultiUniform m_uniProjView;

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -300,7 +300,7 @@ namespace control::animation
         wCam->cleanAnimation();
         wCam->setLoop(false);
         wCam->setSpeed(1);
-        wCam->setAnimationTiming(itConfig->second.getMode(), static_cast<double>(m_lengthSeconds), controlTimes);
+        wCam->setAnimationTiming(itConfig->second.getMode(), static_cast<double>(m_lengthSeconds), controlTimes, itConfig->second.getSmoothTransitions());
         for (const SafePtr<ViewPointNode>& viewpoint : viewpoints)
             wCam->AddViewPoint(viewpoint);
 

--- a/src/gui/Dialog/DialogAnimationConfig.cpp
+++ b/src/gui/Dialog/DialogAnimationConfig.cpp
@@ -100,6 +100,7 @@ void DialogAnimationConfig::setupForNew()
     m_ui.lineEdit_animationName->clear();
     m_ui.animationListWidgetTable->setRowCount(0);
     m_ui.positionAsTimeRadioButton->setChecked(true);
+    m_ui.smoothTransitionsCheckBox->setChecked(false);
     m_ui.deleteButton->setEnabled(false);
     m_ui.lineEdit_animationName->setFocus();
 }
@@ -300,6 +301,8 @@ void DialogAnimationConfig::setCurrentConfigToUi(const ViewPointAnimationConfig&
     else
         m_ui.constantIntervalsRadioButton->setChecked(true);
 
+    m_ui.smoothTransitionsCheckBox->setChecked(config.getSmoothTransitions());
+
     int row = 0;
     for (const ViewPointAnimationLine& line : config.getLines())
     {
@@ -355,6 +358,7 @@ ViewPointAnimationConfig DialogAnimationConfig::buildConfigFromUi(bool* ok) cons
     config.setMode(m_ui.positionAsTimeRadioButton->isChecked() ? ViewPointAnimationMode::PositionAsTime :
                    m_ui.constantSpeedRadioButton->isChecked() ? ViewPointAnimationMode::ConstantSpeed :
                                                                ViewPointAnimationMode::ConstantIntervals);
+    config.setSmoothTransitions(m_ui.smoothTransitionsCheckBox->isChecked());
     config.setLines(readLinesFromUi(ok));
 
     if (m_isEdition)

--- a/src/gui/forms/DialogAnimationConfig.ui
+++ b/src/gui/forms/DialogAnimationConfig.ui
@@ -31,21 +31,21 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
    <widget class="QPushButton" name="okButton">
      <property name="text">
       <string>Ok</string>
      </property>
    </widget>
   </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QPushButton" name="deleteButton">
      <property name="text">
       <string>Delete</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="2">
+   <item row="9" column="2">
     <widget class="QPushButton" name="cancelButton">
      <property name="text">
       <string>Cancel</string>
@@ -56,6 +56,13 @@
     <widget class="QRadioButton" name="constantIntervalsRadioButton">
      <property name="text">
       <string>Constant intervals</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="QCheckBox" name="smoothTransitionsCheckBox">
+     <property name="text">
+      <string>Smooth transitions</string>
      </property>
     </widget>
    </item>

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -834,6 +834,7 @@ nlohmann::json DataSerializer::Serialize(const ViewPointAnimationConfig& data)
 	json[Key_Name] = Utils::to_utf8(data.getName().toStdWString());
 	json[Key_Order] = data.getOrder();
 	json[Key_AnimationMode] = magic_enum::enum_name(data.getMode());
+	json[Key_SmoothTransitions] = data.getSmoothTransitions();
 
 	nlohmann::json lines = nlohmann::json::array();
 	for (const ViewPointAnimationLine& line : data.getLines())

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -2834,6 +2834,11 @@ bool DataDeserializer::DeserializeViewPointAnimation(const nlohmann::json& json,
     }
     data.setMode(mode);
 
+    bool smoothTransitions = false;
+    if (json.find(Key_SmoothTransitions) != json.end())
+        smoothTransitions = json.at(Key_SmoothTransitions).get<bool>();
+    data.setSmoothTransitions(smoothTransitions);
+
     std::vector<ViewPointAnimationLine> lines;
     if (json.find(Key_AnimationLines) != json.end() && json.at(Key_AnimationLines).is_array())
     {

--- a/src/models/application/ViewPointAnimation.cpp
+++ b/src/models/application/ViewPointAnimation.cpp
@@ -4,12 +4,14 @@ ViewPointAnimationConfig::ViewPointAnimationConfig()
     : m_id(xg::newGuid())
     , m_order(0)
     , m_mode(ViewPointAnimationMode::PositionAsTime)
+    , m_smoothTransitions(false)
 {}
 
 ViewPointAnimationConfig::ViewPointAnimationConfig(viewPointAnimationId id)
     : m_id(id)
     , m_order(0)
     , m_mode(ViewPointAnimationMode::PositionAsTime)
+    , m_smoothTransitions(false)
 {}
 
 viewPointAnimationId ViewPointAnimationConfig::getId() const
@@ -30,6 +32,11 @@ uint32_t ViewPointAnimationConfig::getOrder() const
 ViewPointAnimationMode ViewPointAnimationConfig::getMode() const
 {
     return m_mode;
+}
+
+bool ViewPointAnimationConfig::getSmoothTransitions() const
+{
+    return m_smoothTransitions;
 }
 
 const std::vector<ViewPointAnimationLine>& ViewPointAnimationConfig::getLines() const
@@ -55,6 +62,11 @@ void ViewPointAnimationConfig::setOrder(uint32_t order)
 void ViewPointAnimationConfig::setMode(ViewPointAnimationMode mode)
 {
     m_mode = mode;
+}
+
+void ViewPointAnimationConfig::setSmoothTransitions(bool smoothTransitions)
+{
+    m_smoothTransitions = smoothTransitions;
 }
 
 void ViewPointAnimationConfig::setLines(const std::vector<ViewPointAnimationLine>& lines)

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -716,11 +716,12 @@ bool CameraNode::resumeAnimation()
     return true;
 }
 
-void CameraNode::setAnimationTiming(ViewPointAnimationMode mode, double durationSeconds, const std::vector<double>& controlPointTimesSec)
+void CameraNode::setAnimationTiming(ViewPointAnimationMode mode, double durationSeconds, const std::vector<double>& controlPointTimesSec, bool smoothTransitions)
 {
     m_viewPointAnimationMode = mode;
     m_animationDurationSeconds = std::max(0.0, durationSeconds);
     m_controlPointTimesSeconds = controlPointTimesSec;
+    m_smoothViewpointTransitions = smoothTransitions;
 }
 
 void CameraNode::cleanAnimation()
@@ -1510,6 +1511,102 @@ double CameraNode::smoothstep01(double t)
     return clamped * clamped * (3.0 - 2.0 * clamped);
 }
 
+double CameraNode::smootherstep01(double t)
+{
+    const double clamped = std::clamp(t, 0.0, 1.0);
+    return clamped * clamped * clamped * (clamped * (clamped * 6.0 - 15.0) + 10.0);
+}
+
+std::vector<double> CameraNode::computeMonotonicCubicSlopes(const std::vector<double>& x, const std::vector<double>& y)
+{
+    const size_t count = x.size();
+    std::vector<double> slopes(count, 0.0);
+    if (count < 2 || y.size() != count)
+        return slopes;
+
+    std::vector<double> h(count - 1, 0.0);
+    std::vector<double> delta(count - 1, 0.0);
+    for (size_t i = 0; i + 1 < count; ++i)
+    {
+        h[i] = std::max(x[i + 1] - x[i], 1e-9);
+        delta[i] = (y[i + 1] - y[i]) / h[i];
+    }
+
+    slopes.front() = delta.front();
+    slopes.back() = delta.back();
+
+    if (count == 2)
+        return slopes;
+
+    for (size_t i = 1; i + 1 < count; ++i)
+    {
+        if (delta[i - 1] * delta[i] <= 0.0)
+        {
+            slopes[i] = 0.0;
+            continue;
+        }
+
+        const double w1 = 2.0 * h[i] + h[i - 1];
+        const double w2 = h[i] + 2.0 * h[i - 1];
+        slopes[i] = (w1 + w2) / (w1 / delta[i - 1] + w2 / delta[i]);
+    }
+
+    const auto clampEndpointSlope = [](double endpointSlope, double endpointDelta, double neighborDelta)
+    {
+        if (endpointDelta == 0.0)
+            return 0.0;
+        if (endpointSlope * endpointDelta <= 0.0)
+            return 0.0;
+        if (endpointDelta * neighborDelta < 0.0 && std::abs(endpointSlope) > std::abs(3.0 * endpointDelta))
+            return 3.0 * endpointDelta;
+        return endpointSlope;
+    };
+
+    const double d0 = delta[0];
+    const double d1 = delta[1];
+    const double h0 = h[0];
+    const double h1 = h[1];
+    const double m0 = ((2.0 * h0 + h1) * d0 - h0 * d1) / (h0 + h1);
+    slopes[0] = clampEndpointSlope(m0, d0, d1);
+
+    const size_t last = count - 1;
+    const double dn1 = delta[last - 1];
+    const double dn2 = delta[last - 2];
+    const double hn1 = h[last - 1];
+    const double hn2 = h[last - 2];
+    const double mn = ((2.0 * hn1 + hn2) * dn1 - hn1 * dn2) / (hn1 + hn2);
+    slopes[last] = clampEndpointSlope(mn, dn1, dn2);
+
+    return slopes;
+}
+
+double CameraNode::evaluateMonotonicCubicHermite(const std::vector<double>& x, const std::vector<double>& y, const std::vector<double>& slopes, double xQuery)
+{
+    if (x.size() < 2 || y.size() != x.size() || slopes.size() != x.size())
+        return 0.0;
+
+    if (xQuery <= x.front())
+        return y.front();
+    if (xQuery >= x.back())
+        return y.back();
+
+    auto upper = std::upper_bound(x.begin(), x.end(), xQuery);
+    size_t i = static_cast<size_t>(std::distance(x.begin(), upper) - 1);
+    i = std::min(i, x.size() - 2);
+
+    const double x0 = x[i];
+    const double x1 = x[i + 1];
+    const double h = std::max(x1 - x0, 1e-9);
+    const double t = std::clamp((xQuery - x0) / h, 0.0, 1.0);
+
+    const double h00 = (2.0 * t * t * t - 3.0 * t * t + 1.0);
+    const double h10 = (t * t * t - 2.0 * t * t + t);
+    const double h01 = (-2.0 * t * t * t + 3.0 * t * t);
+    const double h11 = (t * t * t - t * t);
+
+    return h00 * y[i] + h10 * h * slopes[i] + h01 * y[i + 1] + h11 * h * slopes[i + 1];
+}
+
 void CameraNode::applyPlaybackTimingFromControlPoints()
 {
     if (m_trajectory.size() < 2 || m_orientationTrajectory.size() != m_trajectory.size())
@@ -1569,20 +1666,72 @@ void CameraNode::applyPlaybackTimingFromControlPoints()
         segmentEndIndices.back() = cumulativeDistances.size() - 1;
 
         m_trajectory[0].dtime_arrival = controlTimes[0];
-        for (size_t seg = 0; seg < segmentCount; ++seg)
+        if (!m_smoothViewpointTransitions)
         {
-            const size_t startIdx = segmentStartIndices[seg];
-            const size_t maxIndex = cumulativeDistances.size() - 1;
-            const size_t endIdx = std::min(std::max(segmentEndIndices[seg], std::min(startIdx + 1, maxIndex)), maxIndex);
-            const double startDistance = cumulativeDistances[startIdx];
-            const double endDistance = cumulativeDistances[endIdx];
-            const double segmentDuration = std::max(0.001, controlTimes[seg + 1] - controlTimes[seg]);
-            for (size_t i = startIdx + 1; i <= endIdx; ++i)
+            for (size_t seg = 0; seg < segmentCount; ++seg)
             {
-                const double segmentAlpha = (endDistance > startDistance) ? (cumulativeDistances[i] - startDistance) / (endDistance - startDistance) : static_cast<double>(i - startIdx) / static_cast<double>(endIdx - startIdx);
-                const double easedAlpha = smoothstep01(segmentAlpha);
-                m_trajectory[i].dtime_arrival = controlTimes[seg] + segmentDuration * easedAlpha;
+                const size_t startIdx = segmentStartIndices[seg];
+                const size_t maxIndex = cumulativeDistances.size() - 1;
+                const size_t endIdx = std::min(std::max(segmentEndIndices[seg], std::min(startIdx + 1, maxIndex)), maxIndex);
+                const double startDistance = cumulativeDistances[startIdx];
+                const double endDistance = cumulativeDistances[endIdx];
+                const double segmentDuration = std::max(0.001, controlTimes[seg + 1] - controlTimes[seg]);
+                for (size_t i = startIdx + 1; i <= endIdx; ++i)
+                {
+                    const double segmentAlpha = (endDistance > startDistance) ? (cumulativeDistances[i] - startDistance) / (endDistance - startDistance) : static_cast<double>(i - startIdx) / static_cast<double>(endIdx - startIdx);
+                    const double easedAlpha = smoothstep01(segmentAlpha);
+                    m_trajectory[i].dtime_arrival = controlTimes[seg] + segmentDuration * easedAlpha;
+                }
             }
+        }
+        else
+        {
+            // Smoother mode (Option B): use a monotonic cubic interpolation of time over path progress.
+            // This keeps a strictly increasing timeline while avoiding abrupt speed changes at viewpoints.
+            std::vector<double> controlRatios(controlTimes.size(), 0.0);
+            controlRatios.front() = 0.0;
+            for (size_t seg = 0; seg < segmentCount; ++seg)
+            {
+                const size_t maxIndex = cumulativeDistances.size() - 1;
+                const size_t endIdx = std::min(segmentEndIndices[seg], maxIndex);
+                controlRatios[seg + 1] = (totalDistance > 1e-9)
+                    ? std::clamp(cumulativeDistances[endIdx] / totalDistance, 0.0, 1.0)
+                    : static_cast<double>(seg + 1) / static_cast<double>(segmentCount);
+            }
+
+            for (size_t i = 1; i < controlRatios.size(); ++i)
+            {
+                if (controlRatios[i] <= controlRatios[i - 1])
+                    controlRatios[i] = std::min(1.0, controlRatios[i - 1] + 1e-6);
+            }
+            controlRatios.back() = 1.0;
+
+            std::vector<double> smoothedControlTimes = controlTimes;
+            if (smoothedControlTimes.size() >= 2)
+            {
+                for (size_t i = 1; i + 1 < smoothedControlTimes.size(); ++i)
+                {
+                    const double neighborAverage = 0.5 * (controlTimes[i - 1] + controlTimes[i + 1]);
+                    const double blended = controlTimes[i] + (neighborAverage - controlTimes[i]) * 0.2;
+                    smoothedControlTimes[i] = std::clamp(blended, controlTimes[i - 1] + 1e-6, controlTimes[i + 1] - 1e-6);
+                }
+            }
+
+            const std::vector<double> slopes = computeMonotonicCubicSlopes(controlRatios, smoothedControlTimes);
+            for (size_t i = 1; i < m_trajectory.size(); ++i)
+            {
+                const double ratio = (totalDistance > 1e-9)
+                    ? std::clamp(cumulativeDistances[i] / totalDistance, 0.0, 1.0)
+                    : static_cast<double>(i) / static_cast<double>(m_trajectory.size() - 1);
+                const double easedRatio = smootherstep01(ratio);
+                const double blendRatio = std::clamp(0.75 * ratio + 0.25 * easedRatio, 0.0, 1.0);
+                m_trajectory[i].dtime_arrival = evaluateMonotonicCubicHermite(controlRatios, smoothedControlTimes, slopes, blendRatio);
+            }
+
+            for (size_t i = 1; i < m_trajectory.size(); ++i)
+                m_trajectory[i].dtime_arrival = std::max(m_trajectory[i].dtime_arrival, m_trajectory[i - 1].dtime_arrival + 1e-6);
+
+            m_trajectory.back().dtime_arrival = std::max(controlTimes.back(), m_trajectory[m_trajectory.size() - 2].dtime_arrival + 1e-6);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Provide an option to produce smoother viewpoint playback timing to avoid abrupt speed changes when animating between viewpoints.
- Persist the preference in animation configs and expose it in the animation configurator UI.
- Implement a numerically-stable monotonic cubic timing interpolation to keep arrival times strictly increasing while smoothing speed profiles.

### Description
- Added a new serialization key `Key_SmoothTransitions` and wired it into `DataSerializer::Serialize` and `DataDeserializer::DeserializeViewPointAnimation`.
- Extended `ViewPointAnimationConfig` with a `bool m_smoothTransitions` member and corresponding `getSmoothTransitions` and `setSmoothTransitions` methods, initialized to `false` in constructors.
- Updated the animation dialog UI to include `smoothTransitionsCheckBox`, and read/write its state in `DialogAnimationConfig::setCurrentConfigToUi` and `buildConfigFromUi`.
- Propagated the option through controls by changing `CameraNode::setAnimationTiming` to accept a `bool smoothTransitions`, storing it in `m_smoothViewpointTransitions` and updating call sites in `ControlAnimation`.
- Implemented smoother timing algorithms in `CameraNode`: added `smootherstep01`, `computeMonotonicCubicSlopes`, and `evaluateMonotonicCubicHermite`, and updated `applyPlaybackTimingFromControlPoints` to branch between eased segment-by-segment timing (`smoothstep01`) and a monotonic cubic Hermite based smoothing when `m_smoothViewpointTransitions` is enabled.

### Testing
- Built the project (full compile) successfully.
- Executed the repository's automated unit test suite and all tests passed.
- Ran the existing automated animation-related tests (where present) and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f89c98e8832f9d7dcc92cea9f2b5)