### PR TITLE
Add vertical orbital animation option and propagate to export/UI/viewport

### DIFF
--- a/include/controller/functionSystem/ContextExportVideoHD.h
+++ b/include/controller/functionSystem/ContextExportVideoHD.h
@@ -44,7 +44,10 @@ private:
 	std::vector<double> m_viewpointControlTimes;
 	double m_orbitalTotalAngleRad = 0.0;
 	double m_orbitalLastAppliedRad = 0.0;
+	double m_orbitalRealAppliedRad = 0.0;
+	double m_orbitalDirectionSign = 1.0;
 	bool m_orbitalUsesExamine = false;
+	bool m_orbitalVertical = false;
 
 	std::chrono::steady_clock::time_point m_tpStart;
 	DecimationOptions m_precedentOptions;

--- a/include/gui/Dialog/DialogExportVideo.h
+++ b/include/gui/Dialog/DialogExportVideo.h
@@ -38,6 +38,7 @@ public:
     void setInterpolateRenderings(bool interpolate);
     void setAnimationConfigId(const viewPointAnimationId& id);
     void setOrbitalDegrees(int degrees);
+    void setVerticalOrbital(bool vertical);
 
 private:
     Ui::DialogExportVideo m_ui;
@@ -48,6 +49,7 @@ private:
 	bool m_interpolateRenderings = false;
 	viewPointAnimationId m_animationConfigId;
 	int m_orbitalDegrees = 360;
+	bool m_verticalOrbital = false;
 
     static constexpr uint64_t MAX_MP4_PIXELS = 8294400;
 };

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -379,12 +379,13 @@ public:
 class GuiDataRenderStartAnimation : public IGuiData
 {
 public:
-	GuiDataRenderStartAnimation(bool isOrbital = false, double durationSeconds = 0.0, bool resume = false, int orbitalDegrees = 360, bool interpolateViewpointRenderings = false)
+	GuiDataRenderStartAnimation(bool isOrbital = false, double durationSeconds = 0.0, bool resume = false, int orbitalDegrees = 360, bool interpolateViewpointRenderings = false, bool verticalOrbital = false)
 		: m_isOrbital(isOrbital)
 		, m_durationSeconds(durationSeconds)
 		, m_resume(resume)
 		, m_orbitalDegrees(orbitalDegrees)
 		, m_interpolateViewpointRenderings(interpolateViewpointRenderings)
+		, m_verticalOrbital(verticalOrbital)
 	{}
 	~GuiDataRenderStartAnimation() {}
 	virtual guiDType getType() override;
@@ -394,6 +395,7 @@ public:
 	const bool m_resume;
 	const int m_orbitalDegrees;
 	const bool m_interpolateViewpointRenderings;
+	const bool m_verticalOrbital;
 };
 
 class GuiDataRenderPauseAnimation : public IGuiData

--- a/include/gui/toolBars/ToolBarAnimationGroup.h
+++ b/include/gui/toolBars/ToolBarAnimationGroup.h
@@ -48,11 +48,13 @@ private slots:
 	void slotPauseAnimation();
 	void slotGenerateVideo();
 	void slotAnimationModeChanged();
+	void slotVerticalOrbitalToggled(bool checked);
 	void slotNewViewPointAnimationConfig();
 	void slotEditViewPointAnimationConfig();
 	void slotAnimationConfigChanged(int index);
 	void onAnimationData(IGuiData* keyValue);
 	void slotChronometerTick();
+	void updateOrbitalDegreesUI();
 
 private:
 	std::unordered_map<guiDType, AnimGroupMethod> m_methods;

--- a/include/gui/viewport/VulkanViewport.h
+++ b/include/gui/viewport/VulkanViewport.h
@@ -301,9 +301,12 @@ private:
     // as a viewpoints animation start.
     bool m_viewpointStartInputLockArmed = false;
     bool m_orbitalUsesExamine = false;
+    bool m_orbitalVertical = false;
+    double m_orbitalDirectionSign = 1.0;
     double m_orbitalDurationSeconds = 0.0;
     double m_orbitalElapsedSeconds = 0.0;
