### PR TITLE
Persist and restore session author between runs

### DIFF
--- a/include/utils/Config.h
+++ b/include/utils/Config.h
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <vector>
 #include <filesystem>
+#include <string>
 
 enum LoggerMode;
 class Color32;
@@ -28,6 +29,11 @@ namespace Config
 
 	LanguageType getLanguage();
 	bool setLanguage(LanguageType type);
+
+    std::string getSessionAuthorId();
+    std::wstring getSessionAuthorName();
+    bool setSessionAuthor(const std::string& id, const std::wstring& name);
+    bool clearSessionAuthor();
 
 	bool getCenteringConfiguration();
 	bool setCenteringConfiguration(bool value);

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -12,6 +12,7 @@
 #include "models/graph/CameraNode.h"
 
 #include "utils/FilesAndFoldersDefinitions.h"
+#include "utils/Config.h"
 #include "utils/Logger.h"
 
 #define CONTROLLERLOG Logger::log(LoggerMode::ControllerLog)
@@ -25,7 +26,41 @@ Controller::Controller(IDataDispatcher& dataDispatcher, GraphManager& graphManag
     m_p->context.addLocalAuthors(SaveLoadSystem::loadLocalAuthors(*this, errorMsg));
     assert(errorMsg == SaveLoadSystem::ErrorCode::Success);
 
-    m_p->dataDispatcher.updateInformation(new GuiDataSendAuthorsList(m_p->context.getLocalAuthors(), SafePtr<Author>()));
+    SafePtr<Author> restoredAuthor;
+    std::string sessionAuthorId = Config::getSessionAuthorId();
+    std::wstring sessionAuthorName = Config::getSessionAuthorName();
+
+    if (!sessionAuthorId.empty() || !sessionAuthorName.empty())
+    {
+        for (const SafePtr<Author>& author : m_p->context.getLocalAuthors())
+        {
+            ReadPtr<Author> rAuth = author.cget();
+            if (!rAuth)
+                continue;
+
+            if (!sessionAuthorId.empty() && rAuth->getId().isValid() && rAuth->getId().str() == sessionAuthorId)
+            {
+                restoredAuthor = author;
+                break;
+            }
+            if (sessionAuthorId.empty() && !sessionAuthorName.empty() && rAuth->getName() == sessionAuthorName)
+            {
+                restoredAuthor = author;
+                break;
+            }
+        }
+    }
+
+    if (restoredAuthor)
+    {
+        m_p->context.setActiveAuthor(restoredAuthor);
+    }
+    else if (!sessionAuthorId.empty() || !sessionAuthorName.empty())
+    {
+        Config::clearSessionAuthor();
+    }
+
+    m_p->dataDispatcher.updateInformation(new GuiDataSendAuthorsList(m_p->context.getLocalAuthors(), restoredAuthor));
 }
 
 Controller::~Controller()

--- a/src/controller/controls/ControlAuthor.cpp
+++ b/src/controller/controls/ControlAuthor.cpp
@@ -222,5 +222,9 @@ namespace control::author
         SafePtr<Author> active = controller.getContext().getActiveAuthor();
 
         controller.updateInfo(new GuiDataSendAuthorsList(authors, active));
+
+        ReadPtr<Author> rAuth = active.cget();
+        if (rAuth)
+            controller.updateInfo(new GuiDataAuthorNameSelection(rAuth->getName()));
     }
 }

--- a/src/controller/functionSystem/ContextSaveCloseLoadProject.cpp
+++ b/src/controller/functionSystem/ContextSaveCloseLoadProject.cpp
@@ -11,7 +11,9 @@
 #include "gui/GuiData/GuiDataIO.h"
 #include "controller/controls/ControlProject.h"
 #include "controller/controls/ControlApplication.h"
+#include "models/application/Author.h"
 #include "utils/FilesAndFoldersDefinitions.h"
+#include "utils/Config.h"
 #include "utils/Logger.h"
 #include "utils/system.h"
 #include "gui/texts/ContextTexts.hpp"
@@ -418,6 +420,12 @@ ContextState ContextSaveQuitProject::launch(Controller& controller)
     //controller.saveCurrentProject();
     if (m_closeLastProject)
         controller.getControlListener()->notifyUIControl(new control::project::Close());
