### PR TITLE
Propagate `rampClamped` to ViewPoint data and add object transform/clip/ramp interpolation for animations and export

### DIFF
--- a/include/models/data/ViewPoint/ViewPointData.h
+++ b/include/models/data/ViewPoint/ViewPointData.h
@@ -31,6 +31,7 @@ public:
 		float minRamp = 0.f;
 		float maxRamp = 1.f;
 		int stepsRamp = 8;
+		bool rampClamped = false;
 	};
 
 	ViewPointData();

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -12,6 +12,7 @@
 #include "models/3d/RenderingParameters.h"
 #include "pointCloudEngine/RenderingTypes.h"
 #include "models/application/ViewPointAnimation.h"
+#include "models/data/ViewPoint/ViewPointData.h"
 
 #include <deque>
 #include <chrono>
@@ -56,6 +57,10 @@ struct ViewpointRenderState
     float fovy = 0.0f;
     std::unordered_set<SafePtr<AGraphNode>> visibleObjects;
     std::unordered_map<SafePtr<AGraphNode>, Color32> scanClusterColors;
+    std::unordered_map<SafePtr<AGraphNode>, TransformationModule> objectTransforms;
+    std::unordered_set<SafePtr<AGraphNode>> positionOnlyObjects;
+    std::unordered_map<SafePtr<AGraphNode>, ViewPointData::ClippingDistances> objectClippingDistances;
+    std::unordered_map<SafePtr<AGraphNode>, ViewPointData::RampDistances> objectRampDistances;
 };
 
 enum class InterpolationValueWithPreviousAnimation { NONE, BEZIER/*, LINEAR*/ };

--- a/src/controller/controls/ControlViewPoint.cpp
+++ b/src/controller/controls/ControlViewPoint.cpp
@@ -60,7 +60,8 @@ bool supportsViewpointClippable(ElementType type)
 
 bool supportsViewpointClippingDistances(ElementType type)
 {
-    return type == ElementType::Tag ||
+    return type == ElementType::Box ||
+        type == ElementType::Tag ||
         type == ElementType::Point ||
         type == ElementType::Cylinder ||
         type == ElementType::Sphere ||
@@ -351,6 +352,8 @@ namespace control::viewpoint
                     clippingObject->setRampMax(rampValues.maxRamp);
                 if (clippingObject->getRampSteps() != rampValues.stepsRamp)
                     clippingObject->setRampSteps(rampValues.stepsRamp);
+                if (writeObject->getType() == ElementType::Box && clippingObject->isRampClamped() != rampValues.rampClamped)
+                    clippingObject->setRampClamped(rampValues.rampClamped);
                 editedNodes.insert(object);
             }
 

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -7,6 +7,7 @@
 
 #include "models/graph/GraphManager.h"
 #include "models/graph/AGraphNode.h"
+#include "models/graph/AClippingNode.h"
 #include "models/graph/CameraNode.h"
 #include "models/graph/ViewPointNode.h"
 #include "models/application/ViewPointAnimation.h"
@@ -68,6 +69,109 @@ Color32 normalizedRgbToColor32(const glm::vec3& rgb, uint8_t alpha)
         static_cast<uint8_t>(std::round(clamped.y * 255.0f)),
         static_cast<uint8_t>(std::round(clamped.z * 255.0f)),
         alpha);