-    double m_orbitalAppliedAngle = 0.0;
+    double m_orbitalAppliedAngle = 0.0; // theoretical target reached
+    double m_orbitalAppliedRealAngle = 0.0; // physically applied by camera (after constraints)
     double m_orbitalTotalAngleRad = 0.0;
     std::chrono::steady_clock::time_point m_orbitalStartTime;
 };

--- a/include/io/exports/ExportParameters.hpp
+++ b/include/io/exports/ExportParameters.hpp
@@ -72,6 +72,7 @@ struct VideoExportParameters
     VideoAnimationMode animMode = VideoAnimationMode::NONE;
     viewPointAnimationId viewPointAnimation = xg::Guid();
     int orbitalDegrees = 360;
+    bool verticalOrbital = false;
     bool interpolateRenderingBetweenViewpoints = false;
     bool openFolderAfterExport = false;
 

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -70,7 +70,10 @@ ContextState ContextExportVideoHD::start(Controller& controller)
     m_viewpointControlTimes.clear();
     m_orbitalTotalAngleRad = 0.0;
     m_orbitalLastAppliedRad = 0.0;
+    m_orbitalRealAppliedRad = 0.0;
+    m_orbitalDirectionSign = 1.0;
     m_orbitalUsesExamine = false;
+    m_orbitalVertical = false;
     DecimationOptions noDecimation = m_precedentOptions;
     noDecimation.mode = DecimationMode::None;
     controller.updateInfo(new GuiDataRenderDecimationOptions(noDecimation));
@@ -205,8 +208,12 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
         {
             m_viewpoints.clear();
             m_viewpointControlTimes.clear();
-            m_orbitalTotalAngleRad = glm::radians(static_cast<double>(std::clamp(m_parameters.orbitalDegrees, 1, 360)));
+            m_orbitalVertical = m_parameters.verticalOrbital;
+            m_orbitalDirectionSign = 1.0; // reserved for future inversion option
+            const int maxDegrees = m_orbitalVertical ? 180 : 360;
+            m_orbitalTotalAngleRad = glm::radians(static_cast<double>(std::clamp(m_parameters.orbitalDegrees, 1, maxDegrees)));
             m_orbitalLastAppliedRad = 0.0;
+            m_orbitalRealAppliedRad = 0.0;
             m_orbitalUsesExamine = wCam->isExamineActive();
         }
 
@@ -271,11 +278,31 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             const double delta = target - m_orbitalLastAppliedRad;
             if (delta > 0.0)
             {
-                if (m_orbitalUsesExamine)
-                    wCam->moveAroundExamine(0.0, delta, 0.0);
+                if (m_orbitalVertical)
+                {
+                    const double signedDelta = m_orbitalDirectionSign * delta;
+                    const double phiBefore = wCam->getPhi();
+                    if (m_orbitalUsesExamine)
+                        wCam->moveAroundExamine(0.0, 0.0, signedDelta);
+                    else
+                        wCam->pitch(signedDelta);
+                    const double phiAfter = wCam->getPhi();
+                    m_orbitalRealAppliedRad += std::abs(phiAfter - phiBefore);
+                }
                 else
-                    wCam->yaw(delta);
+                {
+                    if (m_orbitalUsesExamine)
+                        wCam->moveAroundExamine(0.0, delta, 0.0);
+                    else
+                        wCam->yaw(delta);
+                    m_orbitalRealAppliedRad = target;
+                }
                 m_orbitalLastAppliedRad = target;
+            }
+
+            if (m_orbitalRealAppliedRad + 1e-9 >= m_orbitalTotalAngleRad)
+            {
+                m_animFrame = m_totalFrames + 1;
             }
         }
 

--- a/src/gui/Dialog/DialogExportVideo.cpp
+++ b/src/gui/Dialog/DialogExportVideo.cpp
@@ -162,6 +162,7 @@ void DialogExportVideo::startGeneration()
 	m_parameters.length = m_length;
 	m_parameters.viewPointAnimation = m_animationConfigId;
 	m_parameters.orbitalDegrees = m_orbitalDegrees;
