### PR TITLE
Add advanced transparency HDR controls (knee start, softness, boost) and wire through UI, serialization, renderer and shader

### DIFF
--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -253,15 +253,17 @@ public:
 class GuiDataRenderTransparencyOptions : public GuiDataActiveCamera
 {
 public:
-	GuiDataRenderTransparencyOptions(bool negativeColors, bool reduceFlash, bool flashAdvanced, float flashControl, float hlt, SafePtr<CameraNode> camera);
+	GuiDataRenderTransparencyOptions(bool negativeColors, bool reduceFlash, bool flashAdvanced, float kneeStart, float kneeSoftness, float advancedBoost, float hlt, SafePtr<CameraNode> camera);
 	~GuiDataRenderTransparencyOptions() {};
 	virtual guiDType getType() override;
 
 public:
 	bool m_negativeEffect;
 	bool m_reduceFlash;
-    bool m_flashAdvanced;
-    float m_flashControl;
+	bool m_flashAdvanced;
+	float m_highlightKneeStart;
+	float m_highlightKneeSoftness;
+	float m_advancedFlashBoost;
 	float m_highLuminosityThreshold;
 };
 

--- a/include/gui/toolBars/ToolBarRenderTransparency.h
+++ b/include/gui/toolBars/ToolBarRenderTransparency.h
@@ -32,7 +32,7 @@ private:
 
 	void blockAllSignals(bool block);
 	void enableUI(bool transparencyActive);
-    void updateFlashControlState();
+	void updateAdvancedControlsState();
 
 	void sendTransparency();
 	void sendTransparencyOptions();

--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -231,7 +231,9 @@
 #define Key_NegativeEffect				"NegativeEffect"
 #define Key_ReduceFlash					"ReduceFlash"
 #define Key_FlashAdvanced               "FlashAdvanced"
-#define Key_FlashControl                "FlashControl"
+#define Key_HighlightKneeStart          "HighlightKneeStart"
+#define Key_HighlightKneeSoftness       "HighlightKneeSoftness"
+#define Key_AdvancedFlashBoost          "AdvancedFlashBoost"
 #define Key_Transparency				"Transparency"
 
 #define Key_Post_Rendering_Normals		"PostRenderingNormals"

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -91,7 +91,9 @@ public:
     bool           m_negativeEffect = false;
     bool           m_reduceFlash = true;
     bool           m_flashAdvanced = false;
-    float          m_flashControl = 80.f; // [0.0, 100.0]
+    float          m_highlightKneeStart = 10.f; // [0.0, 100.0]
+    float          m_highlightKneeSoftness = 50.f; // [0.0, 100.0]
+    float          m_advancedFlashBoost = 20.f; // [0.0, 100.0]
     float          m_transparency = 10.f; // [0.0, 100.0]
 
     // Post processing

--- a/src/gui/DisplayPresetManager.cpp
+++ b/src/gui/DisplayPresetManager.cpp
@@ -72,7 +72,9 @@ namespace
 		json[Key_NegativeEffect] = params.m_negativeEffect;
 		json[Key_ReduceFlash] = params.m_reduceFlash;
 		json[Key_FlashAdvanced] = params.m_flashAdvanced;
-		json[Key_FlashControl] = params.m_flashControl;
+		json[Key_HighlightKneeStart] = params.m_highlightKneeStart;
+		json[Key_HighlightKneeSoftness] = params.m_highlightKneeSoftness;
+		json[Key_AdvancedFlashBoost] = params.m_advancedFlashBoost;
 		json[Key_Transparency] = params.m_transparency;
 
 		json[Key_Post_Rendering_Normals] = { params.m_postRenderingNormals.show, params.m_postRenderingNormals.inverseTone, params.m_postRenderingNormals.blendColor, params.m_postRenderingNormals.normalStrength, params.m_postRenderingNormals.gloss };
@@ -296,10 +298,20 @@ namespace
 		else
 			data.m_flashAdvanced = false;
 
