### PR TITLE
Apply viewpoint visibility updates during animations and video export and track last-applied viewpoint index

### DIFF
--- a/include/controller/functionSystem/ContextExportVideoHD.h
+++ b/include/controller/functionSystem/ContextExportVideoHD.h
@@ -4,6 +4,7 @@
 #include "controller/functionSystem/AContext.h"
 #include "io/exports/ExportParameters.hpp"
 #include "pointCloudEngine/RenderingTypes.h"
+#include <cstddef>
 #include <optional>
 #include <vector>
 
@@ -42,6 +43,7 @@ private:
 	uint8_t m_frameDigits = 0;
 	std::vector<SafePtr<ViewPointNode>> m_viewpoints;
 	std::vector<double> m_viewpointControlTimes;
+	size_t m_lastAppliedVisibilityViewpointIndex = 0;
 	double m_orbitalTotalAngleRad = 0.0;
 	double m_orbitalLastAppliedRad = 0.0;
 	double m_orbitalRealAppliedRad = 0.0;

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -350,6 +350,7 @@ private:
     bool m_interpolateViewpointRenderings = false;
     std::vector<ViewpointRenderState> m_viewpointRenderStates;
     std::vector<double> m_renderControlPointTimesSeconds;
+    size_t m_lastAppliedVisibilityViewpointIndex = 0;
     SimpleAnimation m_simpleAnimation = SimpleAnimation();
     // Uniform for projection and view matrix (separated)
     VkMultiUniform m_uniProjView;

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -1,7 +1,9 @@
 #include "controller/functionSystem/ContextExportVideoHD.h"
 #include "controller/Controller.h"
 #include "controller/ControllerContext.h"
+#include "controller/IControlListener.h"
 #include "controller/controls/AnimationHelper.h"
+#include "controller/controls/ControlViewPoint.h"
 
 #include "models/graph/GraphManager.h"
 #include "models/graph/AGraphNode.h"
@@ -68,6 +70,7 @@ ContextState ContextExportVideoHD::start(Controller& controller)
     m_totalFrames = 0;
     m_viewpoints.clear();
     m_viewpointControlTimes.clear();
+    m_lastAppliedVisibilityViewpointIndex = 0;
     m_orbitalTotalAngleRad = 0.0;
     m_orbitalLastAppliedRad = 0.0;
     m_orbitalRealAppliedRad = 0.0;
@@ -203,6 +206,8 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             // Snap directly to the first viewpoint (same expectation as animation Start):
             // no initial transition trajectory before frame 1 capture.
             wCam->snapToViewPoint(m_viewpoints.front());
+            m_lastAppliedVisibilityViewpointIndex = 0;
+            controller.getControlListener()->notifyUIControl(new control::viewpoint::UpdateStatesFromViewpoint(m_viewpoints.front()));
         }
         else
         {
@@ -256,6 +261,16 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             if (rightIndex >= m_viewpointControlTimes.size())
                 rightIndex = m_viewpointControlTimes.size() - 1;
             const size_t leftIndex = rightIndex - 1;
+            size_t activeViewpointIndex = leftIndex;
+            if (rightIndex < m_viewpointControlTimes.size() && t >= m_viewpointControlTimes[rightIndex])
+                activeViewpointIndex = rightIndex;
+            activeViewpointIndex = std::min(activeViewpointIndex, m_viewpoints.size() - 1);
+
+            if (activeViewpointIndex != m_lastAppliedVisibilityViewpointIndex)
+            {
+                m_lastAppliedVisibilityViewpointIndex = activeViewpointIndex;
+                controller.getControlListener()->notifyUIControl(new control::viewpoint::UpdateStatesFromViewpoint(m_viewpoints[activeViewpointIndex]));
+            }
 
             ReadPtr<ViewPointNode> left = m_viewpoints[leftIndex].cget();
             ReadPtr<ViewPointNode> right = m_viewpoints[rightIndex].cget();

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -664,6 +664,7 @@ bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
         if (m_interpolateViewpointRenderings)
             initializeViewpointRenderInterpolationControlTimes();
     }
+    m_lastAppliedVisibilityViewpointIndex = 0;
 
     buildViewpointAnimationPlaybackPath();
 
@@ -711,6 +712,7 @@ bool CameraNode::endAnimation()
     m_currentKeyPoint = 0;
     m_animFrames = 0;
     m_totalPausedDurationSeconds = 0.0;
+    m_lastAppliedVisibilityViewpointIndex = 0;
     resetViewpointRenderInterpolation();
     return wasAnimated;
 }
@@ -761,6 +763,7 @@ void CameraNode::cleanAnimation()
     m_animFrames = 0;
     m_isAnimationPaused = false;
     m_totalPausedDurationSeconds = 0.0;
+    m_lastAppliedVisibilityViewpointIndex = 0;
     resetViewpointRenderInterpolation();
 }
 
@@ -1342,6 +1345,23 @@ bool CameraNode::animateViewpointTrajectory()
     }
 
     applyViewpointRenderInterpolation(dtime);
+
+    if (m_interpolateViewpointRenderings &&
+        m_renderControlPointTimesSeconds.size() == m_animationPlaylist.size() &&
+        !m_animationPlaylist.empty())
+    {
+        auto upperBound = std::upper_bound(m_renderControlPointTimesSeconds.begin(), m_renderControlPointTimesSeconds.end(), dtime);
+        size_t activeViewpointIndex = 0;
+        if (upperBound != m_renderControlPointTimesSeconds.begin())
+            activeViewpointIndex = static_cast<size_t>(std::distance(m_renderControlPointTimesSeconds.begin(), upperBound) - 1);
+        activeViewpointIndex = std::min(activeViewpointIndex, m_animationPlaylist.size() - 1);
+
+        if (activeViewpointIndex != m_lastAppliedVisibilityViewpointIndex)
+        {
+            m_lastAppliedVisibilityViewpointIndex = activeViewpointIndex;
+            m_dataDispatcher.sendControl(new control::viewpoint::UpdateStatesFromViewpoint(m_animationPlaylist[activeViewpointIndex]));
+        }
+    }
 
     if (m_currentKeyPoint >= m_trajectory.size())
         return true;


### PR DESCRIPTION
### Motivation

- Ensure viewpoint-specific visibility/rendering states are applied when switching viewpoints during animations and HD video export so UI and rendering remain in sync.
- Avoid redundant state updates by tracking which viewpoint's visibility was last applied.

### Description

- Added a `size_t m_lastAppliedVisibilityViewpointIndex` member to `CameraNode` and `ContextExportVideoHD` to record the last-applied viewpoint index. 
- Initialize and reset `m_lastAppliedVisibilityViewpointIndex` in animation lifecycle methods (`startAnimation`, `endAnimation`, `cleanAnimation`) and in `ContextExportVideoHD::start` and launch flow. 
- During video export (`ContextExportVideoHD::launch`) and viewpoint trajectory animation (`CameraNode::animateViewpointTrajectory`) compute the active viewpoint index and call `UpdateStatesFromViewpoint` only when the active index changes to apply visibility/rendering state updates. 
- Added missing includes (`<cstddef>`, `controller/IControlListener.h`, and `controller/controls/ControlViewPoint.h`) required by the new logic.

### Testing

- Project build was run after the changes and completed successfully. 
- Existing automated unit/integration tests were executed and passed with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1764c9564832fb4e3d3c09b199cb4)