+	m_parameters.verticalOrbital = m_verticalOrbital;
 	m_parameters.fps = m_ui.fpsSpinBox->value();
 	m_parameters.hdImage = m_ui.imageHDRadioButton->isChecked();
 	m_parameters.openFolderAfterExport = m_ui.openExplorerFolderCheckBox->isChecked();
@@ -269,5 +270,11 @@ void DialogExportVideo::setAnimationConfigId(const viewPointAnimationId& id)
 
 void DialogExportVideo::setOrbitalDegrees(int degrees)
 {
-	m_orbitalDegrees = std::clamp(degrees, 1, 360);
+	m_orbitalDegrees = std::clamp(degrees, 1, m_verticalOrbital ? 180 : 360);
+}
+
+void DialogExportVideo::setVerticalOrbital(bool vertical)
+{
+	m_verticalOrbital = vertical;
+	m_orbitalDegrees = std::clamp(m_orbitalDegrees, 1, m_verticalOrbital ? 180 : 360);
 }

--- a/src/gui/forms/toolbar_animationgroup.ui
+++ b/src/gui/forms/toolbar_animationgroup.ui
@@ -68,6 +68,16 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QCheckBox" name="verticalOrbitalCheckBox">
+     <property name="text">
+      <string>Vertical</string>
+     </property>
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="2" rowspan="3">
     <widget class="Line" name="line_1">
      <property name="orientation">

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -41,10 +41,13 @@ ToolBarAnimationGroup::ToolBarAnimationGroup(IDataDispatcher &dataDispatcher, QW
 	connect(m_ui.generateVideoPushButton, &QPushButton::clicked, this, &ToolBarAnimationGroup::slotGenerateVideo);
 	connect(m_ui.betweenViewpointsRadioButton, &QRadioButton::clicked, this, &ToolBarAnimationGroup::slotAnimationModeChanged);
 	connect(m_ui.orbital360RadioButton, &QRadioButton::clicked, this, &ToolBarAnimationGroup::slotAnimationModeChanged);
+	connect(m_ui.verticalOrbitalCheckBox, &QCheckBox::toggled, this, &ToolBarAnimationGroup::slotVerticalOrbitalToggled);
 	connect(m_ui.toolButton_newViewpointAnimConfig, &QToolButton::clicked, this, &ToolBarAnimationGroup::slotNewViewPointAnimationConfig);
 	connect(m_ui.toolButton_editViewpointAnimConfig, &QToolButton::clicked, this, &ToolBarAnimationGroup::slotEditViewPointAnimationConfig);
 	connect(m_ui.comboBox_animationList, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ToolBarAnimationGroup::slotAnimationConfigChanged);
 	m_ui.degreesLabel->setEnabled(false);
+	m_ui.verticalOrbitalCheckBox->setChecked(false);
+	updateOrbitalDegreesUI();
 	slotAnimationModeChanged();
 
 	updateUI();
@@ -189,6 +192,7 @@ void ToolBarAnimationGroup::updateUI()
 	m_ui.interpolateCheckBox->setEnabled(canEditViewpoints);
 	m_ui.degreesLabel->setEnabled(m_isProjectLoaded && !viewpointsMode);
 	m_ui.degreesSpinBox->setEnabled(m_isProjectLoaded && !viewpointsMode);
+	m_ui.verticalOrbitalCheckBox->setEnabled(m_isProjectLoaded && !viewpointsMode);
 
 	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
 	const bool usesPositionAsTime = selectedConfig && selectedConfig->getMode() == ViewPointAnimationMode::PositionAsTime;
@@ -207,7 +211,7 @@ void ToolBarAnimationGroup::slotStartAnimation()
 		m_isStopRequested = false;
 		m_pendingViewpointsStart = false;
 		m_waitingChronometerStartAtFirstViewpoint = false;
-		m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), true, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked()));
+		m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), true, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked(), m_ui.verticalOrbitalCheckBox->isChecked()));
 		startChronometer();
 		m_isStarted = true;
 		m_isPaused = false;
@@ -250,7 +254,7 @@ void ToolBarAnimationGroup::slotStartAnimation()
 		<< LOGENDL;
 	m_isStopRequested = false;
 	m_waitingChronometerStartAtFirstViewpoint = viewpointsMode;
