### PR TITLE
Guard physical TLS deletion, ensure import path, add copy-name logic and mesh instance lifecycle fixes

### DIFF
--- a/src/controller/controls/ControlSpecial.cpp
+++ b/src/controller/controls/ControlSpecial.cpp
@@ -165,7 +165,38 @@ namespace control::special
 						continue;
 
 					CONTROLLOG << "The file " << scan->getTlsFilePath() << " -- {" << scan->getScanGuid() << "} will be definitly deleted." << LOGENDL;
-					scan->eraseScanFile();
+					const std::filesystem::path currentPath = scan->getTlsFilePath();
+					const ProjectInternalInfo& projectInfo = controller.getContext().cgetProjectInternalInfo();
+					const std::filesystem::path allowedRoot = projectInfo.getPointCloudFolderPath(type == ElementType::PCO);
+
+					bool canDeletePhysicalFile = false;
+					if (!currentPath.empty())
+					{
+						std::error_code ec;
+						const std::filesystem::path canonicalCurrent = std::filesystem::weakly_canonical(currentPath, ec);
+						if (!ec)
+						{
+							const std::filesystem::path canonicalAllowedRoot = std::filesystem::weakly_canonical(allowedRoot, ec);
+							if (!ec)
+							{
+								const std::wstring currentStr = canonicalCurrent.native();
+								const std::wstring allowedStr = canonicalAllowedRoot.native();
+								canDeletePhysicalFile = currentStr.rfind(allowedStr, 0) == 0;
+							}
+						}
+					}
+
+					if (canDeletePhysicalFile)
+					{
+						scan->eraseScanFile();
+					}
+					else
+					{
+						Logger::log(IOLog) << "WARNING - blocked physical deletion for scan {" << scan->getScanGuid()
+							<< "} because current path is outside project folder. current=" << currentPath
+							<< " expectedRoot=" << allowedRoot << Logger::endl;
+						scan->freeScanFile();
+					}
 					break;
 				}
 				case ElementType::MeshObject:

--- a/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
+++ b/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
@@ -9,6 +9,40 @@
 
 #include "models/graph/MeshObjectNode.h"
 #include "models/graph/GraphManager.h"
+#include <algorithm>
+#include <regex>
+
+namespace
+{
+std::wstring getMeshCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    std::wstring baseName = sourceName;
+    std::wsmatch match;
+    static const std::wregex copySuffix(LR"(^(.*)_copy([0-9]+)$)");
+    if (std::regex_match(sourceName, match, copySuffix) && match.size() > 1)
+        baseName = match[1].str();
+
+    int maxIndex = 0;
+    std::unordered_set<SafePtr<AGraphNode>> allMeshes = graphManager.getNodesByTypes({ ElementType::MeshObject }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& meshNode : allMeshes)
+    {
+        ReadPtr<MeshObjectNode> rMesh = static_pointer_cast<MeshObjectNode>(meshNode).cget();
+        if (!rMesh)
+            continue;
+        const std::wstring& existingName = rMesh->getName();
+        if (existingName == baseName)
+        {
+            maxIndex = std::max(maxIndex, 0);
+            continue;
+        }
+        if (std::regex_match(existingName, match, copySuffix) && match.size() > 2 && match[1].str() == baseName)
+        {
+            maxIndex = std::max(maxIndex, std::stoi(match[2].str()));
+        }
+    }
+    return baseName + L"_copy" + std::to_wstring(maxIndex + 1);
+}
+}
 
 ContextMeshObjectDuplication::ContextMeshObjectDuplication(const ContextId& id)
 	: ARayTracingContext(id)
@@ -86,9 +120,8 @@ ContextState ContextMeshObjectDuplication::launch(Controller& controller)
     wNewObj->setModificationTime(time(&timeNow));
     wNewObj->setAuthor(controller.getContext().getActiveAuthor());
     wNewObj->setUserIndex(controller.getNextUserId(wNewObj->getType()));
+    wNewObj->setName(getMeshCopyName(wNewObj->getName(), graphManager));
     setObjectParameters(controller, *&wNewObj, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale * glm::dvec3(dim));
-
-    MeshManager::getInstance().addMeshInstance(wNewObj->getMeshId());
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newObj));
 

--- a/src/controller/functionSystem/ContextPCODuplication.cpp
+++ b/src/controller/functionSystem/ContextPCODuplication.cpp
@@ -8,6 +8,40 @@
 #include "models/graph/PointCloudNode.h"
 #include "models/graph/GraphManager.h"
 #include "utils/Logger.h"
+#include <algorithm>
+#include <regex>
+
+namespace
+{
+std::wstring getPCOCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    std::wstring baseName = sourceName;
+    std::wsmatch match;
+    static const std::wregex copySuffix(LR"(^(.*)_copy([0-9]+)$)");
+    if (std::regex_match(sourceName, match, copySuffix) && match.size() > 1)
+        baseName = match[1].str();
+
+    int maxIndex = 0;
+    std::unordered_set<SafePtr<AGraphNode>> allPcos = graphManager.getNodesByTypes({ ElementType::PCO }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& pcoNode : allPcos)
+    {
+        ReadPtr<PointCloudNode> rPco = static_pointer_cast<PointCloudNode>(pcoNode).cget();
+        if (!rPco)
+            continue;
+        const std::wstring& existingName = rPco->getName();
+        if (existingName == baseName)
+        {
+            maxIndex = std::max(maxIndex, 0);
+            continue;
+        }
+        if (std::regex_match(existingName, match, copySuffix) && match.size() > 2 && match[1].str() == baseName)
+        {
+            maxIndex = std::max(maxIndex, std::stoi(match[2].str()));
+        }
+    }
+    return baseName + L"_copy" + std::to_wstring(maxIndex + 1);
+}
+}
 
 
 ContextPCODuplication::ContextPCODuplication(const ContextId& id)
