### PR TITLE
Prevent unsafe TLS file deletion; sync imports; unique copy names; refine PCO counting

### DIFF
--- a/include/models/graph/GraphManager.h
+++ b/include/models/graph/GraphManager.h
@@ -90,6 +90,7 @@ public:
 	uint32_t getActiveClippingAndRampCount() const;
 
 	uint32_t getPCOcounters(const tls::ScanGuid& scan) const;
+	uint32_t getPCOcounters(const tls::ScanGuid& scan, bool includeDeadNodes) const;
 	bool isFilePathOrScanExists(const std::wstring& name, const std::filesystem::path& filePath) const;
 
 	void replaceObjectsSelected(std::unordered_set<SafePtr<AGraphNode>> toSelectDatas);

--- a/src/controller/controls/ControlSpecial.cpp
+++ b/src/controller/controls/ControlSpecial.cpp
@@ -66,7 +66,7 @@ namespace control::special
 					scanGuid = rScan->getScanGuid();
 				}
 
-				if (controller.getGraphManager().getPCOcounters(scanGuid) == 0)
+					if (controller.getGraphManager().getPCOcounters(scanGuid, false) == 0)
 				{
 					WritePtr<PointCloudNode> wScan = scan.get();
 					if (!wScan)
@@ -165,7 +165,38 @@ namespace control::special
 						continue;
 
 					CONTROLLOG << "The file " << scan->getTlsFilePath() << " -- {" << scan->getScanGuid() << "} will be definitly deleted." << LOGENDL;
-					scan->eraseScanFile();
+					const std::filesystem::path currentPath = scan->getTlsFilePath();
+					const ProjectInternalInfo& projectInfo = controller.getContext().cgetProjectInternalInfo();
+					const std::filesystem::path allowedRoot = projectInfo.getPointCloudFolderPath(type == ElementType::PCO);
+
+					bool canDeletePhysicalFile = false;
+					if (!currentPath.empty())
+					{
+						std::error_code ec;
+						const std::filesystem::path canonicalCurrent = std::filesystem::weakly_canonical(currentPath, ec);
+						if (!ec)
+						{
+							const std::filesystem::path canonicalAllowedRoot = std::filesystem::weakly_canonical(allowedRoot, ec);
+							if (!ec)
+							{
+								const std::wstring currentStr = canonicalCurrent.native();
+								const std::wstring allowedStr = canonicalAllowedRoot.native();
+								canDeletePhysicalFile = currentStr.rfind(allowedStr, 0) == 0;
+							}
+						}
+					}
+
+					if (canDeletePhysicalFile)
+					{
+						scan->eraseScanFile();
+					}
+					else
+					{
+						Logger::log(IOLog) << "WARNING - blocked physical deletion for scan {" << scan->getScanGuid()
+							<< "} because current path is outside project folder. current=" << currentPath
+							<< " expectedRoot=" << allowedRoot << Logger::endl;
+						scan->freeScanFile();
+					}
 					break;
 				}
 				case ElementType::MeshObject:
@@ -365,7 +396,7 @@ namespace control::special
 
 		for (auto scanObjElement : scanObjPathToTls)
 		{
-			if (scanObjElement.first.isValid() && graphManager.getPCOcounters(scanObjElement.first) <= scanObjElement.second.size())
+			if (scanObjElement.first.isValid() && graphManager.getPCOcounters(scanObjElement.first, false) <= scanObjElement.second.size())
 				importantDatas.insert(scanObjElement.second.begin(), scanObjElement.second.end());
 			else
 				otherDatas.insert(scanObjElement.second.begin(), scanObjElement.second.end());

--- a/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
+++ b/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
@@ -9,6 +9,40 @@
 
 #include "models/graph/MeshObjectNode.h"
 #include "models/graph/GraphManager.h"
+#include <algorithm>
+#include <regex>
+
+namespace
+{
+std::wstring getMeshCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    std::wstring baseName = sourceName;
+    std::wsmatch match;
+    static const std::wregex copySuffix(LR"(^(.*)_copy([0-9]+)$)");
+    if (std::regex_match(sourceName, match, copySuffix) && match.size() > 1)
+        baseName = match[1].str();
+
+    int maxIndex = 0;
+    std::unordered_set<SafePtr<AGraphNode>> allMeshes = graphManager.getNodesByTypes({ ElementType::MeshObject }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& meshNode : allMeshes)
+    {
+        ReadPtr<MeshObjectNode> rMesh = static_pointer_cast<MeshObjectNode>(meshNode).cget();
+        if (!rMesh)
+            continue;
+        const std::wstring& existingName = rMesh->getName();
+        if (existingName == baseName)
+        {
+            maxIndex = std::max(maxIndex, 0);
+            continue;
+        }
+        if (std::regex_match(existingName, match, copySuffix) && match.size() > 2 && match[1].str() == baseName)
+        {
+            maxIndex = std::max(maxIndex, std::stoi(match[2].str()));
+        }
+    }
+    return baseName + L"_copy" + std::to_wstring(maxIndex + 1);
+}
+}
 
 ContextMeshObjectDuplication::ContextMeshObjectDuplication(const ContextId& id)
 	: ARayTracingContext(id)
