### PR TITLE
Add Find Min/Max Temperature-in-Clipping feature and toolbar button

### DIFF
--- a/include/controller/FilteredFonctionnalities.h
+++ b/include/controller/FilteredFonctionnalities.h
@@ -240,6 +240,7 @@ static const std::unordered_map<ControlType, std::unordered_set<LicenceVersion>>
 	{ControlType::clickPicking, {LicenceVersion::Free} },
 	{ControlType::findScanFromPicking, {LicenceVersion::Standard} },
 	{ControlType::pickTemperatureFromPicking, {LicenceVersion::Standard} },
+	{ControlType::pickMinMaxTemperatureFromClipping, {LicenceVersion::Standard} },
 
 	// control::viewport
 	{ControlType::multiSelect, {LicenceVersion::Free} },

--- a/include/controller/controls/ControlPicking.h
+++ b/include/controller/controls/ControlPicking.h
@@ -52,6 +52,17 @@ namespace control::picking
         ControlType getType() const override;
     };
 
+    class FindMinMaxTemperatureInClipping : public AControl
+    {
+    public:
+        FindMinMaxTemperatureInClipping();
+        ~FindMinMaxTemperatureInClipping();
+        void doFunction(Controller& controller) override;
+        bool canUndo() const override;
+        void undoFunction(Controller& controller) override;
+        ControlType getType() const override;
+    };
+
 }
 
 #endif // !CONTROL_PICKING_H_

--- a/include/controller/controls/IControl.h
+++ b/include/controller/controls/IControl.h
@@ -241,6 +241,7 @@ enum class ControlType
 	findScanFromPicking,
 	pickTemperatureFromPicking,
 	pickColorimetricFromPicking,
+	pickMinMaxTemperatureFromClipping,
 
 	// control::viewport
 	multiSelect,

--- a/include/gui/texts/ContextTexts.hpp
+++ b/include/gui/texts/ContextTexts.hpp
@@ -99,6 +99,7 @@
 #define TEXT_DELETE_POINTS_QUESTION QObject::tr("Warning: points will be permanently deleted. This action cannot be undone.\nDo you confirm?")
 #define TEXT_DELETE_SAVE_BEFORE_QUESTION QObject::tr("It is recommended to save the project before deleting points. Do you want to save now?")
 #define TEXT_DELETE_POINTS_NO_ACTIVE_CLIPPING QObject::tr("You must activate some clippings or filters to run this feature")
+#define TEXT_TEMPERATURE_MINMAX_NEEDS_ONE_INTERIOR_CLIP QObject::tr("You have to clip an area to use this feature with one clipping box. Please create one clipping box and activate \"Show interior\" mode")
 
 //ContextStatisticalOutlierFilter
 #define TEXT_STAT_OUTLIER_FILTER_QUESTION QObject::tr("Warning: some points will be permanently deleted.\nDepending on the size of the scans and the filter settings, the calculation time may be significant. We recommend that you first perform a test on a small clipped portion.\nDo you confirm?")

--- a/src/controller/controls/ControlPicking.cpp
+++ b/src/controller/controls/ControlPicking.cpp
@@ -1,15 +1,74 @@
 #include "controller/controls/ControlPicking.h"
 #include "controller/Controller.h"
+#include "controller/ControllerContext.h"
+#include "controller/controls/ControlFunction.h"
 #include "controller/functionSystem/FunctionManager.h"
 #include "controller/messages/FullClickMessage.h"
 #include "gui/GuiData/GuiDataMeasure.h"
+#include "gui/GuiData/GuiDataMessages.h"
 #include "gui/GuiData/GuiDataRendering.h"
+#include "gui/UnitConverter.h"
+#include "gui/texts/ContextTexts.hpp"
 #include "utils/Logger.h"
+#include "utils/ProjectColor.hpp"
 
+#include "models/graph/BoxNode.h"
 #include "models/graph/GraphManager.h"