@@ -87,6 +121,7 @@ ContextState ContextPCODuplication::launch(Controller& controller)
     wNewPco->setModificationTime(time(&timeNow));
     wNewPco->setAuthor(controller.getContext().getActiveAuthor());
     wNewPco->setUserIndex(controller.getNextUserId(wNewPco->getType()));
+    wNewPco->setName(getPCOCopyName(wNewPco->getName(), graphManager));
     setObjectParameters(controller, *&wNewPco, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale);
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newPco));

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -8,6 +8,7 @@
 #include "io/exports/DataSerializer.h"
 #include "io/imports/DataDeserializer.h"
 #include "pointCloudEngine/PCE_core.h"
+#include "pointCloudEngine/TlScanOverseer.h"
 
 #include "utils/Config.h"
 #include "utils/Logger.h"
@@ -61,6 +62,8 @@
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 #define SAVELOADSYSTEMVERSION 2.0f
 
@@ -1270,12 +1273,33 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
 
     std::filesystem::path filename(filePath.filename());
     std::filesystem::path dst_path = context.cgetProjectInternalInfo().getPointCloudFolderPath(is_object) / filename;
-    // Asynchronous copy
-    // The availability of the name in the filesystem is checked by the PCE
-    if (!std::filesystem::exists(dst_path))
-        tlCopyScanFile(scanGuid, dst_path, true, false, false);
-    else
-        IOLOG << "INFO: " << filePath << " already exist." << LOGENDL;
+    // Copy to project folder and force destination update to avoid keeping a source path
+    // when a file with the same name already exists in destination.
+    tlCopyScanFile(scanGuid, dst_path, true, true, false);
+
+    // Ensure copy queue is processed and the active scan path points to project storage
+    // before exposing the node to delete workflows.
+    std::filesystem::path currentPath;
+    bool copiedToProjectPath = false;
+    constexpr int maxRetry = 100; // 100 * 50ms = 5s max wait
+    for (int i = 0; i < maxRetry; ++i)
+    {
+        TlScanOverseer::getInstance().resourceManagement_sync();
+        if (tlGetCurrentScanPath(scanGuid, currentPath) && currentPath == dst_path)
+        {
+            copiedToProjectPath = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    if (!copiedToProjectPath)
+    {
+        IOLOG << "Error: TLS import copy to project path failed or timed out. Source [" << filePath
+            << "], destination [" << dst_path << "], current [" << currentPath << "]." << LOGENDL;
+        errorCode = ErrorCode::Failed_Write_Permission;
+        return SafePtr<PointCloudNode>();
+    }
 
     uint64_t nbScanBeforeImport = controller.getGraphManager().getNodesByTypes({ ElementType::Scan }).size();
     SafePtr<PointCloudNode> pc = make_safe<PointCloudNode>(is_object);

--- a/src/models/graph/MeshObjectNode.cpp
+++ b/src/models/graph/MeshObjectNode.cpp
@@ -7,7 +7,8 @@ MeshObjectNode::MeshObjectNode(const MeshObjectNode& node)
     : AGraphNode(node)
     , MeshObjectData(node)
 {
-
+    if (m_meshId.isValid())
+        addMeshInstance();
 }
 
 MeshObjectNode::MeshObjectNode()

--- a/src/vulkan/MeshManager.cpp
+++ b/src/vulkan/MeshManager.cpp
@@ -1149,7 +1149,7 @@ bool MeshManager::removeMeshInstance(MeshId id)
         return false;
     if (m_meshesCounters.find(id) == m_meshesCounters.end())
     {
-        assert(false);
+        GRAPH_LOG << "Warning: removeMeshInstance called on unknown MeshId {" << id << "}." << Logger::endl;
         return false;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental removal of scan files outside the project storage and ensure imported TLS files are fully resident in project storage before exposing nodes. 
- Produce deterministic unique names for duplicated mesh and PCO objects to avoid name collisions. 
- Fix mesh instance lifecycle accounting to avoid unexpected asserts and double/add mismatches. 

### Description
- When deleting point-cloud/PCO files in `DeleteTotalData::doFunction` the physical deletion is now only allowed when the scan's canonical path is inside the project's point-cloud folder; otherwise the code logs a warning and calls `freeScanFile()` instead of `eraseScanFile()`. 
- TLS import in `SaveLoadSystem::ImportNewTlsFile` now forces destination copy (`tlCopyScanFile` with overwrite) and synchronously waits (with `TlScanOverseer::resourceManagement_sync` and `tlGetCurrentScanPath`) up to 5s for the active scan path to point to the project destination before continuing, failing the import on timeout. 
- Added unique copy-name helpers `getMeshCopyName` and `getPCOCopyName` (regex-based `_copyN` suffix) and apply them when creating duplicated nodes in `ContextMeshObjectDuplication` and `ContextPCODuplication`. 
- Adjusted mesh instance lifecycle: the `MeshObjectNode` copy constructor now calls `addMeshInstance()` when `m_meshId` is valid, and `ContextMeshObjectDuplication` no longer calls `MeshManager::addMeshInstance` redundantly. 
- `MeshManager::removeMeshInstance` no longer triggers `assert(false)` on unknown ids and now logs a warning instead. 

### Testing
- Project build completed successfully after the changes. 
- Unit test suite was executed and passed. 
- Core TLS import workflow (copy + path synchronization) was run as an automated integration check and succeeded within the timeout conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46b301d20832f81eea9b208a63f2a)