### PR TITLE
Support viewpoint-animation export and refactor preparation logic

### DIFF
--- a/include/controller/controls/ControlAnimation.h
+++ b/include/controller/controls/ControlAnimation.h
@@ -5,11 +5,28 @@
 #include "models/OpenScanToolsModelEssentials.h"
 #include "models/application/ViewPointAnimation.h"
 
+#include <cstddef>
+
 class IPanel;
 class AGraphNode;
 
 namespace control::animation
 {
+    struct ViewpointsAnimationPreparationResult
+    {
+        double effectiveDurationSeconds = 0.0;
+        ViewPointAnimationMode mode = ViewPointAnimationMode::ConstantSpeed;
+        size_t viewpointCount = 0;
+    };
+
+    bool prepareViewpointsAnimationForPlayback(
+        Controller& controller,
+        const viewPointAnimationId& animationId,
+        int lengthSeconds,
+        bool interpolateRenderingBetweenViewpoints,
+        ViewpointsAnimationPreparationResult* result = nullptr,
+        bool emitWarnings = true);
+
     class AddViewPoint : public AControl
     {
     public:

--- a/include/controller/functionSystem/ContextExportVideoHD.h
+++ b/include/controller/functionSystem/ContextExportVideoHD.h
@@ -34,25 +34,10 @@ private:
 	std::filesystem::path m_videoFilePath;
 	int m_exportState = 0;
 
-	long m_totalFrames;
+	long m_totalFrames = 0;
 	long m_animFrame = 0;
 	uint8_t m_frameDigits = 0;
-
-	glm::dvec3 m_addPosition = glm::dvec3(0.);
-	double m_addTheta = 0.;
-	double m_addPhi = 0.;
-
-	float m_addTransp = 0.f;
-	float m_addNGloss = 0.f;
-	float m_addNStren = 0.f;
-	float m_addHue = 0.f;
-	float m_addBright = 0.f;
-	float m_addSatur = 0.f;
-	float m_addLumi = 0.f;
-	float m_addContr = 0.f;
-	float m_addAlpha = 0.f;
-
-	double m_addFovy = 0.;
+	double m_orbitalStepRad = 0.0;
 
 	std::chrono::steady_clock::time_point m_tpStart;
 	DecimationOptions m_precedentOptions;

--- a/include/gui/Dialog/DialogExportVideo.h
+++ b/include/gui/Dialog/DialogExportVideo.h
@@ -20,9 +20,6 @@ public:
     void closeEvent(QCloseEvent* event);
 
 private:
-    void onViewpoint1Click();
-    void onViewpoint2Click();
-
     void onSelectOutFolder();
 	void onSelectOutFile();
 
@@ -36,6 +33,8 @@ private:
 
 public:
     void setAnimationMode(VideoAnimationMode mode);
+    void setViewpointAnimationId(const viewPointAnimationId& animationId);
+    void setOrbitalDegrees(int degrees);
     void setLength(int length);
     void setInterpolateRenderings(bool interpolate);
 
@@ -43,9 +42,10 @@ private:
     Ui::DialogExportVideo m_ui;
     QString m_openPath;
 
-    int m_viewpointToEdit = -1;
 	VideoExportParameters m_parameters;
 	VideoAnimationMode m_animationMode = VideoAnimationMode::BETWEENVIEWPOINTS;
+	viewPointAnimationId m_viewpointAnimationId = xg::Guid();
+	int m_orbitalDegrees = 360;
 	int m_length = 30;
 	bool m_interpolateRenderings = false;
 

--- a/include/io/exports/ExportParameters.hpp
+++ b/include/io/exports/ExportParameters.hpp
@@ -5,6 +5,7 @@
 #include "io/FileUtils.h"
 #include "tls_def.h"
 #include "models/OpenScanToolsModelEssentials.h"
+#include "models/application/ViewPointAnimation.h"
 
 // NOTE - The enums are used for combo box indexes
 //  (*) They must start at 0 and the values increase "naturally".
@@ -69,6 +70,8 @@ struct VideoExportParameters
     int bitrateKbps = 5000;
     std::filesystem::path outputFilePath;
     VideoAnimationMode animMode = VideoAnimationMode::NONE;
+    viewPointAnimationId viewpointAnimationId = xg::Guid();
+    int orbitalDegrees = 360;
     SafePtr<ViewPointNode> start;
     SafePtr<ViewPointNode> finish;
     bool interpolateRenderingBetweenViewpoints = false;

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -276,15 +276,21 @@ namespace control::animation
     PrepareViewpointsAnimation::~PrepareViewpointsAnimation()
     {}
 
-    void PrepareViewpointsAnimation::doFunction(Controller& controller)
+    bool prepareViewpointsAnimationForPlayback(
+        Controller& controller,
+        const viewPointAnimationId& animationId,
+        int lengthSeconds,
+        bool interpolateRenderingBetweenViewpoints,
+        ViewpointsAnimationPreparationResult* result,
+        bool emitWarnings)
     {
         const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().cgetViewPointAnimations();
-        auto itConfig = configs.find(m_animationId);
+        auto itConfig = configs.find(animationId);
         if (itConfig == configs.end())
         {
-            controller.updateInfo(new GuiDataRenderAnimationToolbarState(false));
-            controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
-            return;
+            if (emitWarnings)
+                controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
+            return false;
         }
 
         std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> perspectiveById;
@@ -315,44 +321,66 @@ namespace control::animation
             {
                 if (line.position <= previousTime)
                 {
-                    controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_INCONSISTENT_TIMES));
-                    return;
+                    if (emitWarnings)
+                        controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_INCONSISTENT_TIMES));
+                    return false;
                 }
                 previousTime = line.position;
             }
         }
 