+}
+
+
+
+bool supportsInterpolatedObjectTransform(ElementType type)
+{
+    return type == ElementType::Box ||
+        type == ElementType::Cylinder ||
+        type == ElementType::Sphere ||
+        type == ElementType::MeshObject ||
+        type == ElementType::Tag ||
+        type == ElementType::Point ||
+        type == ElementType::PCO;
+}
+
+bool isPositionOnlyInterpolatedObject(ElementType type)
+{
+    return type == ElementType::Tag || type == ElementType::Point;
+}
+
+bool supportsInterpolatedClippingDistances(ElementType type)
+{
+    return type == ElementType::Box ||
+        type == ElementType::Tag ||
+        type == ElementType::Point ||
+        type == ElementType::Cylinder ||
+        type == ElementType::Sphere ||
+        type == ElementType::SimpleMeasure ||
+        type == ElementType::PolylineMeasure;
+}
+
+bool supportsInterpolatedLengthThreshold(ElementType type)
+{
+    return type == ElementType::Cylinder ||
+        type == ElementType::SimpleMeasure ||
+        type == ElementType::PolylineMeasure;
+}
+
+void interpolateAndApplyObjects(const ViewPointNode& left, const ViewPointNode& right, double alpha)
+{
+    const auto& leftTransforms = left.getObjectsTransform();
+    const auto& rightTransforms = right.getObjectsTransform();
+    for (const auto& [object, leftTransform] : leftTransforms)
+    {
+        auto itRightTransform = rightTransforms.find(object);
+        if (itRightTransform == rightTransforms.end())
+            continue;
+
+        WritePtr<AGraphNode> wObject = object.get();
+        if (!wObject || !supportsInterpolatedObjectTransform(wObject->getType()))
+            continue;
+
+        const glm::dvec3 interpolatedCenter = leftTransform.getCenter() + (itRightTransform->second.getCenter() - leftTransform.getCenter()) * alpha;
+        if (isPositionOnlyInterpolatedObject(wObject->getType()))
+        {
+            wObject->setPosition(interpolatedCenter);
+            continue;
+        }
+
+        const glm::dquat interpolatedOrientation = glm::normalize(glm::slerp(leftTransform.getOrientation(), itRightTransform->second.getOrientation(), alpha));
+        const glm::dvec3 interpolatedScale = leftTransform.getScale() + (itRightTransform->second.getScale() - leftTransform.getScale()) * alpha;
+        wObject->setTransformationModule(TransformationModule(interpolatedCenter, interpolatedOrientation, interpolatedScale));
+    }
+
+    const auto& leftClips = left.getObjectsClippingDistances();
+    const auto& rightClips = right.getObjectsClippingDistances();
+    for (const auto& [object, leftClip] : leftClips)
+    {
+        auto itRightClip = rightClips.find(object);
+        if (itRightClip == rightClips.end())
+            continue;
+
+        WritePtr<AGraphNode> wObject = object.get();
+        if (!wObject || !supportsInterpolatedClippingDistances(wObject->getType()))
+            continue;
+
+        AClippingNode* clippingObject = static_cast<AClippingNode*>(wObject.operator->());
+        clippingObject->setMinClipDist(leftClip.minClip + (itRightClip->second.minClip - leftClip.minClip) * static_cast<float>(alpha));
+        clippingObject->setMaxClipDist(leftClip.maxClip + (itRightClip->second.maxClip - leftClip.maxClip) * static_cast<float>(alpha));
+        if (supportsInterpolatedLengthThreshold(wObject->getType()))
+            clippingObject->setLengthThresholdClip(leftClip.lengthThreshold + (itRightClip->second.lengthThreshold - leftClip.lengthThreshold) * static_cast<float>(alpha));
+    }
+
+    const auto& leftRamps = left.getObjectsRampDistances();
+    const auto& rightRamps = right.getObjectsRampDistances();
+    for (const auto& [object, leftRamp] : leftRamps)
+    {
+        auto itRightRamp = rightRamps.find(object);
+        if (itRightRamp == rightRamps.end())
+            continue;
+
+        WritePtr<AGraphNode> wObject = object.get();
+        if (!wObject || !supportsInterpolatedClippingDistances(wObject->getType()))
+            continue;
+
+        AClippingNode* clippingObject = static_cast<AClippingNode*>(wObject.operator->());
+        clippingObject->setRampMin(leftRamp.minRamp + (itRightRamp->second.minRamp - leftRamp.minRamp) * static_cast<float>(alpha));
+        clippingObject->setRampMax(leftRamp.maxRamp + (itRightRamp->second.maxRamp - leftRamp.maxRamp) * static_cast<float>(alpha));
+        const float steps = static_cast<float>(leftRamp.stepsRamp) + static_cast<float>(itRightRamp->second.stepsRamp - leftRamp.stepsRamp) * static_cast<float>(alpha);
+        clippingObject->setRampSteps(std::max(1, static_cast<int>(std::round(steps))));
+        if (wObject->getType() == ElementType::Box)
+            clippingObject->setRampClamped(leftRamp.rampClamped);
+    }
 }
 
 Color32 interpolateColorHsvShortestPath(const Color32& start, const Color32& end, float alpha)
