### PR TITLE
Interpolate rendering parameters between viewpoints during animations (optional)

### DIFF
--- a/include/controller/controls/ControlAnimation.h
+++ b/include/controller/controls/ControlAnimation.h
@@ -35,13 +35,14 @@ namespace control::animation
     class PrepareViewpointsAnimation : public AControl
     {
     public:
-        PrepareViewpointsAnimation(const viewPointAnimationId& animationId, int lengthSeconds);
+        PrepareViewpointsAnimation(const viewPointAnimationId& animationId, int lengthSeconds, bool interpolateRenderingBetweenViewpoints);
         ~PrepareViewpointsAnimation();
         void doFunction(Controller& controller) override;
         ControlType getType() const override;
     private:
         viewPointAnimationId m_animationId;
         int m_lengthSeconds;
+        bool m_interpolateRenderingBetweenViewpoints;
     };
 
     class RefreshViewpointsAnimationState : public AControl

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -377,11 +377,12 @@ public:
 class GuiDataRenderStartAnimation : public IGuiData
 {
 public:
-	GuiDataRenderStartAnimation(bool isOrbital = false, double durationSeconds = 0.0, bool resume = false, int orbitalDegrees = 360)
+	GuiDataRenderStartAnimation(bool isOrbital = false, double durationSeconds = 0.0, bool resume = false, int orbitalDegrees = 360, bool interpolateViewpointRenderings = false)
 		: m_isOrbital(isOrbital)
 		, m_durationSeconds(durationSeconds)
 		, m_resume(resume)
 		, m_orbitalDegrees(orbitalDegrees)
+		, m_interpolateViewpointRenderings(interpolateViewpointRenderings)
 	{}
 	~GuiDataRenderStartAnimation() {}
 	virtual guiDType getType() override;
@@ -390,6 +391,7 @@ public:
 	const double m_durationSeconds;
 	const bool m_resume;
 	const int m_orbitalDegrees;
+	const bool m_interpolateViewpointRenderings;
 };
 
 class GuiDataRenderPauseAnimation : public IGuiData

--- a/include/gui/texts/ContextTexts.hpp
+++ b/include/gui/texts/ContextTexts.hpp
@@ -150,6 +150,7 @@
 //ContextAnimation
 #define TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS QObject::tr("At least two perspective viewpoints are required to start the animation.")
 #define TEXT_CONTEXT_ANIMATION_INCONSISTENT_TIMES QObject::tr("The table of viewpoints contains inconsistent time values. Times must be increasing. Example: if you have entered 5 in the Position field for a row in the table, then you must enter a higher value in the next row, for example 6.")
+#define TEXT_CONTEXT_ANIMATION_INCONSISTENT_INTERPOLATION QObject::tr("Some viewpoints are inconsistent and cannot be used for interpolation.")
 
 //ContextMoveManip
 #define TEXT_MOVE_MANIP_START QObject::tr("Select a temporary position for the manipulator.")

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -41,6 +41,20 @@ struct SimpleAnimation {
     KeyPoint end;
 };
 
+struct ViewpointRenderState
+{
+    float transparency = 0.0f;
+    float normalStrength = 0.0f;
+    float normalGloss = 0.0f;
+    float hue = 0.0f;
+    float brightness = 0.0f;
+    float saturation = 0.0f;
+    float luminance = 0.0f;
+    float contrast = 0.0f;
+    float alphaObject = 0.0f;
+    float fovy = 0.0f;
+};
+
 enum class InterpolationValueWithPreviousAnimation { NONE, BEZIER/*, LINEAR*/ };
 
 class CameraNode : public AGraphNode, public IPanel, public RenderingParameters
@@ -99,6 +113,7 @@ public:
     void setSpeed(const int& speed);
     void setLoop(const bool& loop);
     void setAnimationTiming(ViewPointAnimationMode mode, double durationSeconds, const std::vector<double>& controlPointTimesSec, bool smoothTransitions);
+    void setViewpointRenderInterpolationEnabled(bool enabled);
 
     // Orientation as Euler angles
     void yaw(double _amount);
@@ -205,6 +220,12 @@ private:
     static glm::dquat quaternionLog(const glm::dquat& q);
     static glm::dquat quaternionExp(const glm::dquat& q);
     static void enforceQuaternionSignContinuity(std::vector<glm::dquat>& quaternions);