-        const bool canStart = viewpoints.size() >= 2;
-
-        if (!canStart)
+        if (viewpoints.size() < 2)
         {
-            controller.updateInfo(new GuiDataRenderAnimationToolbarState(false));
-            controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
-            return;
+            if (emitWarnings)
+                controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
+            return false;
         }
 
         WritePtr<CameraNode> wCam = controller.getGraphManager().getCameraNode().get();
         if (!wCam)
-            return;
+            return false;
 
         wCam->cleanAnimation();
         wCam->setLoop(false);
         wCam->setSpeed(1);
 
         bool enableInterpolation = false;
-        if (m_interpolateRenderingBetweenViewpoints)
+        if (interpolateRenderingBetweenViewpoints)
         {
             enableInterpolation = canInterpolateSelectedViewpoints(viewpoints);
-            if (!enableInterpolation)
+            if (!enableInterpolation && emitWarnings)
                 controller.updateInfo(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_INCONSISTENT_INTERPOLATION));
         }
         wCam->setViewpointRenderInterpolationEnabled(enableInterpolation);
 
-        wCam->setAnimationTiming(itConfig->second.getMode(), static_cast<double>(m_lengthSeconds), controlTimes, itConfig->second.getSmoothTransitions());
+        wCam->setAnimationTiming(itConfig->second.getMode(), static_cast<double>(lengthSeconds), controlTimes, itConfig->second.getSmoothTransitions());
         for (const SafePtr<ViewPointNode>& viewpoint : viewpoints)
             wCam->AddViewPoint(viewpoint);
 
-        controller.updateInfo(new GuiDataRenderAnimationToolbarState(true));
+        if (result)
+        {
+            result->mode = itConfig->second.getMode();
+            result->viewpointCount = viewpoints.size();
+            if (itConfig->second.getMode() == ViewPointAnimationMode::PositionAsTime && controlTimes.size() >= 2)
+                result->effectiveDurationSeconds = std::max(0.0, controlTimes.back() - controlTimes.front());
+            else
+                result->effectiveDurationSeconds = std::max(0.0, static_cast<double>(lengthSeconds));
+        }
+
+        return true;
+    }
+
+    void PrepareViewpointsAnimation::doFunction(Controller& controller)
+    {
+        const bool prepared = prepareViewpointsAnimationForPlayback(
+            controller,
+            m_animationId,
+            m_lengthSeconds,
+            m_interpolateRenderingBetweenViewpoints,
+            nullptr,
+            true);
+
+        controller.updateInfo(new GuiDataRenderAnimationToolbarState(prepared));
     }
 
     ControlType PrepareViewpointsAnimation::getType() const

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -9,6 +9,7 @@
 #include "controller/messages/FilesMessage.h"
 #include "controller/messages/GeneralMessage.h"
 #include "controller/messages/VideoExportParametersMessage.h"
