### PR TITLE
Ensure unique names for duplicated objects, robust mesh instance loading, and add logging on unknown mesh removal

### DIFF
--- a/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
+++ b/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
@@ -6,9 +6,54 @@
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/texts/MeshObjectTexts.hpp"
 #include "utils/Logger.h"
+#include "vulkan/MeshManager.h"
 
 #include "models/graph/MeshObjectNode.h"
 #include "models/graph/GraphManager.h"
+
+#include <cwctype>
+
+namespace
+{
+std::wstring getNextCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    const std::wstring copyToken = L"_copy";
+    std::wstring baseName = sourceName;
+    const size_t suffixPos = sourceName.rfind(copyToken);
+    if (suffixPos != std::wstring::npos)
+    {
+        bool isNumericSuffix = (suffixPos + copyToken.size() < sourceName.size());
+        for (size_t i = suffixPos + copyToken.size(); i < sourceName.size(); ++i)
+        {
+            if (!iswdigit(sourceName[i]))
+            {
+                isNumericSuffix = false;
+                break;
+            }
+        }
+        if (isNumericSuffix)
+            baseName = sourceName.substr(0, suffixPos);
+    }
+
+    std::unordered_set<std::wstring> usedNames;
+    for (const SafePtr<AGraphNode>& node : graphManager.getNodesByTypes({ ElementType::MeshObject }, ObjectStatusFilter::ALL))
+    {
+        ReadPtr<AGraphNode> rNode = node.cget();
+        if (!rNode)
+            continue;
+        usedNames.insert(rNode->getName());
+    }
+
+    uint32_t index = 1;
+    std::wstring candidate;
+    do
+    {
+        candidate = baseName + copyToken + std::to_wstring(index++);
+    } while (usedNames.find(candidate) != usedNames.end());
+
+    return candidate;
+}
+}
 
 ContextMeshObjectDuplication::ContextMeshObjectDuplication(const ContextId& id)
 	: ARayTracingContext(id)
@@ -86,9 +131,23 @@ ContextState ContextMeshObjectDuplication::launch(Controller& controller)
     wNewObj->setModificationTime(time(&timeNow));
     wNewObj->setAuthor(controller.getContext().getActiveAuthor());
     wNewObj->setUserIndex(controller.getNextUserId(wNewObj->getType()));
+    wNewObj->setName(getNextCopyName(wNewObj->getName(), graphManager));
+    wNewObj->setObjectName(wNewObj->getName());
     setObjectParameters(controller, *&wNewObj, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale * glm::dvec3(dim));
 
-    MeshManager::getInstance().addMeshInstance(wNewObj->getMeshId());
+    MeshManager& meshManager = MeshManager::getInstance();
+    if (!meshManager.addMeshInstance(wNewObj->getMeshId()))
+    {
+        const std::filesystem::path meshFolder = controller.getContext().cgetProjectInternalInfo().getObjectsFilesFolderPath();
+        if (meshManager.reloadMeshFile(*&wNewObj, meshFolder, &controller) != ObjectAllocation::ReturnCode::Success)
+        {
+            FUNCLOG << "AContextWavefrontDuplication failed to add mesh instance for copy" << LOGENDL;
+            if (m_mode == DuplicationMode::Click)
+                return ARayTracingContext::abort(controller);
+            else
+                return (m_state = ContextState::abort);
+        }
+    }
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newObj));
 

--- a/src/controller/functionSystem/ContextPCODuplication.cpp
+++ b/src/controller/functionSystem/ContextPCODuplication.cpp
@@ -9,6 +9,50 @@
 #include "models/graph/GraphManager.h"
 #include "utils/Logger.h"
 
+#include <cwctype>
+
+namespace
+{
+std::wstring getNextCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    const std::wstring copyToken = L"_copy";
+    std::wstring baseName = sourceName;
+    const size_t suffixPos = sourceName.rfind(copyToken);
+    if (suffixPos != std::wstring::npos)
+    {
+        bool isNumericSuffix = (suffixPos + copyToken.size() < sourceName.size());
+        for (size_t i = suffixPos + copyToken.size(); i < sourceName.size(); ++i)
+        {
+            if (!iswdigit(sourceName[i]))
+            {
+                isNumericSuffix = false;
+                break;
+            }
+        }
+        if (isNumericSuffix)
+            baseName = sourceName.substr(0, suffixPos);
+    }
+
+    std::unordered_set<std::wstring> usedNames;
+    for (const SafePtr<AGraphNode>& node : graphManager.getNodesByTypes({ ElementType::PCO }, ObjectStatusFilter::ALL))
+    {
+        ReadPtr<AGraphNode> rNode = node.cget();
+        if (!rNode)
+            continue;
+        usedNames.insert(rNode->getName());
+    }
+
+    uint32_t index = 1;
+    std::wstring candidate;
+    do
+    {
+        candidate = baseName + copyToken + std::to_wstring(index++);
+    } while (usedNames.find(candidate) != usedNames.end());
+
+    return candidate;
+}
+}
+
 
 ContextPCODuplication::ContextPCODuplication(const ContextId& id)
 	: ARayTracingContext(id)
@@ -87,6 +131,7 @@ ContextState ContextPCODuplication::launch(Controller& controller)
     wNewPco->setModificationTime(time(&timeNow));
     wNewPco->setAuthor(controller.getContext().getActiveAuthor());
     wNewPco->setUserIndex(controller.getNextUserId(wNewPco->getType()));
+    wNewPco->setName(getNextCopyName(wNewPco->getName(), graphManager));
     setObjectParameters(controller, *&wNewPco, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale);
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newPco));

--- a/src/vulkan/MeshManager.cpp
+++ b/src/vulkan/MeshManager.cpp
@@ -1149,6 +1149,8 @@ bool MeshManager::removeMeshInstance(MeshId id)
         return false;
     if (m_meshesCounters.find(id) == m_meshesCounters.end())
     {
+        GRAPH_LOG << "removeMeshInstance called on unknown mesh id " << id << " (loaded="
+                  << (m_meshes.find(id) != m_meshes.end()) << ")" << Logger::endl;
         assert(false);
         return false;
     }


### PR DESCRIPTION
### Motivation

- Prevent name collisions when duplicating mesh and point-cloud objects by generating a unique copy name.
- Make mesh duplication more robust by handling failures from `MeshManager::addMeshInstance` and attempting to reload mesh files from the project internal folder.
- Improve diagnostics when `MeshManager::removeMeshInstance` is invoked with an unknown id.

### Description

- Add a helper `getNextCopyName` (local anonymous namespace) to compute unique duplicate names using a `_copyN` suffix and use it in `ContextMeshObjectDuplication` and `ContextPCODuplication` by calling `setName` (and `setObjectName` for mesh objects).
- Include `<cwctype>` and ensure existing `_copy` suffix handling ignores non-numeric suffixes when deriving the base name.
- In `ContextMeshObjectDuplication` include `vulkan/MeshManager.h` and change mesh instance handling to call `MeshManager::getInstance().addMeshInstance`, and if it fails attempt `reloadMeshFile` using the project internal objects folder before aborting.
- Add a diagnostic log in `MeshManager::removeMeshInstance` to report unknown mesh ids (printing whether the id is present in `m_meshes`) before asserting and returning `false`.

### Testing

- Performed a full project build which completed successfully without compilation errors.
- Ran the automated unit test suite and it completed successfully with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43cd0794c832fa25f2e2576563154)