@@ -366,6 +470,8 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
                         wObject->setColor(interpolateColorHsvShortestPath(leftColor, itRightColor->second, alphaF));
                     }
                 }
+
+                interpolateAndApplyObjects(*&left, *&right, alpha);
             }
         }
         else if (m_animFrame > 1)

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -574,15 +574,16 @@ void ExportViewPointData(nlohmann::json& json, const ViewPointData& data)
 		}
 
 		auto rampIt = data.getObjectsRampDistances().find(transformSet.first);
-		if (rampIt != data.getObjectsRampDistances().end())
-		{
-			objState[Key_ViewPoint_Object_Ramp] =
+			if (rampIt != data.getObjectsRampDistances().end())
 			{
-				{ Key_MinRampDistance, rampIt->second.minRamp },
-				{ Key_MaxRampDistance, rampIt->second.maxRamp },
-				{ Key_RampSteps, rampIt->second.stepsRamp }
-			};
-		}
+				objState[Key_ViewPoint_Object_Ramp] =
+				{
+					{ Key_MinRampDistance, rampIt->second.minRamp },
+					{ Key_MaxRampDistance, rampIt->second.maxRamp },
+					{ Key_RampSteps, rampIt->second.stepsRamp },
+					{ Key_RampClamped, rampIt->second.rampClamped }
+				};
+			}
 
 		childrenElem.push_back(objState);
 	}
@@ -651,15 +652,16 @@ void ExportViewPointData(nlohmann::json& json, const ViewPointData& data)
 			});
 		if (it != childrenElem.end())
 			continue;
-		childrenElem.push_back({
-			{ Key_Id, rObj->getId() },
-			{ Key_ViewPoint_Object_Ramp, {
-				{ Key_MinRampDistance, rampSet.second.minRamp },
-				{ Key_MaxRampDistance, rampSet.second.maxRamp },
-				{ Key_RampSteps, rampSet.second.stepsRamp }
-			} }
-		});
-	}
+			childrenElem.push_back({
+				{ Key_Id, rObj->getId() },
+				{ Key_ViewPoint_Object_Ramp, {
+					{ Key_MinRampDistance, rampSet.second.minRamp },
+					{ Key_MaxRampDistance, rampSet.second.maxRamp },
+					{ Key_RampSteps, rampSet.second.stepsRamp },
+					{ Key_RampClamped, rampSet.second.rampClamped }
+				} }
+			});
+		}
 
 	json[Key_ViewPoint_Object_States] = childrenElem;
 }

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -2133,6 +2133,8 @@ bool ImportViewPointData(const nlohmann::json& json, ViewPointData& data, const 
                     distances.maxRamp = ramp.at(Key_MaxRampDistance).get<float>();
                 if (ramp.find(Key_RampSteps) != ramp.end())
                     distances.stepsRamp = ramp.at(Key_RampSteps).get<int>();
+                if (ramp.find(Key_RampClamped) != ramp.end())
+                    distances.rampClamped = ramp.at(Key_RampClamped).get<bool>();
                 objectsRampDistances[objectNode] = distances;
             }
         }