+#include "models/graph/TagNode.h"
+#include "models/pointCloud/PointXYZIRGB.h"
+#include "pointCloudEngine/OctreeRayTracing.h"
+#include "pointCloudEngine/TlScanOverseer.h"
+#include "tls_def.h"
+
+#include <QObject>
+#include <limits>
+#include <vector>
 
 namespace control::picking
 {
+    namespace
+    {
+        GeometricBox makeGeometricBoxFromClippingBox(const BoxNode& box)
+        {
+            const glm::dvec3 localScale = box.getScale();
+            const glm::dmat4 transform = box.getCumulatedTransformation();
+            std::vector<glm::dvec3> corners;
+            corners.reserve(8);
+            for (int sx : { -1, 1 })
+            {
+                for (int sy : { -1, 1 })
+                {
+                    for (int sz : { -1, 1 })
+                    {
+                        const glm::dvec4 localCorner(localScale.x * sx, localScale.y * sy, localScale.z * sz, 1.0);
+                        corners.push_back(glm::dvec3(transform * localCorner));
+                    }
+                }
+            }
+            return GeometricBox(corners);
+        }
+
+        SafePtr<TagNode> createTemperatureTag(Controller& controller, const PointXYZIRGB& point, double temperature, const char* colorName)
+        {
+            SafePtr<TagNode> tagNode = make_safe<TagNode>();
+            WritePtr<TagNode> wTag = tagNode.get();
+            if (!wTag)
+                return SafePtr<TagNode>();
+
+            const int digits = controller.cgetContext().m_unitUsage.displayedDigits;
+            const QString text = QStringLiteral("%1%2")
+                                     .arg(QString::number(temperature, 'f', digits), UnitConverter::getTemperatureUnitText());
+
+            wTag->setDefaultData(controller);
+            wTag->setVisible(true);
+            wTag->setPosition(glm::dvec3(point.x, point.y, point.z));
+            wTag->setMarkerIcon(scs::MarkerIcon::Tag_Base);
+            wTag->setColor(ProjectColor::getColor(colorName));
+            wTag->setName(text.toStdWString());
+            return tagNode;
+        }
+    }
+
     //
     // Click
     //
@@ -151,6 +210,122 @@ namespace control::picking
     ControlType PickColorimetricFromPick::getType() const
     {
         return ControlType::pickColorimetricFromPicking;
+    }
+
+    FindMinMaxTemperatureInClipping::FindMinMaxTemperatureInClipping()
+    {
+    }
+
+    FindMinMaxTemperatureInClipping::~FindMinMaxTemperatureInClipping()
+    {
+    }
+
+    void FindMinMaxTemperatureInClipping::doFunction(Controller& controller)
+    {
+        const GraphManager& graphManager = controller.cgetGraphManager();
+        const TemperatureScaleData temperatureScale = graphManager.getTemperatureScaleData();
+        if (!temperatureScale.isValid || temperatureScale.rgbToTemperature.empty())
+        {
+            controller.updateInfo(new GuiDataWarning(QObject::tr("You must import a valid temperature scale file first.")));
+            return;
+        }
+
+        const std::unordered_set<SafePtr<AClippingNode>> clippings = graphManager.getClippingObjects(true, false);
+        if (clippings.size() != 1)
+        {
+            controller.updateInfo(new GuiDataWarning(TEXT_TEMPERATURE_MINMAX_NEEDS_ONE_INTERIOR_CLIP));
+            return;
+        }
+
+        const SafePtr<AClippingNode>& clipping = *clippings.begin();
+        ReadPtr<AClippingNode> rClip = clipping.cget();
+        if (!rClip || rClip->getType() != ElementType::Box || rClip->getClippingMode() != ClippingMode::showInterior)
+        {
+            controller.updateInfo(new GuiDataWarning(TEXT_TEMPERATURE_MINMAX_NEEDS_ONE_INTERIOR_CLIP));
+            return;
+        }
+
+        ReadPtr<BoxNode> rBox = static_pointer_cast<BoxNode>(clipping).cget();
+        if (!rBox)
+        {
+            controller.updateInfo(new GuiDataWarning(TEXT_TEMPERATURE_MINMAX_NEEDS_ONE_INTERIOR_CLIP));
+            return;
+        }
+
+        controller.updateInfo(new GuiDataProcessingSplashScreenStart(1, QObject::tr("Find min max temperature"), QObject::tr("Please wait...")));
+        controller.updateInfo(new GuiDataProcessingSplashScreenEnableCancelButton(false));
+
+        ClippingAssembly clippingAssembly;
+        graphManager.getClippingAssembly(clippingAssembly, true, false);
+
+        TlScanOverseer::setWorkingScansTransfo(graphManager.getVisiblePointCloudInstances(tls::ScanGuid(), true, true));
+        const GeometricBox searchBox = makeGeometricBoxFromClippingBox(*rBox);
+        std::vector<PointXYZIRGB> points;
+        TlScanOverseer::getInstance().collectPointsInGeometricBox(searchBox, clippingAssembly, tls::ScanGuid(), points);
+
+        bool minFound = false;
+        bool maxFound = false;
+        double minTemperature = std::numeric_limits<double>::max();
+        double maxTemperature = std::numeric_limits<double>::lowest();
+        PointXYZIRGB minPoint{};
+        PointXYZIRGB maxPoint{};
+
+        for (const PointXYZIRGB& point : points)
+        {
+            const uint32_t key = makeTemperatureScaleKey(point.r, point.g, point.b);
+            auto it = temperatureScale.rgbToTemperature.find(key);
+            if (it == temperatureScale.rgbToTemperature.end())
+                continue;
+
+            const double value = it->second;
+            if (!minFound || value < minTemperature)
+            {
+                minFound = true;
+                minTemperature = value;
+                minPoint = point;
+            }
+            if (!maxFound || value > maxTemperature)
+            {
+                maxFound = true;
+                maxTemperature = value;
+                maxPoint = point;
+            }
+        }
+
+        controller.updateInfo(new GuiDataProcessingSplashScreenProgressBarUpdate(QObject::tr("Done"), 1));
+        controller.updateInfo(new GuiDataProcessingSplashScreenEnd(QObject::tr("Done")));
+
+        if (!minFound || !maxFound)
+        {
+            controller.updateInfo(new GuiDataWarning(QObject::tr("No temperature from the current scale was found in the clipped area.")));
+            return;
+        }
+
+        SafePtr<TagNode> minTag = createTemperatureTag(controller, minPoint, minTemperature, "BLUE");
+        SafePtr<TagNode> maxTag = createTemperatureTag(controller, maxPoint, maxTemperature, "RED");
+
+        std::unordered_set<SafePtr<AGraphNode>> tagsToAdd;
+        if (minTag)
+            tagsToAdd.insert(minTag);
+        if (maxTag)
+            tagsToAdd.insert(maxTag);
+
+        if (!tagsToAdd.empty())
+            controller.getControlListener()->notifyUIControl(new control::function::AddNodes(tagsToAdd));
+    }
+
+    bool FindMinMaxTemperatureInClipping::canUndo() const
+    {
+        return false;
+    }
+
+    void FindMinMaxTemperatureInClipping::undoFunction(Controller& controller)
+    {
+    }
+
+    ControlType FindMinMaxTemperatureInClipping::getType() const
+    {
+        return ControlType::pickMinMaxTemperatureFromClipping;
     }
 
 }

