### PR TITLE
Track imported-original state for scans and mesh objects; improve duplication, import, and serialization

### DIFF
--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -80,6 +80,7 @@
 //Scan, PCO & meshObject
 #define Key_Path "Path"
 #define Key_Clippable "Clippable"
+#define Key_IsImportedOriginal "IsImportedOriginal"
 
 //Grid
 #define Key_GridType "GridType"

--- a/include/models/data/MeshObject/MeshObjectData.h
+++ b/include/models/data/MeshObject/MeshObjectData.h
@@ -18,17 +18,20 @@ public:
 	void setObjectName(const std::wstring& name);
 	void setMeshId(const MeshId& id);
 	void setDimension(const glm::vec3& dimension);
+	void setImportedOriginal(bool isImportedOriginal);
 
 	std::filesystem::path getFilePath() const;
 	std::wstring getObjectName() const;
 	MeshId getMeshId() const;
 	glm::vec3 getDimension() const;
+	bool isImportedOriginal() const;
 
 protected:
 	std::filesystem::path	m_filePath;
 	std::wstring			m_objectName;
 	MeshId					m_meshId;
 	glm::vec3				m_dimension;
+	bool                    m_isImportedOriginal = true;
 };
 
 #endif

--- a/include/models/data/Scan/ScanData.h
+++ b/include/models/data/Scan/ScanData.h
@@ -20,6 +20,8 @@ public:
 
     void setClippable(bool clippable);
     bool getClippable() const;
+    void setImportedOriginal(bool isImportedOriginal);
+    bool isImportedOriginal() const;
 
     void freeScanFile() const;
     void eraseScanFile() const;
@@ -46,6 +48,7 @@ protected:
     tls::ScanGuid m_scanGuid = xg::Guid();
     bool m_clippable = true;
     bool is_object_ = false;
+    bool m_isImportedOriginal = true;
 };
 
 

--- a/src/controller/controls/ControlSpecial.cpp
+++ b/src/controller/controls/ControlSpecial.cpp
@@ -13,8 +13,6 @@
 #include "models/graph/MeshObjectNode.h"
 #include "models/ElementType.h"
 
-#include "vulkan/MeshManager.h"
-
 #include "utils/Logger.h"
 
 
@@ -237,9 +235,6 @@ namespace control::special
 		std::unordered_set<SafePtr<AGraphNode>> importantDatas;
 		std::unordered_set<SafePtr<AGraphNode>> otherDatas;
 
-		std::unordered_map<MeshId, std::unordered_set<SafePtr<AGraphNode>>> meshIdToMeshObjects;
-		std::unordered_map<tls::ScanGuid, std::unordered_set<SafePtr<AGraphNode>>> scanObjPathToTls;
-
 
 		for (const SafePtr<AGraphNode>& node : graphManager.getSelectedNodes())
 		{
@@ -318,7 +313,7 @@ namespace control::special
 					ReadPtr<PointCloudNode> scan = static_pointer_cast<PointCloudNode>(toDelete).cget();
 					if (!scan)
 						continue;
-					if(scan->getScanGuid().isValid())
+					if(scan->getScanGuid().isValid() && scan->isImportedOriginal())
 						importantDatas.insert(toDelete);
 					else
 						otherDatas.insert(toDelete);
@@ -329,11 +324,10 @@ namespace control::special
 					ReadPtr<PointCloudNode> scanObj = static_pointer_cast<PointCloudNode>(toDelete).cget();
 					if (!scanObj)
 						continue;
-					tls::ScanGuid scanGuid = scanObj->getScanGuid();
-					if (scanObjPathToTls.find(scanGuid) != scanObjPathToTls.end())
-						scanObjPathToTls[scanGuid].insert(toDelete);
+					if (scanObj->getScanGuid().isValid() && scanObj->isImportedOriginal())
+						importantDatas.insert(toDelete);
 					else
-						scanObjPathToTls[scanGuid] = { toDelete };
+						otherDatas.insert(toDelete);
 				}
 				break;
 				case ElementType::MeshObject:
