### PR TITLE
Support view-point animation and orbital parameters for HD video export; refactor interpolation logic

### DIFF
--- a/include/controller/functionSystem/ContextExportVideoHD.h
+++ b/include/controller/functionSystem/ContextExportVideoHD.h
@@ -5,6 +5,9 @@
 #include "io/exports/ExportParameters.hpp"
 #include "pointCloudEngine/RenderingTypes.h"
 #include <optional>
+#include <vector>
+
+class ViewPointNode;
 
 class ContextExportVideoHD : public AContext
 {
@@ -37,22 +40,11 @@ private:
 	long m_totalFrames;
 	long m_animFrame = 0;
 	uint8_t m_frameDigits = 0;
-
-	glm::dvec3 m_addPosition = glm::dvec3(0.);
-	double m_addTheta = 0.;
-	double m_addPhi = 0.;
-
-	float m_addTransp = 0.f;
-	float m_addNGloss = 0.f;
-	float m_addNStren = 0.f;
-	float m_addHue = 0.f;
-	float m_addBright = 0.f;
-	float m_addSatur = 0.f;
-	float m_addLumi = 0.f;
-	float m_addContr = 0.f;
-	float m_addAlpha = 0.f;
-
-	double m_addFovy = 0.;
+	std::vector<SafePtr<ViewPointNode>> m_viewpoints;
+	std::vector<double> m_viewpointControlTimes;
+	double m_orbitalTotalAngleRad = 0.0;
+	double m_orbitalLastAppliedRad = 0.0;
+	bool m_orbitalUsesExamine = false;
 
 	std::chrono::steady_clock::time_point m_tpStart;
 	DecimationOptions m_precedentOptions;

--- a/include/gui/Dialog/DialogExportVideo.h
+++ b/include/gui/Dialog/DialogExportVideo.h
@@ -4,6 +4,7 @@
 #include "ui_DialogExportVideo.h"
 #include "gui/Dialog/ADialog.h"
 #include "io/exports/ExportParameters.hpp"
+#include "models/application/ViewPointAnimation.h"
 #include <optional>
 #include <utility>
 
@@ -20,9 +21,6 @@ public:
     void closeEvent(QCloseEvent* event);
 
 private:
-    void onViewpoint1Click();
-    void onViewpoint2Click();
-
     void onSelectOutFolder();
 	void onSelectOutFile();
 
@@ -38,16 +36,18 @@ public:
     void setAnimationMode(VideoAnimationMode mode);
     void setLength(int length);
     void setInterpolateRenderings(bool interpolate);
+    void setAnimationConfigId(const viewPointAnimationId& id);
+    void setOrbitalDegrees(int degrees);
 
 private:
     Ui::DialogExportVideo m_ui;
     QString m_openPath;
-
-    int m_viewpointToEdit = -1;
 	VideoExportParameters m_parameters;
 	VideoAnimationMode m_animationMode = VideoAnimationMode::BETWEENVIEWPOINTS;
 	int m_length = 30;
 	bool m_interpolateRenderings = false;
+	viewPointAnimationId m_animationConfigId;
+	int m_orbitalDegrees = 360;
 
     static constexpr uint64_t MAX_MP4_PIXELS = 8294400;
 };

--- a/include/io/exports/ExportParameters.hpp
+++ b/include/io/exports/ExportParameters.hpp
@@ -5,6 +5,7 @@
 #include "io/FileUtils.h"
 #include "tls_def.h"
 #include "models/OpenScanToolsModelEssentials.h"
+#include "models/application/ViewPointAnimation.h"
 
 // NOTE - The enums are used for combo box indexes
 //  (*) They must start at 0 and the values increase "naturally".
@@ -69,8 +70,8 @@ struct VideoExportParameters
     int bitrateKbps = 5000;
     std::filesystem::path outputFilePath;
     VideoAnimationMode animMode = VideoAnimationMode::NONE;