--- a/src/gui/forms/toolbar_render_ramp_group.ui
+++ b/src/gui/forms/toolbar_render_ramp_group.ui
@@ -86,6 +86,16 @@ Separator for columns: tab, space, or ;</string>
      </property>
     </widget>
    </item>
+   <item row="0" column="2">
+    <widget class="QPushButton" name="pushButton_findMinMaxTemperature">
+     <property name="toolTip">
+      <string>Create 2 tags in one active clipping box (Show interior): one at minimum temperature and one at maximum temperature.</string>
+     </property>
+     <property name="text">
+      <string>Find min max temp.</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="1">
     <widget class="QSpinBox" name="spinBox_graduation">
      <property name="maximum">

--- a/src/gui/toolBars/ToolBarRenderRampGroup.cpp
+++ b/src/gui/toolBars/ToolBarRenderRampGroup.cpp
@@ -17,6 +17,7 @@ ToolBarRenderRampGroup::ToolBarRenderRampGroup(IDataDispatcher& dataDispatcher, 
 	m_ui.checkBox_showScale->setChecked(true);
 	m_ui.checkBox_showTemperatureScale->setEnabled(false);
 	m_ui.pushButton_pickTemperature->setEnabled(false);
+	m_ui.pushButton_findMinMaxTemperature->setEnabled(false);
 	m_ui.lineEdit_temperatureScale->setPlaceholderText(tr("No file found"));
 
 	// Connect widgets
@@ -35,6 +36,10 @@ ToolBarRenderRampGroup::ToolBarRenderRampGroup(IDataDispatcher& dataDispatcher, 
 	connect(m_ui.pushButton_pickTemperature, &QPushButton::clicked, [this]()
 		{
 			m_dataDispatcher.sendControl(new control::picking::PickTemperatureFromPick());
+		});
+	connect(m_ui.pushButton_findMinMaxTemperature, &QPushButton::clicked, [this]()
+		{
+			m_dataDispatcher.sendControl(new control::picking::FindMinMaxTemperatureInClipping());
 		});
 
 	// GuiData link
@@ -101,6 +106,7 @@ void ToolBarRenderRampGroup::updateTemperatureScaleStatus(IGuiData* data)
 	const bool canUseTemperatureScale = m_temperatureScaleValid && m_temperatureScaleFileFound;
 	m_ui.checkBox_showTemperatureScale->setEnabled(canUseTemperatureScale);
 	m_ui.pushButton_pickTemperature->setEnabled(canUseTemperatureScale);
+	m_ui.pushButton_findMinMaxTemperature->setEnabled(canUseTemperatureScale);
 
 	if (m_temperatureScalePath.empty())
 	{


### PR DESCRIPTION
### Motivation
- Provide a tool to locate the minimum and maximum temperature points inside a single active clipping box and create tags at those locations.
- Expose the feature from the render-ramp toolbar when a valid temperature scale is imported.
- Restrict availability to projects with a valid temperature scale and a single "show interior" clipping box.

### Description
- Added a new control type `pickMinMaxTemperatureFromClipping` and registered it in `FilteredFonctionnalities.h` with `LicenceVersion::Standard`, and added the enum entry in `IControl.h`.
- Declared `FindMinMaxTemperatureInClipping` in `ControlPicking.h` and implemented it in `ControlPicking.cpp`, including helpers `makeGeometricBoxFromClippingBox` and `createTemperatureTag`; the implementation validates the temperature scale, enforces exactly one interior clipping box, collects points via `TlScanOverseer`, computes min/max using `temperatureScale.rgbToTemperature`, shows processing splash UI messages, and creates red/blue tags for max/min respectively via `control::function::AddNodes`.
- Added UI changes to the render ramp toolbar by adding a `pushButton_findMinMaxTemperature` in `toolbar_render_ramp_group.ui` and wiring it in `ToolBarRenderRampGroup.cpp` so the button is enabled only when the temperature scale file is valid and sends the new control when clicked.
- Added a user-facing context text `TEXT_TEMPERATURE_MINMAX_NEEDS_ONE_INTERIOR_CLIP` used to prompt the user when the clipping preconditions are not met.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baae2b4e4c832f9b31147864fce536)