+#include "controller/controls/ControlAnimation.h"
 
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/GuiData/GuiDataIO.h"
@@ -56,6 +57,11 @@ ContextExportVideoHD::~ContextExportVideoHD()
 
 ContextState ContextExportVideoHD::start(Controller& controller)
 {
+    m_exportState = 0;
+    m_animFrame = 0;
+    m_totalFrames = 0;
+    m_orbitalStepRad = 0.0;
+
     m_precedentOptions = controller.getContext().getDecimationOptions();
     DecimationOptions noDecimation = m_precedentOptions;
     noDecimation.mode = DecimationMode::None;
@@ -87,10 +93,6 @@ ContextState ContextExportVideoHD::feedMessage(IMessage* message, Controller& co
         case IMessage::MessageType::GENERALMESSAGE:
         {
             GeneralMessage* out = static_cast<GeneralMessage*>(message);
-            if (out->m_info == GeneralInfo::ANIMATIONEND && m_exportState == 1)
-            {
-                m_state = ContextState::ready_for_using;
-            }
             if (out->m_info == GeneralInfo::IMAGEEND && m_exportState == 2)
             {
                 controller.updateInfo(new GuiDataProcessingSplashScreenProgressBarUpdate(TEXT_CONTEXT_EXPORT_VIDEO_STEPS.arg(m_animFrame).arg(m_totalFrames), m_animFrame));
@@ -107,10 +109,10 @@ ContextState ContextExportVideoHD::feedMessage(IMessage* message, Controller& co
 
 ContextState ContextExportVideoHD::launch(Controller& controller)
 {
-    if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && m_parameters.start == m_parameters.finish)
+    if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && !m_parameters.viewpointAnimationId.isValid())
         return abort(controller);
 
-    //Start - Move to start position
+    // Start and prepare trajectory
     if (m_exportState == 0)
     {
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
@@ -119,84 +121,46 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             return abort(controller);
 
         wCam->setProjectionMode(ProjectionMode::Perspective);
-        m_exportState = 1;
-
+        m_totalFrames = 1;
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
-            wCam->moveToData(m_parameters.start);
-            return m_state = ContextState::waiting_for_input;
+            control::animation::ViewpointsAnimationPreparationResult preparation;
+            const bool prepared = control::animation::prepareViewpointsAnimationForPlayback(
+                controller,
+                m_parameters.viewpointAnimationId,
+                m_parameters.length,
+                m_parameters.interpolateRenderingBetweenViewpoints,
+                &preparation,
+                true);
+            if (!prepared)
+                return abort(controller);
+
+            if (!wCam->startAnimation(true, static_cast<uint64_t>(std::max(1, m_parameters.fps))))
+                return abort(controller);
+
+            const double durationSeconds = std::max(0.0, preparation.effectiveDurationSeconds);
+            m_totalFrames = std::max<long>(1, static_cast<long>(std::llround(durationSeconds * static_cast<double>(std::max(1, m_parameters.fps)))) + 1);
+        }
+        else
+        {
+            const double durationSeconds = std::max(0.0, static_cast<double>(m_parameters.length));
+            m_totalFrames = std::max<long>(1, static_cast<long>(std::llround(durationSeconds * static_cast<double>(std::max(1, m_parameters.fps)))) + 1);
+            const long moveSteps = std::max<long>(1, m_totalFrames - 1);
+            m_orbitalStepRad = glm::radians(static_cast<double>(std::clamp(m_parameters.orbitalDegrees, 1, 360))) / static_cast<double>(moveSteps);
         }
 
-    }
-
-    //Calcul camera move delta
-    if (m_exportState == 1)
-    {
-        SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
-        ReadPtr<CameraNode> rCam = cam.cget();
-        if (!rCam)
-            return abort(controller);
-        m_totalFrames = (long)m_parameters.length * (long)m_parameters.fps;
         m_animFrame = 1;
-        m_frameDigits = std::max<uint8_t>(1, (uint8_t)(std::log10(std::max<long>(1, m_totalFrames)) + 1));
+        m_frameDigits = std::max<uint8_t>(1, static_cast<uint8_t>(std::log10(std::max<long>(1, m_totalFrames)) + 1));
 
         controller.updateInfo(new GuiDataProcessingSplashScreenStart(m_totalFrames, TEXT_CONTEXT_EXPORT_VIDEO, TEXT_CONTEXT_EXPORT_VIDEO_STEPS.arg(0).arg(m_totalFrames)));
         m_tpStart = std::chrono::steady_clock::now();
 
-        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
-        {
-            ReadPtr<ViewPointNode> rStart;
-            ReadPtr<ViewPointNode> rFinish;
-            multi_cget(m_parameters.start, m_parameters.finish, rStart, rFinish);
-            if (!rStart || !rFinish)
-                return abort(controller);
-
-            glm::dvec3 finishLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFinish->getInverseTransformation();
-
-            double endTheta;
-            if (finishLookDir.x == 0.0 && finishLookDir.y == 0.0)   // Must we change the test to x < epsilon ?
-                endTheta = 0.;
-            else
-                endTheta = atan2(-finishLookDir.x, finishLookDir.y);
-
-            double normXY = sqrt(finishLookDir.x * finishLookDir.x + finishLookDir.y * finishLookDir.y);
-            double endPhi = atan2(-normXY, finishLookDir.z);
-
-            CameraNode::modulo2Pi(rCam->getTheta(), endTheta);
-
-            m_addPosition = (rFinish->getCenter() - rStart->getCenter()) / (double)m_totalFrames;
-            m_addTheta = (endTheta - rCam->getTheta()) / m_totalFrames;
-            m_addPhi = (endPhi - rCam->getPhi()) / m_totalFrames;
-
-            if (rStart->m_blendMode == rFinish->m_blendMode &&
-                rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
-                rStart->m_postRenderingNormals.blendColor == rFinish->m_postRenderingNormals.blendColor &&
-                rStart->m_postRenderingNormals.inverseTone == rFinish->m_postRenderingNormals.inverseTone &&
-                rStart->m_mode == rFinish->m_mode &&
-                rStart->m_negativeEffect == rFinish->m_negativeEffect &&
-                rStart->m_reduceFlash == rFinish->m_reduceFlash &&
-                rStart->m_flashAdvanced == rFinish->m_flashAdvanced &&
-                rStart->m_flashControl == rFinish->m_flashControl
-                )
-            {
-                m_addTransp = (rFinish->m_transparency - rStart->m_transparency) / m_totalFrames;
-
-                m_addNStren = (rFinish->m_postRenderingNormals.normalStrength - rStart->m_postRenderingNormals.normalStrength) / m_totalFrames;
-                m_addNGloss = (rFinish->m_postRenderingNormals.gloss - rStart->m_postRenderingNormals.gloss) / m_totalFrames;
-
-                m_addHue = (rFinish->m_hue - rStart->m_hue) / m_totalFrames;
-
-                m_addBright = (rFinish->m_brightness - rStart->m_brightness) / m_totalFrames;
-                m_addSatur = (rFinish->m_saturation - rStart->m_saturation) / m_totalFrames;
-                m_addLumi = (rFinish->m_luminance - rStart->m_luminance) / m_totalFrames;
-                m_addContr = (rFinish->m_contrast - rStart->m_contrast) / m_totalFrames;
-                m_addAlpha = (rFinish->m_alphaObject - rStart->m_alphaObject) / m_totalFrames;
-
-                m_addFovy = (rFinish->getFovy() - rStart->getFovy()) / m_totalFrames;
-            }
-        }
-        else
-            m_addTheta = 2 * M_PI / m_totalFrames;
+        GUI_LOG << "[VIDEO_EXPORT] start export"
+            << " mode=" << static_cast<int>(m_parameters.animMode)
+            << " fps=" << m_parameters.fps
+            << " totalFrames=" << m_totalFrames
+            << " orbitalDegrees=" << m_parameters.orbitalDegrees
+            << LOGENDL;
 
         controller.updateInfo(new GuiDataCallImage(m_parameters.hdImage, getNextFramePath()));
         m_exportState = 2;
@@ -204,47 +168,38 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
         return m_state = ContextState::waiting_for_input;
     }
 
-    //Mouvement and Image
+    // Move and image
     if (m_exportState == 2)
     {
-
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
         WritePtr<CameraNode> wCam = cam.get();
         if (!wCam)
             return abort(controller);
 
+        if (m_animFrame > m_totalFrames)
+        {
+            m_exportState = 3;
+            return m_state = ContextState::ready_for_using;
+        }
+
         switch (m_parameters.animMode)
         {
             case VideoAnimationMode::BETWEENVIEWPOINTS:
             {
-                wCam->addGlobalTranslation(m_addPosition);
-                wCam->yaw(m_addTheta);
-                wCam->pitch(m_addPhi);
-
-                if (m_parameters.interpolateRenderingBetweenViewpoints)
-                {
-                    wCam->m_transparency += m_addTransp;                    
-                    wCam->m_postRenderingNormals.normalStrength += m_addNStren;
-                    wCam->m_postRenderingNormals.gloss += m_addNGloss;
-                    wCam->m_contrast += m_addContr;
-                    wCam->m_brightness += m_addBright;
-                    wCam->m_luminance += m_addLumi;
-                    wCam->m_saturation += m_addSatur;
-                    wCam->m_hue += m_addHue;
-                    wCam->m_alphaObject += m_addAlpha;
-                    wCam->setFovy(wCam->getFovy() + m_addFovy);
-                }
+                wCam->updateAnimation();
             }
             break;
             case VideoAnimationMode::ORBITAL:
             {
                 if (wCam->isExamineActive())
-                    wCam->moveAroundExamine(0.0, m_addTheta, 0.0);
+                    wCam->moveAroundExamine(0.0, m_orbitalStepRad, 0.0);
                 else
-                    wCam->yaw(m_addTheta);
+                    wCam->yaw(m_orbitalStepRad);
             }
             break;
         }
+
+        GUI_LOG << "[VIDEO_EXPORT] frame=" << m_animFrame << "/" << m_totalFrames << LOGENDL;
 
         controller.updateInfo(new GuiDataCallImage(m_parameters.hdImage, getNextFramePath()));
         return m_state = ContextState::waiting_for_input;

--- a/src/gui/Dialog/DialogExportVideo.cpp
+++ b/src/gui/Dialog/DialogExportVideo.cpp
@@ -7,6 +7,7 @@
 #include "gui/GuiData/GuiDataGeneralProject.h"
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/GuiData/GuiDataIO.h"
+#include "gui/texts/ContextTexts.hpp"
 #include "utils/Config.h"
 
 #include "models/graph/ViewPointNode.h"
@@ -17,6 +18,7 @@
 #include <QtWidgets/QSpinBox>
 #include <QtCore/QProcess>
 #include <QtCore/qstandardpaths.h>
+#include <algorithm>
 #include <filesystem>
 
 namespace
@@ -45,9 +47,6 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
 
 	m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
 
-	connect(m_ui.pushButtonViewPoint1, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint1Click);
-	connect(m_ui.pushButtonViewPoint2, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint2Click);
-
     connect(m_ui.folderToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFolder);
 	connect(m_ui.fileToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFile);
 
@@ -55,7 +54,7 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
     connect(m_ui.cancelPushButton, &QPushButton::clicked, this, &DialogExportVideo::cancelGeneration);
 
     m_dataDispatcher.registerObserverOnKey(this, guiDType::projectPath);
-    m_dataDispatcher.registerObserverOnKey(this, guiDType::objectSelected);
+	m_ui.betweenViewpointsWidget->setVisible(false);
 	this->setMinimumWidth(344 * guiScale);
 	adjustSize();
 
@@ -83,50 +82,7 @@ void DialogExportVideo::informData(IGuiData *data)
 			m_parameters.finish.reset();
 		}
 		break;
-		case guiDType::objectSelected:
-		{
-			if (m_viewpointToEdit != 1 && m_viewpointToEdit != 2)
-				return;
-			auto dataType = static_cast<GuiDataObjectSelected*>(data);
-			if (dataType->m_type != ElementType::ViewPoint)
-				return;
-
-			SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(dataType->m_object);
-			ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
-			if (!rViewpoint)
-				return;
-			if (rViewpoint->getProjectionMode() == ProjectionMode::Orthographic)
-			{
-				m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_ORTHO_VIEWPOINT));
-				return;
-			}
-
-			if (m_viewpointToEdit == 1)
-			{
-				m_parameters.start = viewpoint;
-				m_ui.lineEditViewPoint1->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-			else if(m_viewpointToEdit == 2)
-			{
-				m_parameters.finish = viewpoint;
-				m_ui.lineEditViewPoint2->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-
-			m_viewpointToEdit = -1;
-		}
-		break;
     }
-}
-void DialogExportVideo::onViewpoint1Click()
-{
-	m_ui.lineEditViewPoint1->clear();
-	m_viewpointToEdit = 1;
-}
-
-void DialogExportVideo::onViewpoint2Click()
-{
-	m_ui.lineEditViewPoint2->clear();
-	m_viewpointToEdit = 2;
 }
 
 void DialogExportVideo::onSelectOutFolder()
@@ -174,17 +130,13 @@ void DialogExportVideo::startGeneration()
     }
 
 	m_parameters.animMode = m_animationMode;