@@ -86,9 +120,8 @@ ContextState ContextMeshObjectDuplication::launch(Controller& controller)
     wNewObj->setModificationTime(time(&timeNow));
     wNewObj->setAuthor(controller.getContext().getActiveAuthor());
     wNewObj->setUserIndex(controller.getNextUserId(wNewObj->getType()));
+    wNewObj->setName(getMeshCopyName(wNewObj->getName(), graphManager));
     setObjectParameters(controller, *&wNewObj, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale * glm::dvec3(dim));
-
-    MeshManager::getInstance().addMeshInstance(wNewObj->getMeshId());
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newObj));
 

--- a/src/controller/functionSystem/ContextPCODuplication.cpp
+++ b/src/controller/functionSystem/ContextPCODuplication.cpp
@@ -8,6 +8,40 @@
 #include "models/graph/PointCloudNode.h"
 #include "models/graph/GraphManager.h"
 #include "utils/Logger.h"
+#include <algorithm>
+#include <regex>
+
+namespace
+{
+std::wstring getPCOCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    std::wstring baseName = sourceName;
+    std::wsmatch match;
+    static const std::wregex copySuffix(LR"(^(.*)_copy([0-9]+)$)");
+    if (std::regex_match(sourceName, match, copySuffix) && match.size() > 1)
+        baseName = match[1].str();
+
+    int maxIndex = 0;
+    std::unordered_set<SafePtr<AGraphNode>> allPcos = graphManager.getNodesByTypes({ ElementType::PCO }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& pcoNode : allPcos)
+    {
+        ReadPtr<PointCloudNode> rPco = static_pointer_cast<PointCloudNode>(pcoNode).cget();
+        if (!rPco)
+            continue;
+        const std::wstring& existingName = rPco->getName();
+        if (existingName == baseName)
+        {
+            maxIndex = std::max(maxIndex, 0);
+            continue;
+        }
+        if (std::regex_match(existingName, match, copySuffix) && match.size() > 2 && match[1].str() == baseName)
+        {
+            maxIndex = std::max(maxIndex, std::stoi(match[2].str()));
+        }
+    }
+    return baseName + L"_copy" + std::to_wstring(maxIndex + 1);
+}
+}
 
 
 ContextPCODuplication::ContextPCODuplication(const ContextId& id)
@@ -87,6 +121,7 @@ ContextState ContextPCODuplication::launch(Controller& controller)
     wNewPco->setModificationTime(time(&timeNow));
     wNewPco->setAuthor(controller.getContext().getActiveAuthor());
     wNewPco->setUserIndex(controller.getNextUserId(wNewPco->getType()));
+    wNewPco->setName(getPCOCopyName(wNewPco->getName(), graphManager));
     setObjectParameters(controller, *&wNewPco, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale);
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newPco));

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -8,6 +8,7 @@
 #include "io/exports/DataSerializer.h"
 #include "io/imports/DataDeserializer.h"
 #include "pointCloudEngine/PCE_core.h"
+#include "pointCloudEngine/TlScanOverseer.h"
 
 #include "utils/Config.h"
 #include "utils/Logger.h"
@@ -61,6 +62,8 @@
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 #define SAVELOADSYSTEMVERSION 2.0f
 
@@ -1270,12 +1273,33 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
 
     std::filesystem::path filename(filePath.filename());
     std::filesystem::path dst_path = context.cgetProjectInternalInfo().getPointCloudFolderPath(is_object) / filename;