+    void resetViewpointRenderInterpolation();
+    void initializeViewpointRenderInterpolationControlTimes();
+    void applyViewpointRenderInterpolation(double elapsedAnimationSeconds);
+    static ViewpointRenderState buildViewpointRenderState(const ViewPointNode& viewpoint);
+    static ViewpointRenderState lerpViewpointRenderState(const ViewpointRenderState& start, const ViewpointRenderState& end, double t);
+    void applyViewpointRenderState(const ViewpointRenderState& state);
 
     void applyProjection(const ProjectionData& projectionData);
 
@@ -325,6 +346,9 @@ private:
     double m_animationDurationSeconds = 0.0;
     std::vector<double> m_controlPointTimesSeconds;
     bool m_smoothViewpointTransitions = false;
+    bool m_interpolateViewpointRenderings = false;
+    std::vector<ViewpointRenderState> m_viewpointRenderStates;
+    std::vector<double> m_renderControlPointTimesSeconds;
     SimpleAnimation m_simpleAnimation = SimpleAnimation();
     // Uniform for projection and view matrix (separated)
     VkMultiUniform m_uniProjView;

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -152,6 +152,43 @@ namespace control::animation
 
             return viewpoints;
         }
+
+        bool areViewpointsInterpolationCompatible(const ViewPointNode& reference, const ViewPointNode& candidate)
+        {
+            return reference.m_mode == candidate.m_mode &&
+                reference.m_blendMode == candidate.m_blendMode &&
+                reference.m_reduceFlash == candidate.m_reduceFlash &&
+                reference.m_flashAdvanced == candidate.m_flashAdvanced &&
+                reference.m_negativeEffect == candidate.m_negativeEffect &&
+                reference.m_postRenderingNormals.show == candidate.m_postRenderingNormals.show &&
+                reference.m_postRenderingAmbientOcclusion.enabled == candidate.m_postRenderingAmbientOcclusion.enabled &&
+                reference.m_postRenderingNormals.blendColor == candidate.m_postRenderingNormals.blendColor &&
+                reference.m_edgeAwareBlur.enabled == candidate.m_edgeAwareBlur.enabled &&
+                reference.m_depthLining.enabled == candidate.m_depthLining.enabled &&
+                reference.m_depthLining.strongMode == candidate.m_depthLining.strongMode;
+        }
+
+        bool canInterpolateSelectedViewpoints(const std::vector<SafePtr<ViewPointNode>>& viewpoints)
+        {
+            if (viewpoints.size() < 2)
+                return false;
+
+            ReadPtr<ViewPointNode> rReference = viewpoints.front().cget();
+            if (!rReference)
+                return false;
+
+            for (size_t i = 1; i < viewpoints.size(); ++i)
+            {
+                ReadPtr<ViewPointNode> rCandidate = viewpoints[i].cget();
+                if (!rCandidate)
+                    return false;
+
+                if (!areViewpointsInterpolationCompatible(*&rReference, *&rCandidate))
+                    return false;
+            }
+
+            return true;
+        }
     }
 
     AddViewPoint::AddViewPoint(SafePtr<AGraphNode> toAdd)
@@ -230,9 +267,10 @@ namespace control::animation
         return ControlType::addScansAnimationKeyPoint;
     }
 
-    PrepareViewpointsAnimation::PrepareViewpointsAnimation(const viewPointAnimationId& animationId, int lengthSeconds)
+    PrepareViewpointsAnimation::PrepareViewpointsAnimation(const viewPointAnimationId& animationId, int lengthSeconds, bool interpolateRenderingBetweenViewpoints)
         : m_animationId(animationId)
         , m_lengthSeconds(lengthSeconds)
+        , m_interpolateRenderingBetweenViewpoints(interpolateRenderingBetweenViewpoints)
     {}
 
     PrepareViewpointsAnimation::~PrepareViewpointsAnimation()
@@ -300,6 +338,16 @@ namespace control::animation
         wCam->cleanAnimation();
         wCam->setLoop(false);
         wCam->setSpeed(1);