--- a/src/models/data/ViewPoint/ViewPointData.cpp
+++ b/src/models/data/ViewPoint/ViewPointData.cpp
@@ -40,7 +40,8 @@ namespace
 
 	bool supportsViewpointClippingDistances(ElementType type)
 	{
-		return type == ElementType::Tag ||
+		return type == ElementType::Box ||
+			type == ElementType::Tag ||
 			type == ElementType::Point ||
 			type == ElementType::Cylinder ||
 			type == ElementType::Sphere ||
@@ -262,6 +263,7 @@ void ViewPointData::updateViewpointsObjectsValue(Controller& controller, SafePtr
 			rampDistances.minRamp = clippingObject->getRampMin();
 			rampDistances.maxRamp = clippingObject->getRampMax();
 			rampDistances.stepsRamp = clippingObject->getRampSteps();
+			rampDistances.rampClamped = clippingObject->isRampClamped();
 			objectsRampDistances[object] = rampDistances;
 		}
 	}

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -9,6 +9,7 @@
 #include "models/graph/SimpleMeasureNode.h"
 #include "models/graph/PolylineMeasureNode.h"
 #include "models/graph/ViewPointNode.h"
+#include "models/graph/AClippingNode.h"
 #include "models/graph/TargetNode.h"
 #include "models/3d/UniformClippingData.h"
 
@@ -61,6 +62,41 @@ uint32_t computeNextPolygonId(const PolygonalSelectorSettings& settings)
         maxSuffix = std::max<uint32_t>(maxSuffix, getPolygonSuffix(polygon.name));
 
     return std::max<uint32_t>(std::max<uint32_t>(settings.nextPolygonId, maxSuffix + 1), 1u);
+}
+
+
+bool supportsInterpolatedObjectTransform(ElementType type)
+{
+    return type == ElementType::Box ||
+        type == ElementType::Cylinder ||
+        type == ElementType::Sphere ||
+        type == ElementType::MeshObject ||
+        type == ElementType::Tag ||
+        type == ElementType::Point ||
+        type == ElementType::PCO;
+}
+
+bool isPositionOnlyInterpolatedObject(ElementType type)
+{
+    return type == ElementType::Tag || type == ElementType::Point;
+}
+
+bool supportsInterpolatedClippingDistances(ElementType type)
+{
+    return type == ElementType::Box ||
+        type == ElementType::Tag ||
+        type == ElementType::Point ||
+        type == ElementType::Cylinder ||
+        type == ElementType::Sphere ||
+        type == ElementType::SimpleMeasure ||
+        type == ElementType::PolylineMeasure;
+}
+
+bool supportsInterpolatedLengthThreshold(ElementType type)
+{
+    return type == ElementType::Cylinder ||
+        type == ElementType::SimpleMeasure ||
+        type == ElementType::PolylineMeasure;
 }
 
 glm::vec3 color32ToNormalizedRgb(const Color32& color)
@@ -1576,6 +1612,18 @@ ViewpointRenderState CameraNode::buildViewpointRenderState(const ViewPointNode& 
     state.fovy = viewpoint.getFovy();
     state.visibleObjects = viewpoint.getVisibleObjects();
     state.scanClusterColors = viewpoint.getScanClusterColors();
+    state.objectTransforms = viewpoint.getObjectsTransform();
+    for (const auto& [object, transform] : state.objectTransforms)
+    {
+        ReadPtr<AGraphNode> rObject = object.cget();
+        if (!rObject || !supportsInterpolatedObjectTransform(rObject->getType()))
+            continue;
+
+        if (isPositionOnlyInterpolatedObject(rObject->getType()))
+            state.positionOnlyObjects.insert(object);
+    }
+    state.objectClippingDistances = viewpoint.getObjectsClippingDistances();
+    state.objectRampDistances = viewpoint.getObjectsRampDistances();
     return state;
 }
 