@@ -341,11 +335,10 @@ namespace control::special
 					ReadPtr<MeshObjectNode> meshObject = static_pointer_cast<MeshObjectNode>(toDelete).cget();
 					if (!meshObject)
 						continue;
-					xg::Guid meshId = meshObject->getMeshId();
-					if (meshIdToMeshObjects.find(meshId) != meshIdToMeshObjects.end())
-						meshIdToMeshObjects[meshId].insert(toDelete);
+					if (meshObject->getMeshId().isValid() && meshObject->isImportedOriginal())
+						importantDatas.insert(toDelete);
 					else
-						meshIdToMeshObjects[meshId] = { toDelete };
+						otherDatas.insert(toDelete);
 					break;
 				}
 				default:
@@ -353,23 +346,6 @@ namespace control::special
 					break;
 		    }
         }
-
-		for (auto meshElement : meshIdToMeshObjects)
-		{
-			MeshManager& manager = MeshManager::getInstance();
-			if (meshElement.first.isValid() && manager.getMeshCounters(meshElement.first) <= meshElement.second.size())
-				importantDatas.insert(meshElement.second.begin(), meshElement.second.end());
-			else
-				otherDatas.insert(meshElement.second.begin(), meshElement.second.end());
-		}
-
-		for (auto scanObjElement : scanObjPathToTls)
-		{
-			if (scanObjElement.first.isValid() && graphManager.getPCOcounters(scanObjElement.first) <= scanObjElement.second.size())
-				importantDatas.insert(scanObjElement.second.begin(), scanObjElement.second.end());
-			else
-				otherDatas.insert(scanObjElement.second.begin(), scanObjElement.second.end());
-		}
 
 		if (!importantDatas.empty())
 		{

--- a/src/controller/functionSystem/ContextMeshObjectCreation.cpp
+++ b/src/controller/functionSystem/ContextMeshObjectCreation.cpp
@@ -242,6 +242,7 @@ ContextState ContextMeshObjectCreation::launch(Controller& controller)
 
 			wObject->setFilePath(meshInfo.path);
 			wObject->setObjectName(name);
+			wObject->setImportedOriginal(true);
 			wObject->setMeshId(mId);
 			manager.addMeshInstance(mId);
 			wObject->setDimension(smesh.m_dimensions);

--- a/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
+++ b/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
@@ -6,9 +6,54 @@
 #include "gui/GuiData/GuiDataMessages.h"
 #include "gui/texts/MeshObjectTexts.hpp"
 #include "utils/Logger.h"
+#include "vulkan/MeshManager.h"
 
 #include "models/graph/MeshObjectNode.h"
 #include "models/graph/GraphManager.h"
+
+#include <cwctype>
+
+namespace
+{
+std::wstring getNextCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    const std::wstring copyToken = L"_copy";
+    std::wstring baseName = sourceName;
+    const size_t suffixPos = sourceName.rfind(copyToken);
+    if (suffixPos != std::wstring::npos)
+    {
+        bool isNumericSuffix = (suffixPos + copyToken.size() < sourceName.size());
+        for (size_t i = suffixPos + copyToken.size(); i < sourceName.size(); ++i)
+        {
+            if (!iswdigit(sourceName[i]))
+            {
+                isNumericSuffix = false;
+                break;
+            }
+        }
+        if (isNumericSuffix)
+            baseName = sourceName.substr(0, suffixPos);
+    }
+
+    std::unordered_set<std::wstring> usedNames;
+    for (const SafePtr<AGraphNode>& node : graphManager.getNodesByTypes({ ElementType::MeshObject }, ObjectStatusFilter::ALL))
+    {
+        ReadPtr<AGraphNode> rNode = node.cget();
+        if (!rNode)
+            continue;
+        usedNames.insert(rNode->getName());
+    }
+
+    uint32_t index = 1;
+    std::wstring candidate;
+    do
+    {
+        candidate = baseName + copyToken + std::to_wstring(index++);
+    } while (usedNames.find(candidate) != usedNames.end());
+
+    return candidate;
+}
+}
 
 ContextMeshObjectDuplication::ContextMeshObjectDuplication(const ContextId& id)
 	: ARayTracingContext(id)