+
+        bool enableInterpolation = false;
+        if (m_interpolateRenderingBetweenViewpoints)
+        {
+            enableInterpolation = canInterpolateSelectedViewpoints(viewpoints);
+            if (!enableInterpolation)
+                controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_INCONSISTENT_INTERPOLATION));
+        }
+        wCam->setViewpointRenderInterpolationEnabled(enableInterpolation);
+
         wCam->setAnimationTiming(itConfig->second.getMode(), static_cast<double>(m_lengthSeconds), controlTimes, itConfig->second.getSmoothTransitions());
         for (const SafePtr<ViewPointNode>& viewpoint : viewpoints)
             wCam->AddViewPoint(viewpoint);

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -207,7 +207,7 @@ void ToolBarAnimationGroup::slotStartAnimation()
 		m_isStopRequested = false;
 		m_pendingViewpointsStart = false;
 		m_waitingChronometerStartAtFirstViewpoint = false;
-		m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), true, m_ui.degreesSpinBox->value()));
+		m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), true, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked()));
 		startChronometer();
 		m_isStarted = true;
 		m_isPaused = false;
@@ -237,7 +237,7 @@ void ToolBarAnimationGroup::slotStartAnimation()
 		}
 
 		m_pendingViewpointsStart = true;
-		m_dataDispatcher.sendControl(new control::animation::PrepareViewpointsAnimation(selectedConfig->getId(), m_ui.lengthSpinBox->value()));
+		m_dataDispatcher.sendControl(new control::animation::PrepareViewpointsAnimation(selectedConfig->getId(), m_ui.lengthSpinBox->value(), m_ui.interpolateCheckBox->isChecked()));
 		updateUI();
 		return;
 	}
@@ -250,7 +250,7 @@ void ToolBarAnimationGroup::slotStartAnimation()
 		<< LOGENDL;
 	m_isStopRequested = false;
 	m_waitingChronometerStartAtFirstViewpoint = viewpointsMode;
-	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value()));
+	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked()));
 	if (!viewpointsMode)
 		startChronometer();
 	m_isStarted = true;
@@ -264,7 +264,7 @@ void ToolBarAnimationGroup::startViewpointsAnimationPlayback()
 	resetChronometer();
 	m_isStopRequested = false;
 	m_waitingChronometerStartAtFirstViewpoint = true;
-	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(false, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value()));
+	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(false, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked()));
 	m_isStarted = true;
 	m_isPaused = false;
 	m_isOrbitalRunning = false;

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -218,6 +218,7 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
     }
     else
     {
+        wCam->setViewpointRenderInterpolationEnabled(startData->m_interpolateViewpointRenderings);
         const bool started = wCam->startAnimation(m_saveImagesAnim);
         m_viewpointStartInputLockArmed = started;
         GUI_LOG << "[ANIM_DBG] viewport start request viewpoints started=" << started

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -646,6 +646,25 @@ bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
         return false;
     }
 
+    if (m_interpolateViewpointRenderings)
+    {
+        m_viewpointRenderStates.clear();
+        m_viewpointRenderStates.reserve(m_animationPlaylist.size());
+        for (const SafePtr<ViewPointNode>& vp : m_animationPlaylist)
+        {
+            ReadPtr<ViewPointNode> rViewPoint = vp.cget();
+            if (!rViewPoint)
+            {
+                m_interpolateViewpointRenderings = false;
+                resetViewpointRenderInterpolation();
+                break;
+            }
+            m_viewpointRenderStates.push_back(buildViewpointRenderState(*&rViewPoint));
+        }
+        if (m_interpolateViewpointRenderings)
+            initializeViewpointRenderInterpolationControlTimes();
+    }
+
     buildViewpointAnimationPlaybackPath();
 
     if (m_trajectory.size() < 2)
@@ -692,6 +711,7 @@ bool CameraNode::endAnimation()
     m_currentKeyPoint = 0;
     m_animFrames = 0;
     m_totalPausedDurationSeconds = 0.0;
+    resetViewpointRenderInterpolation();
     return wasAnimated;
 }
 
@@ -724,6 +744,13 @@ void CameraNode::setAnimationTiming(ViewPointAnimationMode mode, double duration
     m_smoothViewpointTransitions = smoothTransitions;
 }
 
