### PR TITLE
Stop animations before render pause and save/close modals to prevent shutdown deadlocks

### DIFF
--- a/src/controller/controls/ControlProject.cpp
+++ b/src/controller/controls/ControlProject.cpp
@@ -387,6 +387,12 @@ namespace control::project
 
         controller.updateInfo(new GuiDataSplashScreenStart(TEXT_PROJECT_CLOSING, GuiDataSplashScreenStart::SplashScreenType::Display));
 
+        // Ensure any running animation is stopped before pausing the render loop.
+        // This avoids shutdown deadlocks when quitting while an animation is active.
+        CONTROLLOG << "control::project::Close stopping active animation before render pause" << LOGENDL;
+        controller.updateInfo(new GuiDataRenderStopAnimation());
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
         constexpr auto kRenderPauseTimeout = std::chrono::milliseconds(2000);
         bool renderPaused = VulkanManager::getInstance().requestRenderPauseAndWait(kRenderPauseTimeout);
         if (!renderPaused)

--- a/src/controller/functionSystem/ContextSaveCloseLoadProject.cpp
+++ b/src/controller/functionSystem/ContextSaveCloseLoadProject.cpp
@@ -9,6 +9,7 @@
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/GuiData/GuiDataContextRequest.h"
 #include "gui/GuiData/GuiDataIO.h"
+#include "gui/GuiData/GuiDataRendering.h"
 #include "controller/controls/ControlProject.h"
 #include "controller/controls/ControlApplication.h"
 #include "models/application/Author.h"
@@ -24,6 +25,14 @@
 #define No 0x00010000
 #define Cancel 0x00400000
 
+namespace
+{
+    void stopAnimationBeforeSaveModal(Controller& controller, const char* contextName)
+    {
+        CONTROLLOG << contextName << " stopping active animation before save modal" << LOGENDL;
+        controller.updateInfo(new GuiDataRenderStopAnimation());
+    }
+}
 
 // *******************************************
 //           Save & Create Project
@@ -63,6 +72,7 @@ ContextState ContextSaveCloseCreateProject::feedMessage(IMessage* message, Contr
         m_languageTemplate = msg->language_template_;
 
 		if (controller.getContext().getIsCurrentProjectSaved() == false) {
+            stopAnimationBeforeSaveModal(controller, "ContextSaveCloseCreateProject");
 			controller.updateInfo(new GuiDataModal(Yes | No | Cancel, TEXT_SAVELOADCLOSE_SAVE_QUESTION));
 			m_isWaitingModal = true;
 		}
@@ -144,7 +154,10 @@ ContextState ContextSaveCloseProject::start(Controller& controller)
 {
     controller.updateInfo(new GuiDataContextRequestActiveCamera(m_id));
     if (controller.getContext().getIsCurrentProjectSaved() == false)
+    {
+        stopAnimationBeforeSaveModal(controller, "ContextSaveCloseProject");
         controller.updateInfo(new GuiDataModal(Yes | No | Cancel, TEXT_SAVELOADCLOSE_SAVE_QUESTION));
+    }
     else
         return (m_state = ContextState::ready_for_using);
     return (m_state = ContextState::waiting_for_input);
@@ -239,6 +252,7 @@ ContextState ContextSaveCloseLoadProject::feedMessage(IMessage* message, Control
             if (controller.getContext().getIsCurrentProjectSaved() == false)
             {
                 m_modalsReturn = WaitFor::Save;
+                stopAnimationBeforeSaveModal(controller, "ContextSaveCloseLoadProject");
                 controller.updateInfo(new GuiDataModal(Yes | No | Cancel, TEXT_SAVELOADCLOSE_SAVE_QUESTION));
             }
             else if (!m_backups.empty())
@@ -369,6 +383,7 @@ ContextState ContextSaveQuitProject::start(Controller& controller)
 
     if (controller.getContext().getIsCurrentProjectSaved() == false)
     {
+        stopAnimationBeforeSaveModal(controller, "ContextSaveQuitProject");
         controller.updateInfo(new GuiDataModal(Yes | No | Cancel, TEXT_SAVELOADCLOSE_SAVE_QUESTION));
         m_disableSave = false;
     }


### PR DESCRIPTION
### Motivation
- Prevent shutdown deadlocks that occur when quitting or showing save/close modals while an animation is actively running. 
- Ensure the render loop can be paused safely by stopping animations first and giving a short grace period.

### Description
- In `ControlProject::Close::doFunction` send `GuiDataRenderStopAnimation` and sleep for 50ms before requesting a render pause, and add a log entry. 
- Add a helper `stopAnimationBeforeSaveModal` (anonymous namespace) and include `GuiDataRendering.h` to centralize stopping the animation prior to showing save/restore modals. 
- Invoke the helper in the save/close/load/quit contexts: `ContextSaveCloseCreateProject`, `ContextSaveCloseProject`, `ContextSaveCloseLoadProject`, and `ContextSaveQuitProject` when a save modal will be shown. 
- Keep existing render pause timeout handling and restore `resumeRender` behavior after cleanup.

### Testing
- Built the project (full build) and ran the automated test suite including unit and integration tests. All automated tests completed successfully. 
- Ran the existing rendering-related CI checks and they passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16c3e60ac832fadbdb88c6a265a49)