+	m_parameters.viewpointAnimationId = m_viewpointAnimationId;
+	m_parameters.orbitalDegrees = m_orbitalDegrees;
 	if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
 	{
-		if (!m_parameters.start || !m_parameters.finish)
+		if (!m_parameters.viewpointAnimationId.isValid())
 		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_MISSING_VIEWPOINTS));
-			return;
-		}
-
-		if (m_parameters.start == m_parameters.finish)
-		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_SAME_VIEWPOINTS));
+			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
 			return;
 		}
 	}
@@ -305,6 +257,16 @@ bool DialogExportVideo::isX265Available() const
 void DialogExportVideo::setAnimationMode(VideoAnimationMode mode)
 {
 	m_animationMode = mode;
+}
+
+void DialogExportVideo::setViewpointAnimationId(const viewPointAnimationId& animationId)
+{
+	m_viewpointAnimationId = animationId;
+}
+
+void DialogExportVideo::setOrbitalDegrees(int degrees)
+{
+	m_orbitalDegrees = std::max(1, std::min(360, degrees));
 }
 
 void DialogExportVideo::setLength(int length)

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -306,6 +306,9 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 		return;
 
 	m_dialog->setAnimationMode(m_ui.betweenViewpointsRadioButton->isChecked() ? VideoAnimationMode::BETWEENVIEWPOINTS : VideoAnimationMode::ORBITAL);