+void CameraNode::setViewpointRenderInterpolationEnabled(bool enabled)
+{
+    m_interpolateViewpointRenderings = enabled;
+    if (!enabled)
+        resetViewpointRenderInterpolation();
+}
+
 void CameraNode::cleanAnimation()
 {
     m_animationPlaylist.clear();
@@ -734,6 +761,7 @@ void CameraNode::cleanAnimation()
     m_animFrames = 0;
     m_isAnimationPaused = false;
     m_totalPausedDurationSeconds = 0.0;
+    resetViewpointRenderInterpolation();
 }
 
 void CameraNode::setSpeed(const int& speed)
@@ -1313,6 +1341,8 @@ bool CameraNode::animateViewpointTrajectory()
         dtime = std::max(0.0, elapsedSeconds) * ((m_speed > 0.0) ? m_speed : 1.0);
     }
 
+    applyViewpointRenderInterpolation(dtime);
+
     if (m_currentKeyPoint >= m_trajectory.size())
         return true;
 
@@ -1404,6 +1434,112 @@ bool CameraNode::animateViewpointTrajectory()
     }
 
     return true;
+}
+
+void CameraNode::resetViewpointRenderInterpolation()
+{
+    m_viewpointRenderStates.clear();
+    m_renderControlPointTimesSeconds.clear();
+}
+
+void CameraNode::initializeViewpointRenderInterpolationControlTimes()
+{
+    m_renderControlPointTimesSeconds.clear();
+    if (m_viewpointRenderStates.size() < 2)
+        return;
+
+    if (m_viewPointAnimationMode == ViewPointAnimationMode::PositionAsTime && m_controlPointTimesSeconds.size() == m_viewpointRenderStates.size())
+    {
+        m_renderControlPointTimesSeconds = m_controlPointTimesSeconds;
+        const double firstTime = m_renderControlPointTimesSeconds.front();
+        for (double& controlTime : m_renderControlPointTimesSeconds)
+            controlTime -= firstTime;
+        return;
+    }
+
+    const double targetDuration = std::max(m_animationDurationSeconds, 0.001);
+    const size_t lastIndex = m_viewpointRenderStates.size() - 1;
+    m_renderControlPointTimesSeconds.resize(m_viewpointRenderStates.size(), 0.0);
+    for (size_t i = 0; i <= lastIndex; ++i)
+        m_renderControlPointTimesSeconds[i] = targetDuration * static_cast<double>(i) / static_cast<double>(lastIndex);
+}
+
+void CameraNode::applyViewpointRenderInterpolation(double elapsedAnimationSeconds)
+{
+    if (!m_interpolateViewpointRenderings || m_viewpointRenderStates.size() < 2 || m_renderControlPointTimesSeconds.size() != m_viewpointRenderStates.size())
+        return;
+
+    const double clampedTime = std::clamp(elapsedAnimationSeconds, m_renderControlPointTimesSeconds.front(), m_renderControlPointTimesSeconds.back());
+    auto upperBound = std::upper_bound(m_renderControlPointTimesSeconds.begin(), m_renderControlPointTimesSeconds.end(), clampedTime);
+
+    if (upperBound == m_renderControlPointTimesSeconds.begin())
+    {
+        applyViewpointRenderState(m_viewpointRenderStates.front());
+        return;
+    }
+
+    if (upperBound == m_renderControlPointTimesSeconds.end())
+    {
+        applyViewpointRenderState(m_viewpointRenderStates.back());
+        return;
+    }
+
+    const size_t rightIndex = static_cast<size_t>(std::distance(m_renderControlPointTimesSeconds.begin(), upperBound));
+    const size_t leftIndex = rightIndex - 1;
+    const double leftTime = m_renderControlPointTimesSeconds[leftIndex];
+    const double rightTime = m_renderControlPointTimesSeconds[rightIndex];
+    const double safeDuration = std::max(rightTime - leftTime, 1e-9);
+    const double alpha = std::clamp((clampedTime - leftTime) / safeDuration, 0.0, 1.0);
+
+    const ViewpointRenderState interpolatedState = lerpViewpointRenderState(m_viewpointRenderStates[leftIndex], m_viewpointRenderStates[rightIndex], alpha);
+    applyViewpointRenderState(interpolatedState);
+}
+
+ViewpointRenderState CameraNode::buildViewpointRenderState(const ViewPointNode& viewpoint)
+{
+    ViewpointRenderState state;
+    state.transparency = viewpoint.m_transparency;
+    state.normalStrength = viewpoint.m_postRenderingNormals.normalStrength;
+    state.normalGloss = viewpoint.m_postRenderingNormals.gloss;
+    state.hue = viewpoint.m_hue;
+    state.brightness = viewpoint.m_brightness;
+    state.saturation = viewpoint.m_saturation;
+    state.luminance = viewpoint.m_luminance;
+    state.contrast = viewpoint.m_contrast;
+    state.alphaObject = viewpoint.m_alphaObject;
+    state.fovy = viewpoint.getFovy();
+    return state;
+}
+
+ViewpointRenderState CameraNode::lerpViewpointRenderState(const ViewpointRenderState& start, const ViewpointRenderState& end, double t)
+{
+    const float alpha = static_cast<float>(std::clamp(t, 0.0, 1.0));
+    ViewpointRenderState state;
+    state.transparency = start.transparency + (end.transparency - start.transparency) * alpha;
+    state.normalStrength = start.normalStrength + (end.normalStrength - start.normalStrength) * alpha;
+    state.normalGloss = start.normalGloss + (end.normalGloss - start.normalGloss) * alpha;
+    state.hue = start.hue + (end.hue - start.hue) * alpha;
+    state.brightness = start.brightness + (end.brightness - start.brightness) * alpha;
+    state.saturation = start.saturation + (end.saturation - start.saturation) * alpha;
+    state.luminance = start.luminance + (end.luminance - start.luminance) * alpha;
+    state.contrast = start.contrast + (end.contrast - start.contrast) * alpha;
+    state.alphaObject = start.alphaObject + (end.alphaObject - start.alphaObject) * alpha;
+    state.fovy = start.fovy + (end.fovy - start.fovy) * alpha;
+    return state;
+}
+
+void CameraNode::applyViewpointRenderState(const ViewpointRenderState& state)
+{
+    m_transparency = state.transparency;
+    m_postRenderingNormals.normalStrength = state.normalStrength;
+    m_postRenderingNormals.gloss = state.normalGloss;
+    m_hue = state.hue;
+    m_brightness = state.brightness;
+    m_saturation = state.saturation;
+    m_luminance = state.luminance;
+    m_contrast = state.contrast;
+    m_alphaObject = state.alphaObject;
+    setFovy(state.fovy, false);
 }
 
 void CameraNode::buildViewpointAnimationPlaybackPath()