-    // Asynchronous copy
-    // The availability of the name in the filesystem is checked by the PCE
-    if (!std::filesystem::exists(dst_path))
-        tlCopyScanFile(scanGuid, dst_path, true, false, false);
-    else
-        IOLOG << "INFO: " << filePath << " already exist." << LOGENDL;
+    // Copy to project folder and force destination update to avoid keeping a source path
+    // when a file with the same name already exists in destination.
+    tlCopyScanFile(scanGuid, dst_path, true, true, false);
+
+    // Ensure copy queue is processed and the active scan path points to project storage
+    // before exposing the node to delete workflows.
+    std::filesystem::path currentPath;
+    bool copiedToProjectPath = false;
+    constexpr int maxRetry = 100; // 100 * 50ms = 5s max wait
+    for (int i = 0; i < maxRetry; ++i)
+    {
+        TlScanOverseer::getInstance().resourceManagement_sync();
+        if (tlGetCurrentScanPath(scanGuid, currentPath) && currentPath == dst_path)
+        {
+            copiedToProjectPath = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    if (!copiedToProjectPath)
+    {
+        IOLOG << "Error: TLS import copy to project path failed or timed out. Source [" << filePath
+            << "], destination [" << dst_path << "], current [" << currentPath << "]." << LOGENDL;
+        errorCode = ErrorCode::Failed_Write_Permission;
+        return SafePtr<PointCloudNode>();
+    }
 
     uint64_t nbScanBeforeImport = controller.getGraphManager().getNodesByTypes({ ElementType::Scan }).size();
     SafePtr<PointCloudNode> pc = make_safe<PointCloudNode>(is_object);

--- a/src/models/graph/GraphManager.cpp
+++ b/src/models/graph/GraphManager.cpp
@@ -595,12 +595,21 @@ uint32_t GraphManager::getActiveClippingAndRampCount() const
 
 uint32_t GraphManager::getPCOcounters(const tls::ScanGuid& scan) const
 {
+    return getPCOcounters(scan, true);
+}
+
+uint32_t GraphManager::getPCOcounters(const tls::ScanGuid& scan, bool includeDeadNodes) const
+{
     return (uint32_t)getNodesOnFilter<PointCloudNode>(
-            [](ReadPtr<AGraphNode>& node)
-            { return node->getType() == ElementType::PCO || node->getType() == ElementType::Scan; },
-            [&scan](ReadPtr<PointCloudNode>& node)
-            { return node->getScanGuid() == scan; }
-        ).size();
+        [](ReadPtr<AGraphNode>& node)
+        { return node->getType() == ElementType::PCO || node->getType() == ElementType::Scan; },
+        [&scan, includeDeadNodes](ReadPtr<PointCloudNode>& node)
+        {
+            if (!includeDeadNodes && node->isDead())
+                return false;
+            return node->getScanGuid() == scan;
+        }
+    ).size();
 }
 
 std::unordered_set<SafePtr<TagNode>> GraphManager::getTagsWithTemplate(SafePtr<sma::TagTemplate> tagTemplate) const

--- a/src/models/graph/MeshObjectNode.cpp
+++ b/src/models/graph/MeshObjectNode.cpp
@@ -7,7 +7,8 @@ MeshObjectNode::MeshObjectNode(const MeshObjectNode& node)
     : AGraphNode(node)
     , MeshObjectData(node)
 {
-
+    if (m_meshId.isValid())
+        addMeshInstance();
 }
 
 MeshObjectNode::MeshObjectNode()

--- a/src/vulkan/MeshManager.cpp
+++ b/src/vulkan/MeshManager.cpp
@@ -1149,7 +1149,7 @@ bool MeshManager::removeMeshInstance(MeshId id)
         return false;
     if (m_meshesCounters.find(id) == m_meshesCounters.end())
     {
-        assert(false);
+        GRAPH_LOG << "Warning: removeMeshInstance called on unknown MeshId {" << id << "}." << Logger::endl;
         return false;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental physical deletion of TLS/PCO files that are located outside the project storage when removing data.
- Ensure imported TLS files are actually copied into the project storage before exposing them to deletion workflows.
- Avoid name collisions for duplicated mesh and PCO objects by producing deterministic `_copyN` names.
- Make PCO counter queries flexible with respect to dead/soft-deleted nodes and make mesh manager removal more robust.

### Description
- Added an overload `GraphManager::getPCOcounters(const tls::ScanGuid&, bool includeDeadNodes)` and kept the original behavior via a forwarding method to preserve callers.
- Updated deletion flows in `ControlSpecial.cpp` to query PCO counters excluding dead nodes (`includeDeadNodes = false`) and changed `DeleteTotalData` to only call `eraseScanFile()` when the scan's canonical path is inside the project's allowed point cloud folder, otherwise `freeScanFile()` is used and a warning is logged.
- Changed TLS import behavior in `SaveLoadSystem::ImportNewTlsFile` to always request copy into project storage (overwrite enabled) and wait (with retries) for `TlScanOverseer::resourceManagement_sync()` and `tlGetCurrentScanPath()` to confirm the active path points to the project destination; failures abort the import with `Failed_Write_Permission`.
- Implemented unique copy name generators for mesh and PCO duplication (`getMeshCopyName` and `getPCOCopyName`) using a regex to detect existing `_copyN` suffixes and select the next index, and applied these names in `ContextMeshObjectDuplication` and `ContextPCODuplication`.
- Restored mesh instance accounting in `MeshObjectNode` copy constructor by calling `addMeshInstance()` when appropriate, and softened `MeshManager::removeMeshInstance()` from `assert(false)` to logging a warning and returning `false` when an unknown `MeshId` is removed.
- Minor includes and formatting fixes: added headers (`TlScanOverseer`, `<chrono>`, `<thread>`, `<regex>`, `<algorithm>`), and small EOF cleanup.

### Testing
- Built the project (`build`) successfully after changes with no compile errors.
- Ran the unit and integration test suites covering import/duplication/deletion flows (`ctest`), and all automated tests passed.
- Exercised TLS import + delete scenarios in automated integration checks to validate copy synchronization and guarded physical deletion, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46b301d20832f81eea9b208a63f2a)