@@ -1600,22 +1648,88 @@ ViewpointRenderState CameraNode::lerpViewpointRenderState(const ViewpointRenderS
         start.renderMode == end.renderMode &&
         (start.renderMode == UiRenderMode::Scans_Color || start.renderMode == UiRenderMode::Clusters_Color);
 
-    if (!interpolateScanClusterColors)
-        return state;
-
-    for (const auto& [object, startColor] : start.scanClusterColors)
+    if (interpolateScanClusterColors)
     {
-        if (start.visibleObjects.find(object) == start.visibleObjects.end())
+        for (const auto& [object, startColor] : start.scanClusterColors)
+        {
+            if (start.visibleObjects.find(object) == start.visibleObjects.end())
+                continue;
+
+            auto endColorIt = end.scanClusterColors.find(object);
+            if (endColorIt == end.scanClusterColors.end())
+                continue;
+
+            if (end.visibleObjects.find(object) == end.visibleObjects.end())
+                continue;
+
+            state.scanClusterColors[object] = interpolateColorHsvShortestPath(startColor, endColorIt->second, alpha);
+        }
+    }
+
+    for (const auto& [object, startTransform] : start.objectTransforms)
+    {
+        auto endTransformIt = end.objectTransforms.find(object);
+        if (endTransformIt == end.objectTransforms.end())
             continue;
 
-        auto endColorIt = end.scanClusterColors.find(object);
-        if (endColorIt == end.scanClusterColors.end())
+        ReadPtr<AGraphNode> rObject = object.cget();
+        if (!rObject || !supportsInterpolatedObjectTransform(rObject->getType()))
             continue;
 
-        if (end.visibleObjects.find(object) == end.visibleObjects.end())
+        const bool positionOnly = isPositionOnlyInterpolatedObject(rObject->getType());
+        if (positionOnly)
+            state.positionOnlyObjects.insert(object);
+
+        const glm::dvec3 interpolatedCenter = startTransform.getCenter() + (endTransformIt->second.getCenter() - startTransform.getCenter()) * static_cast<double>(alpha);
+        if (positionOnly)
+        {
+            TransformationModule interpolatedTransform = startTransform;
+            interpolatedTransform.setPosition(interpolatedCenter);
+            state.objectTransforms[object] = interpolatedTransform;
+            continue;
+        }
+
+        const glm::dquat interpolatedOrientation = glm::normalize(glm::slerp(startTransform.getOrientation(), endTransformIt->second.getOrientation(), static_cast<double>(alpha)));
+        const glm::dvec3 interpolatedScale = startTransform.getScale() + (endTransformIt->second.getScale() - startTransform.getScale()) * static_cast<double>(alpha);
+        state.objectTransforms[object] = TransformationModule(interpolatedCenter, interpolatedOrientation, interpolatedScale);
+    }
+
+    for (const auto& [object, startClip] : start.objectClippingDistances)
+    {
+        auto endClipIt = end.objectClippingDistances.find(object);
+        if (endClipIt == end.objectClippingDistances.end())
             continue;
 
-        state.scanClusterColors[object] = interpolateColorHsvShortestPath(startColor, endColorIt->second, alpha);
+        ReadPtr<AGraphNode> rObject = object.cget();
+        if (!rObject || !supportsInterpolatedClippingDistances(rObject->getType()))
+            continue;
+
+        ViewPointData::ClippingDistances interpolatedClip;
+        interpolatedClip.minClip = startClip.minClip + (endClipIt->second.minClip - startClip.minClip) * alpha;
+        interpolatedClip.maxClip = startClip.maxClip + (endClipIt->second.maxClip - startClip.maxClip) * alpha;
+        interpolatedClip.lengthThreshold = supportsInterpolatedLengthThreshold(rObject->getType())
+            ? startClip.lengthThreshold + (endClipIt->second.lengthThreshold - startClip.lengthThreshold) * alpha
+            : 0.f;
+        state.objectClippingDistances[object] = interpolatedClip;
+    }
+
+    for (const auto& [object, startRamp] : start.objectRampDistances)
+    {
+        auto endRampIt = end.objectRampDistances.find(object);
+        if (endRampIt == end.objectRampDistances.end())
+            continue;
+
+        ReadPtr<AGraphNode> rObject = object.cget();
+        if (!rObject || !supportsInterpolatedClippingDistances(rObject->getType()))
+            continue;
+
+        ViewPointData::RampDistances interpolatedRamp;
+        interpolatedRamp.minRamp = startRamp.minRamp + (endRampIt->second.minRamp - startRamp.minRamp) * alpha;
+        interpolatedRamp.maxRamp = startRamp.maxRamp + (endRampIt->second.maxRamp - startRamp.maxRamp) * alpha;
+        const float steps = static_cast<float>(startRamp.stepsRamp) + static_cast<float>(endRampIt->second.stepsRamp - startRamp.stepsRamp) * alpha;
+        interpolatedRamp.stepsRamp = std::max(1, static_cast<int>(std::round(steps)));
+        interpolatedRamp.rampClamped = startRamp.rampClamped;
+        state.objectRampDistances[object] = interpolatedRamp;
     }
 
     return state;
@@ -1642,6 +1756,45 @@ void CameraNode::applyViewpointRenderState(const ViewpointRenderState& state)
             if (wObject)
                 wObject->setColor(color);
         }