-    SafePtr<ViewPointNode> start;
-    SafePtr<ViewPointNode> finish;
+    viewPointAnimationId viewPointAnimation = xg::Guid();
+    int orbitalDegrees = 360;
     bool interpolateRenderingBetweenViewpoints = false;
     bool openFolderAfterExport = false;
 

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -3,8 +3,10 @@
 #include "controller/ControllerContext.h"
 
 #include "models/graph/GraphManager.h"
+#include "models/graph/AGraphNode.h"
 #include "models/graph/CameraNode.h"
 #include "models/graph/ViewPointNode.h"
+#include "models/application/ViewPointAnimation.h"
 
 #include "controller/messages/FilesMessage.h"
 #include "controller/messages/GeneralMessage.h"
@@ -24,6 +26,9 @@
 #include "utils/math/basic_define.h"
 #include <cmath>
 #include <algorithm>
+#include <unordered_map>
+#include <limits>
+#include <glm/gtc/quaternion.hpp>
 #include <filesystem>
 #include <QtCore/QProcess>
 #include <QtCore/QStringList>
@@ -43,6 +48,71 @@ QString resolveFfmpegExecutable()
     }
     return QStringLiteral("ffmpeg");
 }
+
+bool areViewpointsInterpolationCompatible(const ViewPointNode& reference, const ViewPointNode& candidate)
+{
+    return reference.m_mode == candidate.m_mode &&
+        reference.m_blendMode == candidate.m_blendMode &&
+        reference.m_reduceFlash == candidate.m_reduceFlash &&
+        reference.m_flashAdvanced == candidate.m_flashAdvanced &&
+        reference.m_negativeEffect == candidate.m_negativeEffect &&
+        reference.m_postRenderingNormals.show == candidate.m_postRenderingNormals.show &&
+        reference.m_postRenderingAmbientOcclusion.enabled == candidate.m_postRenderingAmbientOcclusion.enabled &&
+        reference.m_postRenderingNormals.blendColor == candidate.m_postRenderingNormals.blendColor &&
+        reference.m_edgeAwareBlur.enabled == candidate.m_edgeAwareBlur.enabled &&
+        reference.m_depthLining.enabled == candidate.m_depthLining.enabled &&
+        reference.m_depthLining.strongMode == candidate.m_depthLining.strongMode;
+}
+
+bool buildAnimationViewpointSequence(Controller& controller,
+    const viewPointAnimationId& animationId,
+    std::vector<SafePtr<ViewPointNode>>& viewpoints,
+    std::vector<double>& controlTimes,
+    ViewPointAnimationMode& mode)
+{
+    viewpoints.clear();
+    controlTimes.clear();
+
+    const std::unordered_map<viewPointAnimationId, ViewPointAnimationConfig>& configs = controller.getContext().cgetViewPointAnimations();
+    auto itConfig = configs.find(animationId);
+    if (itConfig == configs.end())
+        return false;
+
+    mode = itConfig->second.getMode();
+
+    std::unordered_map<xg::Guid, SafePtr<ViewPointNode>> perspectiveById;
+    const std::unordered_set<SafePtr<AGraphNode>> allViewpoints = controller.getGraphManager().getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+    perspectiveById.reserve(allViewpoints.size());
+
+    for (const SafePtr<AGraphNode>& node : allViewpoints)
+    {
+        SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(node);
+        ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+        if (!rViewpoint || rViewpoint->getProjectionMode() != ProjectionMode::Perspective)
+            continue;
+        perspectiveById.insert_or_assign(rViewpoint->getId(), viewpoint);
+    }
+
+    viewpoints.reserve(itConfig->second.getLines().size());
+    controlTimes.reserve(itConfig->second.getLines().size());
+
+    double previousTime = -std::numeric_limits<double>::infinity();
+    for (const ViewPointAnimationLine& line : itConfig->second.getLines())
+    {
+        auto itVp = perspectiveById.find(line.viewpointId);
+        if (itVp == perspectiveById.end())
+            continue;
+
+        if (mode == ViewPointAnimationMode::PositionAsTime && line.position <= previousTime)
+            return false;
+
+        viewpoints.push_back(itVp->second);
+        controlTimes.push_back(line.position);
+        previousTime = line.position;
+    }
+
+    return viewpoints.size() >= 2;
+}
 }
 
 ContextExportVideoHD::ContextExportVideoHD(const ContextId& id)