-	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked()));
+	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked(), m_ui.verticalOrbitalCheckBox->isChecked()));
 	if (!viewpointsMode)
 		startChronometer();
 	m_isStarted = true;
@@ -264,7 +268,7 @@ void ToolBarAnimationGroup::startViewpointsAnimationPlayback()
 	resetChronometer();
 	m_isStopRequested = false;
 	m_waitingChronometerStartAtFirstViewpoint = true;
-	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(false, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked()));
+	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(false, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked(), m_ui.verticalOrbitalCheckBox->isChecked()));
 	m_isStarted = true;
 	m_isPaused = false;
 	m_isOrbitalRunning = false;
@@ -309,6 +313,7 @@ void ToolBarAnimationGroup::slotGenerateVideo()
 	m_dialog->setLength(m_ui.lengthSpinBox->value());
 	m_dialog->setInterpolateRenderings(m_ui.interpolateCheckBox->isChecked());
 	m_dialog->setOrbitalDegrees(m_ui.degreesSpinBox->value());
+	m_dialog->setVerticalOrbital(m_ui.verticalOrbitalCheckBox->isChecked());
 	const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
 	m_dialog->setAnimationConfigId(selectedConfig ? selectedConfig->getId() : xg::Guid());
 	m_dialog->show();
@@ -322,7 +327,23 @@ void ToolBarAnimationGroup::slotAnimationModeChanged()
 		m_pendingViewpointsStart = false;
 		m_isPaused = false;
 	}
+	updateOrbitalDegreesUI();
 	updateUI();
+}
+
+void ToolBarAnimationGroup::slotVerticalOrbitalToggled(bool checked)
+{
+	(void)checked;
+	updateOrbitalDegreesUI();
+}
+
+void ToolBarAnimationGroup::updateOrbitalDegreesUI()
+{
+	const bool isVertical = m_ui.verticalOrbitalCheckBox->isChecked();
+	const int maxDegrees = isVertical ? 180 : 360;
+	m_ui.degreesSpinBox->setMaximum(maxDegrees);
+	if (m_ui.degreesSpinBox->value() > maxDegrees)
+		m_ui.degreesSpinBox->setValue(maxDegrees);
 }
 
 void ToolBarAnimationGroup::refreshAnimationAvailability()

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -25,6 +25,7 @@
 #include <QtGui/qevent.h>
 #include <QApplication.h>
 #include <algorithm>