-		if (json.find(Key_FlashControl) != json.end())
-			data.m_flashControl = json.at(Key_FlashControl).get<float>();
+		if (json.find(Key_HighlightKneeStart) != json.end())
+			data.m_highlightKneeStart = json.at(Key_HighlightKneeStart).get<float>();
 		else
-			data.m_flashControl = 50.f;
+			data.m_highlightKneeStart = 10.f;
+
+		if (json.find(Key_HighlightKneeSoftness) != json.end())
+			data.m_highlightKneeSoftness = json.at(Key_HighlightKneeSoftness).get<float>();
+		else
+			data.m_highlightKneeSoftness = 50.f;
+
+		if (json.find(Key_AdvancedFlashBoost) != json.end())
+			data.m_advancedFlashBoost = json.at(Key_AdvancedFlashBoost).get<float>();
+		else
+			data.m_advancedFlashBoost = 20.f;
 
 		if (json.find(Key_Transparency) != json.end())
 			data.m_transparency = json.at(Key_Transparency).get<float>();
@@ -933,7 +945,7 @@ void DisplayPresetManager::applyPreset(const DisplayPreset& preset)
 	m_dataDispatcher.updateInformation(new GuiDataRenderFlatColor(params.m_flatColor, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderDistanceRampValues(params.m_distRampMin, params.m_distRampMax, params.m_distRampSteps, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderTransparency(params.m_blendMode, params.m_transparency, m_focusCamera), this);
-	m_dataDispatcher.updateInformation(new GuiDataRenderTransparencyOptions(params.m_negativeEffect, params.m_reduceFlash, params.m_flashAdvanced, params.m_flashControl, 0.f, m_focusCamera), this);
+	m_dataDispatcher.updateInformation(new GuiDataRenderTransparencyOptions(params.m_negativeEffect, params.m_reduceFlash, params.m_flashAdvanced, params.m_highlightKneeStart, params.m_highlightKneeSoftness, params.m_advancedFlashBoost, 0.f, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataPostRenderingNormals(params.m_postRenderingNormals, false, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderAmbientOcclusion(params.m_postRenderingAmbientOcclusion, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(params.m_edgeAwareBlur, m_focusCamera), this);

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -234,12 +234,14 @@ guiDType GuiDataRenderTransparency::getType()
 
 //*** Transparency Options ***//
 
-GuiDataRenderTransparencyOptions::GuiDataRenderTransparencyOptions(bool negativeEffect, bool reduceFlash, bool flashAdvanced, float flashControl, float hlt, SafePtr<CameraNode> camera)
+GuiDataRenderTransparencyOptions::GuiDataRenderTransparencyOptions(bool negativeEffect, bool reduceFlash, bool flashAdvanced, float kneeStart, float kneeSoftness, float advancedBoost, float hlt, SafePtr<CameraNode> camera)
 	: GuiDataActiveCamera(camera)
 	, m_negativeEffect(negativeEffect)
 	, m_reduceFlash(reduceFlash)
-    , m_flashAdvanced(flashAdvanced)
-    , m_flashControl(flashControl)
+	, m_flashAdvanced(flashAdvanced)
+	, m_highlightKneeStart(kneeStart)
+	, m_highlightKneeSoftness(kneeSoftness)
+	, m_advancedFlashBoost(advancedBoost)
 	, m_highLuminosityThreshold(hlt)
 {}
 

--- a/src/gui/forms/toolbar_rendertransparencygroup.ui
+++ b/src/gui/forms/toolbar_rendertransparencygroup.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>462</width>
-    <height>105</height>
+    <width>900</width>
+    <height>108</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -66,14 +66,14 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_flashControl">
+    <widget class="QLabel" name="label_kneeStart">
      <property name="text">
-      <string>Flash control</string>
+      <string>Knee start</string>
      </property>
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QSlider" name="slider_flashControl">
+    <widget class="QSlider" name="slider_kneeStart">
      <property name="minimumSize">
       <size>
        <width>100</width>
@@ -87,8 +87,8 @@
       <number>100</number>
      </property>
      <property name="value">
-      <number>50</number>
-     </property>
+      <number>10</number>
+      </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -118,7 +118,55 @@
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="QSpinBox" name="spinBox_flashControl">
+    <widget class="QSpinBox" name="spinBox_kneeStart">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>10</number>
+      </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QLabel" name="label_kneeSoftness">
+     <property name="text">
+      <string>Knee softness</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QSlider" name="slider_kneeSoftness">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>50</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="tickPosition">
+      <enum>QSlider::TicksAbove</enum>
+     </property>
+     <property name="tickInterval">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="5">
+    <widget class="QSpinBox" name="spinBox_kneeSoftness">
      <property name="minimum">
       <number>0</number>
      </property>
@@ -130,7 +178,55 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+   <item row="1" column="3">
+    <widget class="QLabel" name="label_advancedBoost">
+     <property name="text">
+      <string>Advanced boost</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QSlider" name="slider_advancedBoost">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>20</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="tickPosition">
+      <enum>QSlider::TicksAbove</enum>
+     </property>
+     <property name="tickInterval">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="5">
+    <widget class="QSpinBox" name="spinBox_advancedBoost">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>20</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="6">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -160,7 +256,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3" rowspan="4">
+   <item row="1" column="6" rowspan="4">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -176,7 +272,7 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="3">
+   <item row="0" column="6">
     <widget class="QCheckBox" name="checkBox_negativeEffect">
      <property name="text">
       <string>Negative Effect</string>

--- a/src/gui/toolBars/ToolBarRenderTransparency.cpp
+++ b/src/gui/toolBars/ToolBarRenderTransparency.cpp
@@ -14,7 +14,9 @@ ToolBarRenderTransparency::ToolBarRenderTransparency(IDataDispatcher& dataDispat
     setEnabled(false);
 
     m_ui.slider_transparency->setMinimumWidth(100.f * guiScale);
-    m_ui.slider_flashControl->setMinimumWidth(100.f * guiScale);
+    m_ui.slider_kneeStart->setMinimumWidth(100.f * guiScale);
+    m_ui.slider_kneeSoftness->setMinimumWidth(100.f * guiScale);
+    m_ui.slider_advancedBoost->setMinimumWidth(100.f * guiScale);
 
     connect(m_ui.slider_transparency, &QSlider::valueChanged, m_ui.spinBox_transparency, &QSpinBox::setValue);
     connect(m_ui.spinBox_transparency, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_transparency, &QSlider::setValue);
@@ -26,9 +28,15 @@ ToolBarRenderTransparency::ToolBarRenderTransparency(IDataDispatcher& dataDispat
     connect(m_ui.checkBox_negativeEffect, &QCheckBox::stateChanged, this, &ToolBarRenderTransparency::slotTransparencyOptionsChanged);
     connect(m_ui.basicEnhanceContrastRadioButton, &QRadioButton::toggled, this, &ToolBarRenderTransparency::slotTransparencyOptionsChanged);
     connect(m_ui.advEnhanceContrastRadioButton, &QRadioButton::toggled, this, &ToolBarRenderTransparency::slotTransparencyOptionsChanged);
-    connect(m_ui.slider_flashControl, &QSlider::valueChanged, m_ui.spinBox_flashControl, &QSpinBox::setValue);
-    connect(m_ui.spinBox_flashControl, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_flashControl, &QSlider::setValue);
-    connect(m_ui.slider_flashControl, &QSlider::valueChanged, this, &ToolBarRenderTransparency::slotTransparencyOptionsChanged);
+    connect(m_ui.slider_kneeStart, &QSlider::valueChanged, m_ui.spinBox_kneeStart, &QSpinBox::setValue);
+    connect(m_ui.spinBox_kneeStart, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_kneeStart, &QSlider::setValue);
+    connect(m_ui.slider_kneeStart, &QSlider::valueChanged, this, &ToolBarRenderTransparency::slotTransparencyOptionsChanged);
+    connect(m_ui.slider_kneeSoftness, &QSlider::valueChanged, m_ui.spinBox_kneeSoftness, &QSpinBox::setValue);
+    connect(m_ui.spinBox_kneeSoftness, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_kneeSoftness, &QSlider::setValue);
+    connect(m_ui.slider_kneeSoftness, &QSlider::valueChanged, this, &ToolBarRenderTransparency::slotTransparencyOptionsChanged);
+    connect(m_ui.slider_advancedBoost, &QSlider::valueChanged, m_ui.spinBox_advancedBoost, &QSpinBox::setValue);
+    connect(m_ui.spinBox_advancedBoost, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_advancedBoost, &QSlider::setValue);
+    connect(m_ui.slider_advancedBoost, &QSlider::valueChanged, this, &ToolBarRenderTransparency::slotTransparencyOptionsChanged);
 
     registerGuiDataFunction(guiDType::projectLoaded, &ToolBarRenderTransparency::onProjectLoad);
     registerGuiDataFunction(guiDType::renderActiveCamera, &ToolBarRenderTransparency::onActiveCamera);
@@ -87,11 +95,15 @@ void ToolBarRenderTransparency::onActiveCamera(IGuiData* idata)
     m_ui.checkBox_enhanceContrast->setChecked(displayParameters.m_reduceFlash);
     m_ui.basicEnhanceContrastRadioButton->setChecked(!displayParameters.m_flashAdvanced);
     m_ui.advEnhanceContrastRadioButton->setChecked(displayParameters.m_flashAdvanced);
-    m_ui.spinBox_flashControl->setValue(static_cast<int>(displayParameters.m_flashControl));
-    m_ui.slider_flashControl->setValue(static_cast<int>(displayParameters.m_flashControl));
+    m_ui.spinBox_kneeStart->setValue(static_cast<int>(displayParameters.m_highlightKneeStart));
+    m_ui.slider_kneeStart->setValue(static_cast<int>(displayParameters.m_highlightKneeStart));
+    m_ui.spinBox_kneeSoftness->setValue(static_cast<int>(displayParameters.m_highlightKneeSoftness));
+    m_ui.slider_kneeSoftness->setValue(static_cast<int>(displayParameters.m_highlightKneeSoftness));
+    m_ui.spinBox_advancedBoost->setValue(static_cast<int>(displayParameters.m_advancedFlashBoost));
+    m_ui.slider_advancedBoost->setValue(static_cast<int>(displayParameters.m_advancedFlashBoost));
 
     blockAllSignals(false);
-    updateFlashControlState();
+    updateAdvancedControlsState();
 }
 
 
@@ -104,8 +116,12 @@ void ToolBarRenderTransparency::blockAllSignals(bool block)
     m_ui.checkBox_enhanceContrast->blockSignals(block);
     m_ui.basicEnhanceContrastRadioButton->blockSignals(block);
     m_ui.advEnhanceContrastRadioButton->blockSignals(block);
-    m_ui.slider_flashControl->blockSignals(block);
-    m_ui.spinBox_flashControl->blockSignals(block);
+    m_ui.slider_kneeStart->blockSignals(block);
+    m_ui.spinBox_kneeStart->blockSignals(block);
+    m_ui.slider_kneeSoftness->blockSignals(block);
+    m_ui.spinBox_kneeSoftness->blockSignals(block);
+    m_ui.slider_advancedBoost->blockSignals(block);
+    m_ui.spinBox_advancedBoost->blockSignals(block);
 }
 
 void ToolBarRenderTransparency::enableUI(bool transparencyActive)
@@ -114,7 +130,7 @@ void ToolBarRenderTransparency::enableUI(bool transparencyActive)
     m_ui.slider_transparency->setEnabled(transparencyActive);
     m_ui.checkBox_enhanceContrast->setEnabled(transparencyActive);
     m_ui.checkBox_negativeEffect->setEnabled(transparencyActive);
-    updateFlashControlState();
+    updateAdvancedControlsState();
 }
 
 void ToolBarRenderTransparency::sendTransparency()
@@ -128,8 +144,10 @@ void ToolBarRenderTransparency::sendTransparency()
 void ToolBarRenderTransparency::sendTransparencyOptions()
 {
     bool advanced = m_ui.advEnhanceContrastRadioButton->isChecked();
-    float flashControl = static_cast<float>(m_ui.slider_flashControl->value());
-    m_dataDispatcher.updateInformation(new GuiDataRenderTransparencyOptions(m_ui.checkBox_negativeEffect->isChecked(), m_ui.checkBox_enhanceContrast->isChecked(), advanced, flashControl, 0.f, m_focusCamera));
+    float kneeStart = static_cast<float>(m_ui.slider_kneeStart->value());
+    float kneeSoftness = static_cast<float>(m_ui.slider_kneeSoftness->value());
+    float advancedBoost = static_cast<float>(m_ui.slider_advancedBoost->value());
+    m_dataDispatcher.updateInformation(new GuiDataRenderTransparencyOptions(m_ui.checkBox_negativeEffect->isChecked(), m_ui.checkBox_enhanceContrast->isChecked(), advanced, kneeStart, kneeSoftness, advancedBoost, 0.f, m_focusCamera));
 }
 
 void ToolBarRenderTransparency::slotTranparencyActivationChanged(int value)
@@ -145,11 +163,11 @@ void ToolBarRenderTransparency::slotTransparencyValueChanged(int value)
 
 void ToolBarRenderTransparency::slotTransparencyOptionsChanged(int value)
 {
-    updateFlashControlState();
+    updateAdvancedControlsState();
     sendTransparencyOptions();
 }
 
-void ToolBarRenderTransparency::updateFlashControlState()
+void ToolBarRenderTransparency::updateAdvancedControlsState()
 {
     bool transparencyActive = m_ui.checkBox_transparency->isChecked();
     bool enhance = transparencyActive && m_ui.checkBox_enhanceContrast->isChecked();
@@ -157,7 +175,13 @@ void ToolBarRenderTransparency::updateFlashControlState()
     m_ui.advEnhanceContrastRadioButton->setEnabled(enhance);
 
     bool advanced = enhance && m_ui.advEnhanceContrastRadioButton->isChecked();
-    m_ui.slider_flashControl->setEnabled(advanced);
-    m_ui.spinBox_flashControl->setEnabled(advanced);
-    m_ui.label_flashControl->setEnabled(advanced);
+    m_ui.slider_kneeStart->setEnabled(advanced);
+    m_ui.spinBox_kneeStart->setEnabled(advanced);
+    m_ui.label_kneeStart->setEnabled(advanced);
+    m_ui.slider_kneeSoftness->setEnabled(advanced);
+    m_ui.spinBox_kneeSoftness->setEnabled(advanced);
+    m_ui.label_kneeSoftness->setEnabled(advanced);
+    m_ui.slider_advancedBoost->setEnabled(advanced);
+    m_ui.spinBox_advancedBoost->setEnabled(advanced);
+    m_ui.label_advancedBoost->setEnabled(advanced);
 }

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -364,7 +364,9 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 	json[Key_NegativeEffect] = params.m_negativeEffect;
 	json[Key_ReduceFlash] = params.m_reduceFlash;
     json[Key_FlashAdvanced] = params.m_flashAdvanced;
-    json[Key_FlashControl] = params.m_flashControl;
+    json[Key_HighlightKneeStart] = params.m_highlightKneeStart;
+    json[Key_HighlightKneeSoftness] = params.m_highlightKneeSoftness;
+    json[Key_AdvancedFlashBoost] = params.m_advancedFlashBoost;
 	json[Key_Transparency] = params.m_transparency;
 
     json[Key_Post_Rendering_Normals] = { params.m_postRenderingNormals.show, params.m_postRenderingNormals.inverseTone, params.m_postRenderingNormals.blendColor, params.m_postRenderingNormals.normalStrength, params.m_postRenderingNormals.gloss };

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -575,14 +575,20 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
         data.m_flashAdvanced = false;
     }
 
-    if (json.find(Key_FlashControl) != json.end())
-    {
-        data.m_flashControl = json.at(Key_FlashControl).get<float>();
-    }
+    if (json.find(Key_HighlightKneeStart) != json.end())
+        data.m_highlightKneeStart = json.at(Key_HighlightKneeStart).get<float>();
     else
-    {
-        data.m_flashControl = 50.f;
-    }
+        data.m_highlightKneeStart = 10.f;
+
+    if (json.find(Key_HighlightKneeSoftness) != json.end())
+        data.m_highlightKneeSoftness = json.at(Key_HighlightKneeSoftness).get<float>();
+    else
+        data.m_highlightKneeSoftness = 50.f;
+
+    if (json.find(Key_AdvancedFlashBoost) != json.end())
+        data.m_advancedFlashBoost = json.at(Key_AdvancedFlashBoost).get<float>();
+    else
+        data.m_advancedFlashBoost = 20.f;
 
     if (json.find(Key_Transparency) != json.end())
     {

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -2245,7 +2245,9 @@ void CameraNode::onRenderTransparencyOptions(IGuiData* data)
     auto castData = static_cast<GuiDataRenderTransparencyOptions*>(data);
     m_reduceFlash = castData->m_reduceFlash;
     m_flashAdvanced = castData->m_flashAdvanced;
-    m_flashControl = castData->m_flashControl;
+    m_highlightKneeStart = castData->m_highlightKneeStart;
+    m_highlightKneeSoftness = castData->m_highlightKneeSoftness;
+    m_advancedFlashBoost = castData->m_advancedFlashBoost;
     m_negativeEffect = castData->m_negativeEffect;
     sendNewUIViewPoint();
 }

--- a/src/pointCloudEngine/RenderingEcoSystem.cpp
+++ b/src/pointCloudEngine/RenderingEcoSystem.cpp
@@ -122,7 +122,9 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
     hash += hash_fn_32((uint32_t)display.m_negativeEffect);
     hash += hash_fn_32((uint32_t)display.m_reduceFlash);
     hash += hash_fn_32((uint32_t)display.m_flashAdvanced);
-    hash += hash_fn_f(display.m_flashControl);
+    hash += hash_fn_f(display.m_highlightKneeStart);
+    hash += hash_fn_f(display.m_highlightKneeSoftness);
+    hash += hash_fn_f(display.m_advancedFlashBoost);
     hash += hash_fn_f(display.m_transparency);
 
     hash += hash_fn_b(display.m_postRenderingNormals.show);

--- a/src/pointCloudEngine/RenderingEngine.cpp
+++ b/src/pointCloudEngine/RenderingEngine.cpp
@@ -891,7 +891,7 @@ bool RenderingEngine::updateFramebuffer(VulkanViewport& viewport)
         if (display.m_blendMode != BlendMode::Opaque && display.m_transparency > 0.f)
         {
             vkm.beginPostTreatmentTransparency(framebuffer);
-            m_postRenderer.setConstantHDR(display.m_transparency, display.m_negativeEffect, display.m_reduceFlash, display.m_flashAdvanced, display.m_flashControl, framebuffer->extent, display.m_backgroundColor, cmdBuffer);
+            m_postRenderer.setConstantHDR(display.m_transparency, display.m_negativeEffect, display.m_reduceFlash, display.m_flashAdvanced, display.m_highlightKneeStart, display.m_highlightKneeSoftness, display.m_advancedFlashBoost, framebuffer->extent, display.m_backgroundColor, cmdBuffer);
             m_postRenderer.processTransparencyHDR(cmdBuffer, framebuffer->descSetSamplers, framebuffer->extent);
         }
     }
@@ -1068,7 +1068,7 @@ bool RenderingEngine::renderVirtualViewport(TlFramebuffer framebuffer, const Cam
     if (displayParam.m_blendMode != BlendMode::Opaque && displayParam.m_transparency > 0.f)
     {
         vkm.beginPostTreatmentTransparency(framebuffer);
-        m_postRenderer.setConstantHDR(displayParam.m_transparency, displayParam.m_negativeEffect, displayParam.m_reduceFlash, displayParam.m_flashAdvanced, displayParam.m_flashControl, framebuffer->extent, displayParam.m_backgroundColor, cmdBuffer);
+        m_postRenderer.setConstantHDR(displayParam.m_transparency, displayParam.m_negativeEffect, displayParam.m_reduceFlash, displayParam.m_flashAdvanced, displayParam.m_highlightKneeStart, displayParam.m_highlightKneeSoftness, displayParam.m_advancedFlashBoost, framebuffer->extent, displayParam.m_backgroundColor, cmdBuffer);
         m_postRenderer.processTransparencyHDR(cmdBuffer, framebuffer->descSetSamplers, framebuffer->extent);
     }
 

--- a/src/shaders/post_rendering/transparency_hdr.comp
+++ b/src/shaders/post_rendering/transparency_hdr.comp
@@ -13,7 +13,9 @@ layout(push_constant) uniform PC {
    layout(offset = 16) vec3 background;
    layout(offset = 28) int noFlash;
    layout(offset = 32) int flashAdvanced;
-   layout(offset = 36) float flashControl; // slider value [0..100]
+   layout(offset = 36) float highlightKneeStart;    // [0..100]
+   layout(offset = 40) float highlightKneeSoftness; // [0..100]
+   layout(offset = 44) float advancedFlashBoost;    // [0..100]
 } pc;
 
 void main() 
@@ -48,15 +50,24 @@ void main()
       }
       else
       {
-         // Advanced mode: tone-map luminance only and preserve chroma
-         // Map slider [0..100] to exposure in [0.2, 10.0]
-         float exposure = 0.2 + clamp(pc.flashControl, 0.0, 100.0) * (10.0 - 0.2) / 100.0;
+         // Advanced mode: soft-knee luminance compression while preserving chroma
          const vec3 luma = vec3(0.2126, 0.7152, 0.0722);
          float Y = dot(c_rgb, luma);
-         // Knee to keep mid-tones intact
-         float Y0 = 0.6;
-         float high = max(Y - Y0, 0.0);
-         float Yt = Y0 + (1.0 - exp(-exposure * high));
+
+         float knee = clamp(pc.highlightKneeStart, 0.0, 100.0) / 100.0;
+         float softness = clamp(pc.highlightKneeSoftness, 0.0, 100.0) / 100.0;
+         float boost = clamp(pc.advancedFlashBoost, 0.0, 100.0) / 100.0;
+         float high = max(Y - knee, 0.0);
+         float softRange = mix(0.05, 1.0, softness);
+         float Yt = knee + softRange * log(1.0 + high / softRange);
+
+         // Re-dynamize low/mid tones while preserving highlight compression
+         float shadowWeight = (knee < 0.999)
+            ? (1.0 - smoothstep(knee, 1.0, Y))
+            : float(Y < 1.0);
+         float boostGain = 1.0 + boost * 0.8 * shadowWeight;
+         Yt *= boostGain;
+
          float scale = (Y > 1e-6) ? (Yt / Y) : 1.0;
          c_rgb *= scale;
       }

--- a/src/vulkan/Renderers/PostRenderer.cpp
+++ b/src/vulkan/Renderers/PostRenderer.cpp
@@ -593,7 +593,7 @@ void PostRenderer::setConstantLighting(const PostRenderingNormals& lighting, VkC
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_normalPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 52, 4, &blend);
 }
 
-void PostRenderer::setConstantHDR(float opacity, bool substract, bool noFlash, bool flashAdvanced, float flashControl, VkExtent2D screenSize, Color32 background, VkCommandBuffer _cmdBuffer)
+void PostRenderer::setConstantHDR(float opacity, bool substract, bool noFlash, bool flashAdvanced, float highlightKneeStart, float highlightKneeSoftness, float advancedFlashBoost, VkExtent2D screenSize, Color32 background, VkCommandBuffer _cmdBuffer)
 {
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_transparencyHDRPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, 4, &opacity);
     int mode = substract ? 1 : 0;
@@ -605,7 +605,9 @@ void PostRenderer::setConstantHDR(float opacity, bool substract, bool noFlash, b
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_transparencyHDRPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 28, 4, &iNoFlash);
     int iAdvanced = flashAdvanced ? 1 : 0;
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_transparencyHDRPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 32, 4, &iAdvanced);
-    h_pfn->vkCmdPushConstants(_cmdBuffer, m_transparencyHDRPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 36, 4, &flashControl);
+    h_pfn->vkCmdPushConstants(_cmdBuffer, m_transparencyHDRPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 36, 4, &highlightKneeStart);
+    h_pfn->vkCmdPushConstants(_cmdBuffer, m_transparencyHDRPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 40, 4, &highlightKneeSoftness);
+    h_pfn->vkCmdPushConstants(_cmdBuffer, m_transparencyHDRPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 44, 4, &advancedFlashBoost);
 }
 
 void PostRenderer::cleanup()