+
+    ReadPtr<Author> rAuth = controller.getContext().getActiveAuthor().cget();
+    if (rAuth && rAuth->getId().isValid())
+        Config::setSessionAuthor(rAuth->getId().str(), rAuth->getName());
+    else
+        Config::clearSessionAuthor();
 
     controller.getControlListener()->notifyUIControl(new control::application::Quit());
 

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -113,6 +113,7 @@
 #include "controller/controls/ControlProject.h"
 #include "controller/controls/ControlApplication.h"
 #include "controller/controls/ControlModal.h"
+#include "controller/controls/ControlAuthor.h"
 #include "controller/controls/ControlFunction.h"
 #include "controller/controls/ControlIO.h"
 
@@ -536,7 +537,11 @@ void Gui::informData(IGuiData *data)
 void Gui::launch()
 {
 	show();
-	m_projectGroup->manageAuthors(false);
+    m_dataDispatcher.sendControl(new control::author::SendAuthorList());
+
+    bool hasSessionAuthor = !Config::getSessionAuthorId().empty() || !Config::getSessionAuthorName().empty();
+    if (!hasSessionAuthor)
+	    m_projectGroup->manageAuthors(false);
 }
 
 void Gui::showWarningMBox(IGuiData * data)

--- a/src/utils/Config.cpp
+++ b/src/utils/Config.cpp
@@ -22,6 +22,8 @@
 #define LOG_JSON_KEY "logs"
 #define LICENSE_JSON_KEY "license"
 #define LANG_JSON_KEY "lang"
+#define SESSION_AUTHOR_ID_JSON_KEY "session_author_id"
+#define SESSION_AUTHOR_NAME_JSON_KEY "session_author_name"
 #define CENTER_JSON_KEY "center"
 #define KEEP_EXAMINE_JSON_KEY "keep_examine"
 #define EXAMINE_DISPLAY_JSON_KEY "display_examine"
@@ -204,6 +206,48 @@ namespace Config
 		jsonConfig[LANG_JSON_KEY] = std::string(magic_enum::enum_name(type));
 		return saveConfigFile(filePath);
 	}
+
+    std::string getSessionAuthorId()
+    {
+        if (jsonConfig.find(SESSION_AUTHOR_ID_JSON_KEY) == jsonConfig.end())
+            return "";
+        try
+        {
+            return cleanString(jsonConfig.at(SESSION_AUTHOR_ID_JSON_KEY).dump());
+        }
+        catch (...)
+        {
+            return "";
+        }
+    }
+
+    std::wstring getSessionAuthorName()
+    {
+        if (jsonConfig.find(SESSION_AUTHOR_NAME_JSON_KEY) == jsonConfig.end())
+            return L"";
+        try
+        {
+            return cleanWString(jsonConfig.at(SESSION_AUTHOR_NAME_JSON_KEY).get<std::string>());
+        }
+        catch (...)
+        {
+            return L"";
+        }
+    }
+
+    bool setSessionAuthor(const std::string& id, const std::wstring& name)
+    {
+        jsonConfig[SESSION_AUTHOR_ID_JSON_KEY] = id;
+        jsonConfig[SESSION_AUTHOR_NAME_JSON_KEY] = Utils::to_utf8(name);
+        return saveConfigFile(filePath);
+    }
+
+    bool clearSessionAuthor()
+    {
+        jsonConfig.erase(SESSION_AUTHOR_ID_JSON_KEY);
+        jsonConfig.erase(SESSION_AUTHOR_NAME_JSON_KEY);
+        return saveConfigFile(filePath);
+    }
 
 	bool getCenteringConfiguration()
 	{


### PR DESCRIPTION
### Motivation
- Remember the last active author across application sessions so the UI can restore or preselect the same author on next launch.
- Provide configuration storage for a session author id and display name to improve user experience when reopening the app.

### Description
- Added session author APIs to `Config`: `getSessionAuthorId`, `getSessionAuthorName`, `setSessionAuthor`, and `clearSessionAuthor`, and persisted keys `session_author_id` and `session_author_name` in the JSON config.
- On startup, `Controller` reads the session author id/name from `Config` and attempts to restore the matching local author as the active author, clearing the saved session data if no match is found.
- On quit, `ContextSaveQuitProject` saves the active author's id and name to `Config` when available, or clears the session author entries otherwise.
- GUI/controls were updated to request and broadcast the authors list on launch (`control::author::SendAuthorList`), and to send `GuiDataAuthorNameSelection` when an active author is present so the UI can preselect the author name; `Gui::launch` now avoids managing authors dialog when a session author is present.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1562f69e4832fa0898d6d71b38d98)