+    }
+
+    for (const auto& [object, transform] : state.objectTransforms)
+    {
+        WritePtr<AGraphNode> wObject = object.get();
+        if (!wObject)
+            continue;
+
+        if (state.positionOnlyObjects.find(object) != state.positionOnlyObjects.end())
+            wObject->setPosition(transform.getCenter());
+        else
+            wObject->setTransformationModule(transform);
+    }
+
+    for (const auto& [object, clip] : state.objectClippingDistances)
+    {
+        WritePtr<AGraphNode> wObject = object.get();
+        if (!wObject || !supportsInterpolatedClippingDistances(wObject->getType()))
+            continue;
+
+        AClippingNode* clippingObject = static_cast<AClippingNode*>(wObject.operator->());
+        clippingObject->setMinClipDist(clip.minClip);
+        clippingObject->setMaxClipDist(clip.maxClip);
+        if (supportsInterpolatedLengthThreshold(wObject->getType()))
+            clippingObject->setLengthThresholdClip(clip.lengthThreshold);
+    }
+
+    for (const auto& [object, ramp] : state.objectRampDistances)
+    {
+        WritePtr<AGraphNode> wObject = object.get();
+        if (!wObject || !supportsInterpolatedClippingDistances(wObject->getType()))
+            continue;
+
+        AClippingNode* clippingObject = static_cast<AClippingNode*>(wObject.operator->());
+        clippingObject->setRampMin(ramp.minRamp);
+        clippingObject->setRampMax(ramp.maxRamp);
+        clippingObject->setRampSteps(std::max(1, ramp.stepsRamp));
+        if (wObject->getType() == ElementType::Box)
+            clippingObject->setRampClamped(ramp.rampClamped);
     }
 }
 


### PR DESCRIPTION
### Motivation
- Add support for an additional ramp flag so box clipping ramps can be preserved in saved viewpoints and applied during playback/export.
- Enable smooth interpolation of object transformations, clipping distances and ramp parameters across viewpoint keyframes so animations and HD video exports reflect object-level state changes.
- Ensure import/export round-trips include the new ramp flag and existing viewpoint object properties.

### Description
- Extended `ViewPointData::RampDistances` with a `rampClamped` boolean and wired it through `ViewPointData` population in `ViewPointData.cpp`.
- Persisted the new `Key_RampClamped` field in `DataSerializer::ExportViewPointData` and read it in `ImportViewPointData` inside `DataDeserializer.cpp`.
- Added interpolation helpers and logic for object transforms, clipping distances and ramp distances in `ContextExportVideoHD.cpp` and `CameraNode.cpp`, including per-type checks (`supportsInterpolated*`) and special handling for position-only objects and box `rampClamped` behavior.
- Extended `ViewpointRenderState` with `objectTransforms`, `positionOnlyObjects`, `objectClippingDistances` and `objectRampDistances`, and updated `lerpViewpointRenderState` / `applyViewpointRenderState` to interpolate and apply these states during animation playback.
- Included necessary header imports (`AClippingNode`, `ViewPointData`) and small API uses to set/get `isRampClamped` and `setRampClamped` when applicable.

### Testing
- Project was built successfully after changes and compilation errors were resolved for modified files.
- ViewPoint import/export code paths were exercised to verify that `Key_RampClamped` is written and read back and that viewpoint JSON contains the new field; these tests succeeded.
- Video export and viewpoint animation playback paths were executed to validate interpolated object transforms, clipping distances and ramps, and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b347ffb8832f88d0614fccba01b6)