+	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+	m_dialog->setViewpointAnimationId(selectedConfig ? selectedConfig->getId() : xg::Guid());
+	m_dialog->setOrbitalDegrees(m_ui.degreesSpinBox->value());
 	m_dialog->setLength(m_ui.lengthSpinBox->value());
 	m_dialog->setInterpolateRenderings(m_ui.interpolateCheckBox->isChecked());
 	m_dialog->show();


### PR DESCRIPTION
### Motivation
- Enable exporting HD videos driven by saved viewpoint animations and orbital degrees instead of two explicit viewpoint nodes. 
- Centralize and reuse viewpoint animation preparation logic to avoid duplication between UI controls and export flow.

### Description
- Added `ViewpointsAnimationPreparationResult` and `prepareViewpointsAnimationForPlayback` in `control::animation` and refactored `PrepareViewpointsAnimation::doFunction` to call it, returning a boolean and optional metadata. 
- Extended `VideoExportParameters` with `viewpointAnimationId` and `orbitalDegrees` and adjusted `DialogExportVideo` to set these via new methods `setViewpointAnimationId` and `setOrbitalDegrees`, removing the old two-viewpoint selection UI. 
- Updated `ContextExportVideoHD` to use the preparation result to compute `m_totalFrames`, start camera animation with `wCam->startAnimation(...)`, update frames via `wCam->updateAnimation()`, and apply orbital stepping using `m_orbitalStepRad`. Removed legacy per-frame member variables and reinitialized state members on `start`. 
- Modified toolbar to pass the selected animation config id and orbital degrees to the export dialog, and added logging for export start and per-frame progress. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b863af10f8832fa374fa4797d659a1)