--- a/src/vulkan/Renderers/PostRenderer.h
+++ b/src/vulkan/Renderers/PostRenderer.h
@@ -41,7 +41,7 @@ public:
     void setConstantTexelThreshold(int texelThreshold, VkCommandBuffer _cmdBuffer);
     void setConstantLighting(const PostRenderingNormals& lighting, VkCommandBuffer _cmdBuffer) const;
 
-    void setConstantHDR(float transparency, bool substract, bool noFlash, bool flashAdvanced, float flashControl, VkExtent2D screenSize, Color32 background, VkCommandBuffer _cmdBuffer);
+    void setConstantHDR(float transparency, bool substract, bool noFlash, bool flashAdvanced, float highlightKneeStart, float highlightKneeSoftness, float advancedFlashBoost, VkExtent2D screenSize, Color32 background, VkCommandBuffer _cmdBuffer);
 
     void cleanup();
 


### PR DESCRIPTION
### Motivation
- Replace the legacy single `flashControl` parameter with a more expressive advanced HDR tone-mapping model exposing `highlightKneeStart`, `highlightKneeSoftness` and `advancedFlashBoost` for improved highlight handling and boost of low/mid tones.
- Expose the new controls in the transparency toolbar and persist them through presets/serialization so advanced transparency settings survive save/load and rendering pipelines.