@@ -57,6 +127,14 @@ ContextExportVideoHD::~ContextExportVideoHD()
 ContextState ContextExportVideoHD::start(Controller& controller)
 {
     m_precedentOptions = controller.getContext().getDecimationOptions();
+    m_exportState = 0;
+    m_animFrame = 0;
+    m_totalFrames = 0;
+    m_viewpoints.clear();
+    m_viewpointControlTimes.clear();
+    m_orbitalTotalAngleRad = 0.0;
+    m_orbitalLastAppliedRad = 0.0;
+    m_orbitalUsesExamine = false;
     DecimationOptions noDecimation = m_precedentOptions;
     noDecimation.mode = DecimationMode::None;
     controller.updateInfo(new GuiDataRenderDecimationOptions(noDecimation));
@@ -87,10 +165,6 @@ ContextState ContextExportVideoHD::feedMessage(IMessage* message, Controller& co
         case IMessage::MessageType::GENERALMESSAGE:
         {
             GeneralMessage* out = static_cast<GeneralMessage*>(message);
-            if (out->m_info == GeneralInfo::ANIMATIONEND && m_exportState == 1)
-            {
-                m_state = ContextState::ready_for_using;
-            }
             if (out->m_info == GeneralInfo::IMAGEEND && m_exportState == 2)
             {
                 controller.updateInfo(new GuiDataProcessingSplashScreenProgressBarUpdate(TEXT_CONTEXT_EXPORT_VIDEO_STEPS.arg(m_animFrame).arg(m_totalFrames), m_animFrame));
@@ -107,10 +181,6 @@ ContextState ContextExportVideoHD::feedMessage(IMessage* message, Controller& co
 
 ContextState ContextExportVideoHD::launch(Controller& controller)
 {
-    if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS && m_parameters.start == m_parameters.finish)
-        return abort(controller);
-
-    //Start - Move to start position
     if (m_exportState == 0)
     {
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
@@ -119,131 +189,160 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             return abort(controller);
 
         wCam->setProjectionMode(ProjectionMode::Perspective);
-        m_exportState = 1;
 
-        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
-        {
-            wCam->moveToData(m_parameters.start);
-            return m_state = ContextState::waiting_for_input;
-        }
-
-    }
-
-    //Calcul camera move delta
-    if (m_exportState == 1)
-    {
-        SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
-        ReadPtr<CameraNode> rCam = cam.cget();
-        if (!rCam)
-            return abort(controller);
-        m_totalFrames = (long)m_parameters.length * (long)m_parameters.fps;
+        m_totalFrames = std::max<long>(1, static_cast<long>(m_parameters.length) * static_cast<long>(m_parameters.fps));
         m_animFrame = 1;
-        m_frameDigits = std::max<uint8_t>(1, (uint8_t)(std::log10(std::max<long>(1, m_totalFrames)) + 1));
+        m_frameDigits = std::max<uint8_t>(1, static_cast<uint8_t>(std::log10(std::max<long>(1, m_totalFrames)) + 1));
 
         controller.updateInfo(new GuiDataProcessingSplashScreenStart(m_totalFrames, TEXT_CONTEXT_EXPORT_VIDEO, TEXT_CONTEXT_EXPORT_VIDEO_STEPS.arg(0).arg(m_totalFrames)));
         m_tpStart = std::chrono::steady_clock::now();
 
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
-            ReadPtr<ViewPointNode> rStart;
-            ReadPtr<ViewPointNode> rFinish;
-            multi_cget(m_parameters.start, m_parameters.finish, rStart, rFinish);
-            if (!rStart || !rFinish)
+            ViewPointAnimationMode mode = ViewPointAnimationMode::ConstantIntervals;
+            if (!buildAnimationViewpointSequence(controller, m_parameters.viewPointAnimation, m_viewpoints, m_viewpointControlTimes, mode))
                 return abort(controller);
 
-            glm::dvec3 finishLookDir = glm::dvec4(0.0, 0.0, 1.0, 1.0) * rFinish->getInverseTransformation();
-
-            double endTheta;
-            if (finishLookDir.x == 0.0 && finishLookDir.y == 0.0)   // Must we change the test to x < epsilon ?
-                endTheta = 0.;
-            else
-                endTheta = atan2(-finishLookDir.x, finishLookDir.y);
-
-            double normXY = sqrt(finishLookDir.x * finishLookDir.x + finishLookDir.y * finishLookDir.y);
-            double endPhi = atan2(-normXY, finishLookDir.z);
-
-            CameraNode::modulo2Pi(rCam->getTheta(), endTheta);
-
-            m_addPosition = (rFinish->getCenter() - rStart->getCenter()) / (double)m_totalFrames;
-            m_addTheta = (endTheta - rCam->getTheta()) / m_totalFrames;
-            m_addPhi = (endPhi - rCam->getPhi()) / m_totalFrames;
-
-            if (rStart->m_blendMode == rFinish->m_blendMode &&
-                rStart->m_postRenderingNormals.show == rFinish->m_postRenderingNormals.show &&
-                rStart->m_postRenderingNormals.blendColor == rFinish->m_postRenderingNormals.blendColor &&
-                rStart->m_postRenderingNormals.inverseTone == rFinish->m_postRenderingNormals.inverseTone &&
-                rStart->m_mode == rFinish->m_mode &&
-                rStart->m_negativeEffect == rFinish->m_negativeEffect &&
-                rStart->m_reduceFlash == rFinish->m_reduceFlash &&
-                rStart->m_flashAdvanced == rFinish->m_flashAdvanced &&
-                rStart->m_flashControl == rFinish->m_flashControl
-                )
+            bool canInterpolate = true;
+            ReadPtr<ViewPointNode> rReference = m_viewpoints.front().cget();
+            if (!rReference)
+                return abort(controller);
+            for (size_t i = 1; i < m_viewpoints.size() && canInterpolate; ++i)
             {
-                m_addTransp = (rFinish->m_transparency - rStart->m_transparency) / m_totalFrames;
-
-                m_addNStren = (rFinish->m_postRenderingNormals.normalStrength - rStart->m_postRenderingNormals.normalStrength) / m_totalFrames;
-                m_addNGloss = (rFinish->m_postRenderingNormals.gloss - rStart->m_postRenderingNormals.gloss) / m_totalFrames;
-
-                m_addHue = (rFinish->m_hue - rStart->m_hue) / m_totalFrames;
-
-                m_addBright = (rFinish->m_brightness - rStart->m_brightness) / m_totalFrames;
-                m_addSatur = (rFinish->m_saturation - rStart->m_saturation) / m_totalFrames;
-                m_addLumi = (rFinish->m_luminance - rStart->m_luminance) / m_totalFrames;
-                m_addContr = (rFinish->m_contrast - rStart->m_contrast) / m_totalFrames;
-                m_addAlpha = (rFinish->m_alphaObject - rStart->m_alphaObject) / m_totalFrames;
-
-                m_addFovy = (rFinish->getFovy() - rStart->getFovy()) / m_totalFrames;
+                ReadPtr<ViewPointNode> rCandidate = m_viewpoints[i].cget();
+                canInterpolate = rCandidate && areViewpointsInterpolationCompatible(*&rReference, *&rCandidate);
             }
+            wCam->setViewpointRenderInterpolationEnabled(m_parameters.interpolateRenderingBetweenViewpoints && canInterpolate);
+
+            if (mode == ViewPointAnimationMode::PositionAsTime)
+            {
+                const double offset = m_viewpointControlTimes.front();
+                for (double& value : m_viewpointControlTimes)
+                    value -= offset;
+            }
+            else if (mode == ViewPointAnimationMode::ConstantSpeed)
+            {
+                std::vector<double> cumulative(m_viewpoints.size(), 0.0);
+                double totalDist = 0.0;
+                for (size_t i = 1; i < m_viewpoints.size(); ++i)
+                {
+                    ReadPtr<ViewPointNode> prev = m_viewpoints[i - 1].cget();
+                    ReadPtr<ViewPointNode> curr = m_viewpoints[i].cget();
+                    if (!prev || !curr)
+                        return abort(controller);
+                    totalDist += glm::distance(prev->getCenter(), curr->getCenter());
+                    cumulative[i] = totalDist;
+                }
+                const double targetDuration = std::max(0.001, static_cast<double>(m_parameters.length));
+                if (totalDist <= 1e-9)
+                {
+                    for (size_t i = 0; i < cumulative.size(); ++i)
+                        cumulative[i] = targetDuration * static_cast<double>(i) / static_cast<double>(std::max<size_t>(1, cumulative.size() - 1));
+                }
+                else
+                {
+                    for (double& value : cumulative)
+                        value = targetDuration * value / totalDist;
+                }
+                m_viewpointControlTimes = cumulative;
+            }
+            else
+            {
+                const double targetDuration = std::max(0.001, static_cast<double>(m_parameters.length));
+                const size_t lastIndex = m_viewpoints.size() - 1;
+                m_viewpointControlTimes.resize(m_viewpoints.size(), 0.0);
+                for (size_t i = 0; i <= lastIndex; ++i)
+                    m_viewpointControlTimes[i] = targetDuration * static_cast<double>(i) / static_cast<double>(std::max<size_t>(1, lastIndex));
+            }
+
+            ReadPtr<ViewPointNode> rStart = m_viewpoints.front().cget();
+            if (!rStart)
+                return abort(controller);
+            wCam->moveToData(m_viewpoints.front());
         }
         else
-            m_addTheta = 2 * M_PI / m_totalFrames;
+        {
+            m_viewpoints.clear();
+            m_viewpointControlTimes.clear();
+            m_orbitalTotalAngleRad = glm::radians(static_cast<double>(std::clamp(m_parameters.orbitalDegrees, 1, 360)));
+            m_orbitalLastAppliedRad = 0.0;
+            m_orbitalUsesExamine = wCam->isExamineActive();
+        }
 
+        m_exportState = 1;
         controller.updateInfo(new GuiDataCallImage(m_parameters.hdImage, getNextFramePath()));
-        m_exportState = 2;
-
         return m_state = ContextState::waiting_for_input;
     }
 
-    //Mouvement and Image
+    if (m_exportState == 1)
+    {
+        m_exportState = 2;
+        return m_state = ContextState::waiting_for_input;
+    }
+
     if (m_exportState == 2)
     {
-
         SafePtr<CameraNode> cam = controller.getGraphManager().getCameraNode();
         WritePtr<CameraNode> wCam = cam.get();
         if (!wCam)
             return abort(controller);
 
-        switch (m_parameters.animMode)
+        if (m_animFrame > m_totalFrames)
         {
-            case VideoAnimationMode::BETWEENVIEWPOINTS:
-            {
-                wCam->addGlobalTranslation(m_addPosition);
-                wCam->yaw(m_addTheta);
-                wCam->pitch(m_addPhi);
+            m_exportState = 3;
+            return m_state = ContextState::ready_for_using;
+        }
 
-                if (m_parameters.interpolateRenderingBetweenViewpoints)
-                {
-                    wCam->m_transparency += m_addTransp;                    
-                    wCam->m_postRenderingNormals.normalStrength += m_addNStren;
-                    wCam->m_postRenderingNormals.gloss += m_addNGloss;
-                    wCam->m_contrast += m_addContr;
-                    wCam->m_brightness += m_addBright;
-                    wCam->m_luminance += m_addLumi;
-                    wCam->m_saturation += m_addSatur;
-                    wCam->m_hue += m_addHue;
-                    wCam->m_alphaObject += m_addAlpha;
-                    wCam->setFovy(wCam->getFovy() + m_addFovy);
-                }
-            }
-            break;
-            case VideoAnimationMode::ORBITAL:
+        if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
+        {
+            const double t = std::clamp(static_cast<double>(m_animFrame - 1) / static_cast<double>(std::max(1, m_parameters.fps)), 0.0, m_viewpointControlTimes.back());
+            auto upper = std::upper_bound(m_viewpointControlTimes.begin(), m_viewpointControlTimes.end(), t);
+            size_t rightIndex = static_cast<size_t>(std::distance(m_viewpointControlTimes.begin(), upper));
+            if (rightIndex == 0)
+                rightIndex = 1;
+            if (rightIndex >= m_viewpointControlTimes.size())
+                rightIndex = m_viewpointControlTimes.size() - 1;
+            const size_t leftIndex = rightIndex - 1;
+
+            ReadPtr<ViewPointNode> left = m_viewpoints[leftIndex].cget();
+            ReadPtr<ViewPointNode> right = m_viewpoints[rightIndex].cget();
+            if (!left || !right)
+                return abort(controller);
+
+            const double leftTime = m_viewpointControlTimes[leftIndex];
+            const double rightTime = m_viewpointControlTimes[rightIndex];
+            const double safeDuration = std::max(1e-9, rightTime - leftTime);
+            const double alpha = std::clamp((t - leftTime) / safeDuration, 0.0, 1.0);
+
+            wCam->setPosition(left->getCenter() * (1.0 - alpha) + right->getCenter() * alpha);
+            wCam->setRotation(glm::normalize(glm::slerp(left->getOrientation(), right->getOrientation(), alpha)));
+
+            if (m_parameters.interpolateRenderingBetweenViewpoints && areViewpointsInterpolationCompatible(*&left, *&right))
             {
-                if (wCam->isExamineActive())
-                    wCam->moveAroundExamine(0.0, m_addTheta, 0.0);
-                else
-                    wCam->yaw(m_addTheta);
+                wCam->m_transparency = left->m_transparency * static_cast<float>(1.0 - alpha) + right->m_transparency * static_cast<float>(alpha);
+                wCam->m_postRenderingNormals.normalStrength = left->m_postRenderingNormals.normalStrength * static_cast<float>(1.0 - alpha) + right->m_postRenderingNormals.normalStrength * static_cast<float>(alpha);
+                wCam->m_postRenderingNormals.gloss = left->m_postRenderingNormals.gloss * static_cast<float>(1.0 - alpha) + right->m_postRenderingNormals.gloss * static_cast<float>(alpha);
+                wCam->m_contrast = left->m_contrast * static_cast<float>(1.0 - alpha) + right->m_contrast * static_cast<float>(alpha);
+                wCam->m_brightness = left->m_brightness * static_cast<float>(1.0 - alpha) + right->m_brightness * static_cast<float>(alpha);
+                wCam->m_luminance = left->m_luminance * static_cast<float>(1.0 - alpha) + right->m_luminance * static_cast<float>(alpha);
+                wCam->m_saturation = left->m_saturation * static_cast<float>(1.0 - alpha) + right->m_saturation * static_cast<float>(alpha);
+                wCam->m_hue = left->m_hue * static_cast<float>(1.0 - alpha) + right->m_hue * static_cast<float>(alpha);
+                wCam->m_alphaObject = left->m_alphaObject * static_cast<float>(1.0 - alpha) + right->m_alphaObject * static_cast<float>(alpha);
+                wCam->setFovy(left->getFovy() * (1.0 - alpha) + right->getFovy() * alpha);
             }
-            break;
+        }
+        else
+        {
+            const double target = m_orbitalTotalAngleRad * static_cast<double>(m_animFrame - 1) / static_cast<double>(std::max<long>(1, m_totalFrames));
+            const double delta = target - m_orbitalLastAppliedRad;
+            if (delta > 0.0)
+            {
+                if (m_orbitalUsesExamine)
+                    wCam->moveAroundExamine(0.0, delta, 0.0);
+                else
+                    wCam->yaw(delta);
+                m_orbitalLastAppliedRad = target;
+            }
         }
 
         controller.updateInfo(new GuiDataCallImage(m_parameters.hdImage, getNextFramePath()));

--- a/src/gui/Dialog/DialogExportVideo.cpp
+++ b/src/gui/Dialog/DialogExportVideo.cpp
@@ -7,9 +7,8 @@
 #include "gui/GuiData/GuiDataGeneralProject.h"
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/GuiData/GuiDataIO.h"
+#include "gui/texts/ContextTexts.hpp"
 #include "utils/Config.h"
-
-#include "models/graph/ViewPointNode.h"
 
 #include <QtWidgets/qfiledialog.h>
 #include <QtWidgets/QApplication>
@@ -17,6 +16,7 @@
 #include <QtWidgets/QSpinBox>
 #include <QtCore/QProcess>
 #include <QtCore/qstandardpaths.h>
+#include <algorithm>
 #include <filesystem>
 
 namespace
@@ -45,9 +45,6 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
 
 	m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
 
-	connect(m_ui.pushButtonViewPoint1, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint1Click);
-	connect(m_ui.pushButtonViewPoint2, &QPushButton::clicked, this, &DialogExportVideo::onViewpoint2Click);
-
     connect(m_ui.folderToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFolder);
 	connect(m_ui.fileToolButton, &QToolButton::clicked, this, &DialogExportVideo::onSelectOutFile);
 
@@ -55,7 +52,6 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
     connect(m_ui.cancelPushButton, &QPushButton::clicked, this, &DialogExportVideo::cancelGeneration);
 
     m_dataDispatcher.registerObserverOnKey(this, guiDType::projectPath);
-    m_dataDispatcher.registerObserverOnKey(this, guiDType::objectSelected);
 	this->setMinimumWidth(344 * guiScale);
 	adjustSize();
 
@@ -77,56 +73,9 @@ void DialogExportVideo::informData(IGuiData *data)
 		{
 			auto dataType = static_cast<GuiDataProjectPath*>(data);
 			m_openPath = QString::fromStdWString(dataType->m_path.wstring());
-			m_ui.lineEditViewPoint1->clear();
-			m_ui.lineEditViewPoint2->clear();
-			m_parameters.start.reset();
-			m_parameters.finish.reset();
-		}
-		break;
-		case guiDType::objectSelected:
-		{
-			if (m_viewpointToEdit != 1 && m_viewpointToEdit != 2)
-				return;
-			auto dataType = static_cast<GuiDataObjectSelected*>(data);
-			if (dataType->m_type != ElementType::ViewPoint)
-				return;
-
-			SafePtr<ViewPointNode> viewpoint = static_pointer_cast<ViewPointNode>(dataType->m_object);
-			ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
-			if (!rViewpoint)
-				return;
-			if (rViewpoint->getProjectionMode() == ProjectionMode::Orthographic)
-			{
-				m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_ORTHO_VIEWPOINT));
-				return;
-			}
-
-			if (m_viewpointToEdit == 1)
-			{
-				m_parameters.start = viewpoint;
-				m_ui.lineEditViewPoint1->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-			else if(m_viewpointToEdit == 2)
-			{
-				m_parameters.finish = viewpoint;
-				m_ui.lineEditViewPoint2->setText(QString::fromStdWString(rViewpoint->getComposedName()));
-			}
-
-			m_viewpointToEdit = -1;
 		}
 		break;
     }
-}
-void DialogExportVideo::onViewpoint1Click()
-{
-	m_ui.lineEditViewPoint1->clear();
-	m_viewpointToEdit = 1;
-}
-
-void DialogExportVideo::onViewpoint2Click()
-{
-	m_ui.lineEditViewPoint2->clear();
-	m_viewpointToEdit = 2;
 }
 
 void DialogExportVideo::onSelectOutFolder()
@@ -176,15 +125,9 @@ void DialogExportVideo::startGeneration()
 	m_parameters.animMode = m_animationMode;
 	if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
 	{
-		if (!m_parameters.start || !m_parameters.finish)
+		if (m_animationConfigId.isNull())
 		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_MISSING_VIEWPOINTS));
-			return;
-		}
-
-		if (m_parameters.start == m_parameters.finish)
-		{
-			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_EXPORT_VIDEO_SAME_VIEWPOINTS));
+			m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_CONTEXT_ANIMATION_NEED_TWO_VIEWPOINTS));
 			return;
 		}
 	}