@@ -86,9 +131,24 @@ ContextState ContextMeshObjectDuplication::launch(Controller& controller)
     wNewObj->setModificationTime(time(&timeNow));
     wNewObj->setAuthor(controller.getContext().getActiveAuthor());
     wNewObj->setUserIndex(controller.getNextUserId(wNewObj->getType()));
+    wNewObj->setName(getNextCopyName(wNewObj->getName(), graphManager));
+    wNewObj->setObjectName(wNewObj->getName());
+    wNewObj->setImportedOriginal(false);
     setObjectParameters(controller, *&wNewObj, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale * glm::dvec3(dim));
 
-    MeshManager::getInstance().addMeshInstance(wNewObj->getMeshId());
+    MeshManager& meshManager = MeshManager::getInstance();
+    if (!meshManager.addMeshInstance(wNewObj->getMeshId()))
+    {
+        const std::filesystem::path meshFolder = controller.getContext().cgetProjectInternalInfo().getObjectsFilesFolderPath();
+        if (meshManager.reloadMeshFile(*&wNewObj, meshFolder, &controller) != ObjectAllocation::ReturnCode::Success)
+        {
+            FUNCLOG << "AContextWavefrontDuplication failed to add mesh instance for copy" << LOGENDL;
+            if (m_mode == DuplicationMode::Click)
+                return ARayTracingContext::abort(controller);
+            else
+                return (m_state = ContextState::abort);
+        }
+    }
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newObj));
 

--- a/src/controller/functionSystem/ContextPCODuplication.cpp
+++ b/src/controller/functionSystem/ContextPCODuplication.cpp
@@ -9,6 +9,50 @@
 #include "models/graph/GraphManager.h"
 #include "utils/Logger.h"
 
+#include <cwctype>
+
+namespace
+{
+std::wstring getNextCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    const std::wstring copyToken = L"_copy";
+    std::wstring baseName = sourceName;
+    const size_t suffixPos = sourceName.rfind(copyToken);
+    if (suffixPos != std::wstring::npos)
+    {
+        bool isNumericSuffix = (suffixPos + copyToken.size() < sourceName.size());
+        for (size_t i = suffixPos + copyToken.size(); i < sourceName.size(); ++i)
+        {
+            if (!iswdigit(sourceName[i]))
+            {
+                isNumericSuffix = false;
+                break;
+            }
+        }
+        if (isNumericSuffix)
+            baseName = sourceName.substr(0, suffixPos);
+    }
+
+    std::unordered_set<std::wstring> usedNames;
+    for (const SafePtr<AGraphNode>& node : graphManager.getNodesByTypes({ ElementType::PCO }, ObjectStatusFilter::ALL))
+    {
+        ReadPtr<AGraphNode> rNode = node.cget();
+        if (!rNode)
+            continue;
+        usedNames.insert(rNode->getName());
+    }
+
+    uint32_t index = 1;
+    std::wstring candidate;
+    do
+    {
+        candidate = baseName + copyToken + std::to_wstring(index++);
+    } while (usedNames.find(candidate) != usedNames.end());
+
+    return candidate;
+}
+}
+
 
 ContextPCODuplication::ContextPCODuplication(const ContextId& id)
 	: ARayTracingContext(id)
@@ -87,6 +131,8 @@ ContextState ContextPCODuplication::launch(Controller& controller)
     wNewPco->setModificationTime(time(&timeNow));
     wNewPco->setAuthor(controller.getContext().getActiveAuthor());
     wNewPco->setUserIndex(controller.getNextUserId(wNewPco->getType()));