### Description
- Replaced `m_flashControl` with `m_highlightKneeStart`, `m_highlightKneeSoftness`, and `m_advancedFlashBoost` in `DisplayParameters` and related GUI data class `GuiDataRenderTransparencyOptions` and updated constructor/signatures accordingly.
- Updated serializer keys in `SerializerKeys.h` and wired new keys through `DisplayPresetManager`, `DataSerializer::ExportRenderingParameters`, and `DataDeserializer::ImportDisplayParameters` to preserve the new parameters in presets/import/export flows.
- Extended the transparency UI form `toolbar_rendertransparencygroup.ui` with three controls (knee start, knee softness, advanced boost), resized layout, and updated `ToolBarRenderTransparency` to connect signals/slots, block signals, propagate changes, and enable/disable advanced controls via `updateAdvancedControlsState`.
- Propagated new parameters to runtime: updated `CameraNode::onRenderTransparencyOptions`, hashing in `RenderingEcoSystem::hashRenderingData`, and places that send `GuiDataRenderTransparencyOptions` to include the new fields.
- Wired renderer and shader to use the new parameters: `PostRenderer::setConstantHDR` signature changed and push-constant offsets updated, `RenderingEngine` calls updated to pass the new params, and the compute shader `transparency_hdr.comp` now implements a soft-knee compression, softness and boost algorithm to replace the old exposure-based advanced flash behavior.

### Testing
- Performed a full project rebuild after changes and the codebase compiled successfully with the updated headers, sources, UI form and shader push constants.
- Ran the repository's automated test suite and CI checks (unit/integration) and they completed successfully on the updated branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9aad15854832faf10d51b13e61745)