### PR TITLE
Stop active animation before pausing render during project close to avoid shutdown deadlocks

### DIFF
--- a/src/controller/controls/ControlProject.cpp
+++ b/src/controller/controls/ControlProject.cpp
@@ -387,6 +387,12 @@ namespace control::project
 
         controller.updateInfo(new GuiDataSplashScreenStart(TEXT_PROJECT_CLOSING, GuiDataSplashScreenStart::SplashScreenType::Display));
 
+        // Ensure any running animation is stopped before pausing the render loop.
+        // This avoids shutdown deadlocks when quitting while an animation is active.
+        CONTROLLOG << "control::project::Close stopping active animation before render pause" << LOGENDL;
+        controller.updateInfo(new GuiDataRenderStopAnimation());
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
         constexpr auto kRenderPauseTimeout = std::chrono::milliseconds(2000);
         bool renderPaused = VulkanManager::getInstance().requestRenderPauseAndWait(kRenderPauseTimeout);
         if (!renderPaused)


### PR DESCRIPTION
### Motivation

- Prevent hangs when quitting while an animation is active by ensuring animations are stopped before pausing the render loop. 
- Reduce the chance of shutdown deadlocks caused by race conditions between active animations and render pause sequencing.

### Description

- Add a call to dispatch `GuiDataRenderStopAnimation` via `controller.updateInfo()` to request stopping any running animation before pausing the renderer. 
- Insert a short `std::this_thread::sleep_for(std::chrono::milliseconds(50))` to allow the stop request to be processed prior to calling `VulkanManager::requestRenderPauseAndWait()`. 
- Add a diagnostic log message to indicate the animation stop step and keep the existing render pause timeout handling intact.

### Testing

- Project builds were verified successfully after the change. 
- Existing automated unit tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16c3e60ac832fadbdb88c6a265a49)