### PR DESCRIPTION
### Motivation
- Allow smooth transitions of rendering/display parameters (exposure, hue/contrast, normals, fovy, etc.) when playing viewpoint-based animations, optionally enabled by the user if viewpoints are compatible.

### Description
- Add `ViewpointRenderState` and store per-viewpoint render states and control times in `CameraNode`, and add methods `setViewpointRenderInterpolationEnabled`, `resetViewpointRenderInterpolation`, `initializeViewpointRenderInterpolationControlTimes`, `applyViewpointRenderInterpolation`, `buildViewpointRenderState`, `lerpViewpointRenderState`, and `applyViewpointRenderState` to manage interpolation and application of render parameters during playback.
- Apply render-state interpolation each frame in `CameraNode::animateViewpointTrajectory` when enabled, and populate render states in `startAnimation`; reset states on `endAnimation` and `cleanAnimation`.
- Add compatibility checks and helper functions `areViewpointsInterpolationCompatible` and `canInterpolateSelectedViewpoints` in `control::animation`, and extend `PrepareViewpointsAnimation` to accept an `interpolateRenderingBetweenViewpoints` flag to enable interpolation only when viewpoints are compatible (emit a warning otherwise).
- Thread the new option through the UI and commands by extending `GuiDataRenderStartAnimation` with `m_interpolateViewpointRenderings`, passing the checkbox value from `ToolBarAnimationGroup`, and applying it in `VulkanViewport::onRenderStartAnimation` and when preparing viewpoints with `PrepareViewpointsAnimation`.
- Add a new localized text `TEXT_CONTEXT_ANIMATION_INCONSISTENT_INTERPOLATION` for incompatible viewpoint interpolation warnings.

### Testing
- Project build completed successfully after the changes with no compilation errors. 
- Ran automated unit/test suite available in the repository and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81094f09c832fa4b0b0358054a161)