+    wNewPco->setName(getNextCopyName(wNewPco->getName(), graphManager));
+    wNewPco->setImportedOriginal(false);
     setObjectParameters(controller, *&wNewPco, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale);
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newPco));

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -1292,6 +1292,7 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
         if (!is_object)
             wpc->setManipulable(Config::isUnlockScanManipulation());
         wpc->setTlsFilePath(dst_path, true, scanGuid);
+        wpc->setImportedOriginal(true);
         if (!is_object)
             wpc->setColor(Color32(rand() % 255, rand() % 255, rand() % 255, 255));
     }

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -186,6 +186,7 @@ void ExportTagData(nlohmann::json& json, const TagData& data)
 void ExportScanData(nlohmann::json& json, const ScanData& data)
 {
 	json[Key_Clippable] = data.getClippable();
+	json[Key_IsImportedOriginal] = data.isImportedOriginal();
 	//json[Key_PointCloud_IsObject] = data.is_object_;
 }
 
@@ -231,6 +232,7 @@ void ExportMeshObjectData(nlohmann::json& json, const MeshObjectData& data)
 	json[Key_Path] = Utils::to_utf8(data.getFilePath().wstring());
 	json[Key_ObjectName] = Utils::to_utf8(data.getObjectName());
 	json[Key_MeshId] = data.getMeshId();
+	json[Key_IsImportedOriginal] = data.isImportedOriginal();
 }
 
 void ExportSimpleMeasureData(nlohmann::json& json, const SimpleMeasureData& data)

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <string>
+#include <cwctype>
 
 namespace
 {
@@ -58,6 +59,23 @@ uint32_t getPolygonSuffix(const std::string& name)
     bool ok = false;
     int suffix = QString::fromStdString(name.substr(8)).toInt(&ok);
     return (ok && suffix > 0) ? static_cast<uint32_t>(suffix) : 0;
+}
+
+bool hasCopyNumericSuffix(const std::wstring& name)
+{
+    const std::wstring copyToken = L"_copy";
+    const size_t suffixPos = name.rfind(copyToken);
+    if (suffixPos == std::wstring::npos)
+        return false;
+    if (suffixPos + copyToken.size() >= name.size())
+        return false;
+
+    for (size_t i = suffixPos + copyToken.size(); i < name.size(); ++i)
+    {
+        if (!iswdigit(name[i]))
+            return false;
+    }
+    return true;
 }
 }
 
@@ -369,6 +387,13 @@ bool ImportScanData(const nlohmann::json& json, ScanData& data)
         auto elemType = magic_enum::enum_cast<ElementType>(json.at(Key_Type).get<std::string>());
         data.setIsObject(elemType == ElementType::PCO);
     }
+
+    if (json.find(Key_IsImportedOriginal) != json.end())
+        data.setImportedOriginal(json.at(Key_IsImportedOriginal).get<bool>());
+    else if (json.find(Key_Name) != json.end())
+        data.setImportedOriginal(!hasCopyNumericSuffix(Utils::from_utf8(json.at(Key_Name).get<std::string>())));
+    else
+        data.setImportedOriginal(true);
 
     return retVal;
 }
@@ -1207,6 +1232,11 @@ bool ImportMeshObjectData(const nlohmann::json& json, MeshObjectData& data, cons
         IOLOG << "MeshObject Key_MeshId read error" << LOGENDL;
         retVal = false;
     }
+
+    if (json.find(Key_IsImportedOriginal) != json.end())
+        data.setImportedOriginal(json.at(Key_IsImportedOriginal).get<bool>());
+    else
+        data.setImportedOriginal(!hasCopyNumericSuffix(data.getObjectName()));
 
     return retVal;
 }

--- a/src/models/data/MeshObject/MeshObjectData.cpp
+++ b/src/models/data/MeshObject/MeshObjectData.cpp
@@ -18,6 +18,7 @@ void MeshObjectData::copyWavefrontData(const MeshObjectData& data)
 	m_objectName = data.getObjectName();
 	m_dimension = data.getDimension();
 	m_meshId = data.getMeshId();