+#include <cmath>
 
 namespace
 {
@@ -190,7 +191,8 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
     {
         GUI_LOG << "[ANIM_DBG] viewport start request orbital resume=" << startData->m_resume
             << " duration=" << startData->m_durationSeconds
-            << " degrees=" << startData->m_orbitalDegrees << LOGENDL;
+            << " degrees=" << startData->m_orbitalDegrees
+            << " vertical=" << startData->m_verticalOrbital << LOGENDL;
         m_viewpointStartInputLockArmed = false;
         if (startData->m_resume && m_isOrbitalAnimationActive && m_isOrbitalAnimationPaused)
         {
@@ -204,7 +206,11 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
         m_orbitalDurationSeconds = std::max(0.001, startData->m_durationSeconds);
         m_orbitalElapsedSeconds = 0.0;
         m_orbitalAppliedAngle = 0.0;
-        m_orbitalTotalAngleRad = glm::radians(static_cast<double>(std::clamp(startData->m_orbitalDegrees, 1, 360)));
+        m_orbitalAppliedRealAngle = 0.0;
+        m_orbitalVertical = startData->m_verticalOrbital;
+        m_orbitalDirectionSign = 1.0; // reserved for future inversion option
+        const int maxDegrees = m_orbitalVertical ? 180 : 360;
+        m_orbitalTotalAngleRad = glm::radians(static_cast<double>(std::clamp(startData->m_orbitalDegrees, 1, maxDegrees)));
         m_orbitalStartTime = std::chrono::steady_clock::now();
         m_orbitalUsesExamine = wCam->isExamineActive();
         return;
@@ -259,7 +265,10 @@ void VulkanViewport::onRenderStopAnimation(IGuiData* data)
     m_viewpointStartInputLockArmed = false;
     m_orbitalElapsedSeconds = 0.0;
     m_orbitalAppliedAngle = 0.0;
+    m_orbitalAppliedRealAngle = 0.0;
     m_orbitalTotalAngleRad = 0.0;
+    m_orbitalVertical = false;
+    m_orbitalDirectionSign = 1.0;
     GUI_LOG << "[ANIM_DBG] viewport received stop animation" << LOGENDL;
     wCam->endAnimation();
 }
@@ -381,20 +390,39 @@ void VulkanViewport::updateInputs(WritePtr<CameraNode>& wCam, SafePtr<Manipulato
 
         if (deltaAngle > 0.0)
         {
-            if (m_orbitalUsesExamine)
-                wCam->moveAroundExamine(0.0, deltaAngle, 0.0);
+            if (m_orbitalVertical)
+            {
+                const double signedDelta = m_orbitalDirectionSign * deltaAngle;
+                const double phiBefore = wCam->getPhi();
+                if (m_orbitalUsesExamine)
+                    wCam->moveAroundExamine(0.0, 0.0, signedDelta);
+                else
+                    wCam->pitch(signedDelta);
+                const double phiAfter = wCam->getPhi();
+                m_orbitalAppliedRealAngle += std::abs(phiAfter - phiBefore);
+            }
             else
-                wCam->yaw(deltaAngle);
+            {
+                if (m_orbitalUsesExamine)
+                    wCam->moveAroundExamine(0.0, deltaAngle, 0.0);
+                else
+                    wCam->yaw(deltaAngle);
+                m_orbitalAppliedRealAngle = targetAngle;
+            }
             m_orbitalAppliedAngle = targetAngle;
         }
 
-        if (clampedElapsed >= m_orbitalDurationSeconds)
+        const bool reachedAngle = m_orbitalAppliedRealAngle + 1e-9 >= m_orbitalTotalAngleRad;
+        if (clampedElapsed >= m_orbitalDurationSeconds || reachedAngle)
         {
             m_isOrbitalAnimationActive = false;
             m_isOrbitalAnimationPaused = false;
             m_orbitalElapsedSeconds = 0.0;
             m_orbitalAppliedAngle = 0.0;
+            m_orbitalAppliedRealAngle = 0.0;
             m_orbitalTotalAngleRad = 0.0;
+            m_orbitalVertical = false;
+            m_orbitalDirectionSign = 1.0;
             m_dataDispatcher.updateInformation(new GuiDataRenderStopAnimation());
         }
     }


### PR DESCRIPTION
### Motivation
- Introduce a vertical orbital mode for camera animations so users can perform pitch-based orbitals (up/down) in addition to the existing yaw-based orbitals and allow exporting videos using that mode.

### Description
- Add a `verticalOrbital` flag to `VideoExportParameters` and `GuiDataRenderStartAnimation` and thread it through the export dialog via `DialogExportVideo::setVerticalOrbital` and `m_parameters.verticalOrbital` so video export can request vertical orbitals.
- Add a `Vertical` checkbox to the animation toolbar UI and handle its state in `ToolBarAnimationGroup` by toggling the UI, clamping the degrees (`180` max when vertical), and passing the flag when starting/resuming animations or generating videos.
- Update runtime animation logic in `VulkanViewport` and `ContextExportVideoHD` to support vertical orbitals by tracking a separate "real applied" angle (`m_orbitalAppliedRealAngle` / `m_orbitalRealAppliedRad`), applying motion via `pitch` or `moveAroundExamine(..., z)` for vertical mode, and terminating the orbital when the applied angle reaches the requested target.
- Misc: expose new members/flags in headers, add `slotVerticalOrbitalToggled` and `updateOrbitalDegreesUI` helpers to keep the degrees spinbox in sync with the vertical toggle, and clamp degrees in `DialogExportVideo::setOrbitalDegrees` accordingly.

### Testing
- Performed a full project build which succeeded without compile errors after the changes.
- Ran the existing automated unit/gui test suite and the tests passed (no regressions detected in animation/export related tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9bf9bd2c832fac86180e3cd59192)