@@ -217,6 +160,8 @@ void DialogExportVideo::startGeneration()
     }
 
 	m_parameters.length = m_length;
+	m_parameters.viewPointAnimation = m_animationConfigId;
+	m_parameters.orbitalDegrees = m_orbitalDegrees;
 	m_parameters.fps = m_ui.fpsSpinBox->value();
 	m_parameters.hdImage = m_ui.imageHDRadioButton->isChecked();
 	m_parameters.openFolderAfterExport = m_ui.openExplorerFolderCheckBox->isChecked();
@@ -315,4 +260,14 @@ void DialogExportVideo::setLength(int length)
 void DialogExportVideo::setInterpolateRenderings(bool interpolate)
 {
 	m_interpolateRenderings = interpolate;
+}
+
+void DialogExportVideo::setAnimationConfigId(const viewPointAnimationId& id)
+{
+	m_animationConfigId = id;
+}
+
+void DialogExportVideo::setOrbitalDegrees(int degrees)
+{
+	m_orbitalDegrees = std::clamp(degrees, 1, 360);
 }

--- a/src/gui/forms/DialogExportVideo.ui
+++ b/src/gui/forms/DialogExportVideo.ui
@@ -26,40 +26,6 @@
    <string>Video Generation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="4">
-    <widget class="QWidget" name="betweenViewpointsWidget" native="true">
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="lineEditViewPoint1">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QPushButton" name="pushButtonViewPoint2">
-        <property name="text">
-         <string>Select viewpoint 2</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="lineEditViewPoint2">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="pushButtonViewPoint1">
-        <property name="text">
-         <string>Select viewpoint 1</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="9" column="0">
     <widget class="QLabel" name="label_folder">
      <property name="text">

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -308,6 +308,9 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 	m_dialog->setAnimationMode(m_ui.betweenViewpointsRadioButton->isChecked() ? VideoAnimationMode::BETWEENVIEWPOINTS : VideoAnimationMode::ORBITAL);
 	m_dialog->setLength(m_ui.lengthSpinBox->value());
 	m_dialog->setInterpolateRenderings(m_ui.interpolateCheckBox->isChecked());