+	m_isImportedOriginal = data.isImportedOriginal();
 }
 
 void MeshObjectData::setFilePath(const std::filesystem::path& filePath)
@@ -40,6 +41,11 @@ void MeshObjectData::setDimension(const glm::vec3& dimension)
 	m_dimension = dimension;
 }
 
+void MeshObjectData::setImportedOriginal(bool isImportedOriginal)
+{
+	m_isImportedOriginal = isImportedOriginal;
+}
+
 std::filesystem::path MeshObjectData::getFilePath() const
 {
 	return m_filePath;
@@ -58,4 +64,9 @@ MeshId MeshObjectData::getMeshId() const
 glm::vec3 MeshObjectData::getDimension() const
 {
 	return m_dimension;
+}
+
+bool MeshObjectData::isImportedOriginal() const
+{
+	return m_isImportedOriginal;
 }

--- a/src/models/data/Scan/ScanData.cpp
+++ b/src/models/data/Scan/ScanData.cpp
@@ -19,6 +19,7 @@ void ScanData::copyScanData(const ScanData& uiScanData)
     m_scanGuid = uiScanData.getScanGuid();
     m_clippable = uiScanData.m_clippable;
     is_object_ = uiScanData.is_object_;
+    m_isImportedOriginal = uiScanData.m_isImportedOriginal;
 }
 
 void ScanData::setClippable(bool clippable)
@@ -29,6 +30,16 @@ void ScanData::setClippable(bool clippable)
 bool ScanData::getClippable() const
 {
     return (m_clippable);
+}
+
+void ScanData::setImportedOriginal(bool isImportedOriginal)
+{
+    m_isImportedOriginal = isImportedOriginal;
+}
+
+bool ScanData::isImportedOriginal() const
+{
+    return m_isImportedOriginal;
 }
 
 void ScanData::setIsObject(bool is_object)

--- a/src/vulkan/MeshManager.cpp
+++ b/src/vulkan/MeshManager.cpp
@@ -1149,6 +1149,8 @@ bool MeshManager::removeMeshInstance(MeshId id)
         return false;
     if (m_meshesCounters.find(id) == m_meshesCounters.end())
     {
+        GRAPH_LOG << "removeMeshInstance called on unknown mesh id " << id << " (loaded="
+                  << (m_meshes.find(id) != m_meshes.end()) << ")" << Logger::endl;
         assert(false);
         return false;
     }


### PR DESCRIPTION
### Motivation
- Differentiate original imported scans/mesh objects from user-made copies to avoid accidental deletion and to manage resource lifecycle correctly.
- Ensure duplicated objects get unique names and do not claim original import ownership, and allow import/serialization to preserve or infer this state.

### Description
- Add a new serialization key `Key_IsImportedOriginal` and a boolean member `m_isImportedOriginal` to `ScanData` and `MeshObjectData` with `set`/`get` accessors and copy propagation in `copyWavefrontData`/`copyScanData`.
- Export and import the new flag in `DataSerializer::ExportScanData`/`ExportMeshObjectData` and `DataDeserializer::ImportScanData`/`ImportMeshObjectData`, where deserialization will infer original status from the name using `hasCopyNumericSuffix` if the flag is missing.
- Set `isImportedOriginal` to `true` when importing a new TLS file in `SaveLoadSystem::ImportNewTlsFile`, and set duplicated objects to `false` in `ContextMeshObjectDuplication` and `ContextPCODuplication` while assigning unique copy names via `getNextCopyName` helpers.
- Simplify deletion-classification in `ControlSpecial` to use `isImportedOriginal()` for deciding `importantDatas` vs `otherDatas`, add mesh instance reload logic in duplication using `MeshManager::addMeshInstance`, and add logging in `MeshManager::removeMeshInstance`.

### Testing
- Project compiled successfully (local/debug build) after the changes with no compilation errors.
- Ran the automated unit/integration test suite and regression tests relevant to import/export, duplication, and deletion workflows; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43cd0794c832fa25f2e2576563154)