+	m_dialog->setOrbitalDegrees(m_ui.degreesSpinBox->value());
+	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
+	m_dialog->setAnimationConfigId(selectedConfig ? selectedConfig->getId() : xg::Guid());
 	m_dialog->show();
 }
 


### PR DESCRIPTION
### Motivation
- Add support for exporting HD videos using saved view-point animation configurations and configurable orbital degrees, and make interpolation of camera transforms more robust and flexible.
- Remove ad-hoc start/finish viewpoint selection in the dialog in favor of reusable animation configs and centralize animation sequencing logic.

### Description
- Replace `start`/`finish` fields in `VideoExportParameters` with `viewPointAnimation` (`viewPointAnimationId`) and add `orbitalDegrees` to store orbital export settings.
- Refactor `ContextExportVideoHD` to build viewpoint sequences from `ViewPointAnimation` configs via `buildAnimationViewpointSequence`, compute control times for `PositionAsTime` and `ConstantSpeed` modes, and interpolate camera position and rotation using `glm::slerp`; also add compatibility checks in `areViewpointsInterpolationCompatible` and orbital tracking state (`m_orbitalTotalAngleRad`, `m_orbitalLastAppliedRad`, `m_orbitalUsesExamine`).
- Remove per-parameter incremental delta members and replace them with `m_viewpoints` and `m_viewpointControlTimes` vectors and simplified frame/encoding state handling; use safer numeric clamping for frame counts and time calculations.
- Update `DialogExportVideo` to accept an animation config id via `setAnimationConfigId` and orbital degrees via `setOrbitalDegrees`, remove direct viewpoint pick UI, and wire `ToolBarAnimationGroup` to pass the selected animation config id and orbital degrees when opening the dialog.

### Testing
- Project compiled successfully after the changes and UI form adjustments.
- Ran the project's automated test suite and integration checks for video export flows; tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8842a2628832f8f2ffa6942a5cf28)