### PR TITLE
Safe file deletion, unique duplication names, scan import sync, and mesh cache invalidation

### DIFF
--- a/include/models/graph/GraphManager.h
+++ b/include/models/graph/GraphManager.h
@@ -90,6 +90,7 @@ public:
 	uint32_t getActiveClippingAndRampCount() const;
 
 	uint32_t getPCOcounters(const tls::ScanGuid& scan) const;
+	uint32_t getPCOcounters(const tls::ScanGuid& scan, bool includeDeadNodes) const;
 	bool isFilePathOrScanExists(const std::wstring& name, const std::filesystem::path& filePath) const;
 
 	void replaceObjectsSelected(std::unordered_set<SafePtr<AGraphNode>> toSelectDatas);

--- a/include/vulkan/MeshManager.h
+++ b/include/vulkan/MeshManager.h
@@ -131,10 +131,11 @@ public:
 
 	static std::shared_ptr<MeshBuffer> getGenericMesh(GenericMeshId meshId);
 	SMesh const getMesh(const MeshId& id);
-	std::shared_ptr<MeshBuffer> getManipMesh(ManipulationMode manipMod);
-	bool isMeshLoaded(const MeshId& id);
-	bool addMeshInstance(const MeshId& id);
-	uint64_t getMeshCounters(const MeshId& id);
+		std::shared_ptr<MeshBuffer> getManipMesh(ManipulationMode manipMod);
+		bool isMeshLoaded(const MeshId& id);
+		bool addMeshInstance(const MeshId& id);
+		uint64_t getMeshCounters(const MeshId& id);
+		void invalidateLoadedCacheForPath(const std::filesystem::path& meshPath);
 
 	glm::vec3 getMeshDimension(const MeshId& id);
 

--- a/src/controller/controls/ControlSpecial.cpp
+++ b/src/controller/controls/ControlSpecial.cpp
@@ -66,7 +66,7 @@ namespace control::special
 					scanGuid = rScan->getScanGuid();
 				}
 
-				if (controller.getGraphManager().getPCOcounters(scanGuid) == 0)
+					if (controller.getGraphManager().getPCOcounters(scanGuid, false) == 0)
 				{
 					WritePtr<PointCloudNode> wScan = scan.get();
 					if (!wScan)
@@ -165,7 +165,38 @@ namespace control::special
 						continue;
 
 					CONTROLLOG << "The file " << scan->getTlsFilePath() << " -- {" << scan->getScanGuid() << "} will be definitly deleted." << LOGENDL;
-					scan->eraseScanFile();
+					const std::filesystem::path currentPath = scan->getTlsFilePath();
+					const ProjectInternalInfo& projectInfo = controller.getContext().cgetProjectInternalInfo();
+					const std::filesystem::path allowedRoot = projectInfo.getPointCloudFolderPath(type == ElementType::PCO);
+
+					bool canDeletePhysicalFile = false;
+					if (!currentPath.empty())
+					{
+						std::error_code ec;
+						const std::filesystem::path canonicalCurrent = std::filesystem::weakly_canonical(currentPath, ec);
+						if (!ec)
+						{
+							const std::filesystem::path canonicalAllowedRoot = std::filesystem::weakly_canonical(allowedRoot, ec);
+							if (!ec)
+							{
+								const std::wstring currentStr = canonicalCurrent.native();
+								const std::wstring allowedStr = canonicalAllowedRoot.native();
+								canDeletePhysicalFile = currentStr.rfind(allowedStr, 0) == 0;
+							}
+						}
+					}
+
+					if (canDeletePhysicalFile)
+					{
+						scan->eraseScanFile();
+					}
+					else
+					{
+						Logger::log(IOLog) << "WARNING - blocked physical deletion for scan {" << scan->getScanGuid()
+							<< "} because current path is outside project folder. current=" << currentPath
+							<< " expectedRoot=" << allowedRoot << Logger::endl;
+						scan->freeScanFile();
+					}
 					break;
 				}
 				case ElementType::MeshObject:
@@ -176,6 +207,7 @@ namespace control::special
 
 					CONTROLLOG << "The file " << meshObj->getFilePath() << " -- {" << meshObj->getMeshId() << "} will be definitly deleted." << LOGENDL;
 					std::filesystem::path filePath = controller.getContext().cgetProjectInternalInfo().getObjectsFilesFolderPath() / meshObj->getFilePath().filename();
+					MeshManager::getInstance().invalidateLoadedCacheForPath(filePath);
 
 					if (!std::filesystem::exists(filePath) || std::filesystem::is_directory(filePath))
 						break;
@@ -365,7 +397,7 @@ namespace control::special
 
 		for (auto scanObjElement : scanObjPathToTls)
 		{
-			if (scanObjElement.first.isValid() && graphManager.getPCOcounters(scanObjElement.first) <= scanObjElement.second.size())
+			if (scanObjElement.first.isValid() && graphManager.getPCOcounters(scanObjElement.first, false) <= scanObjElement.second.size())
 				importantDatas.insert(scanObjElement.second.begin(), scanObjElement.second.end());
 			else
 				otherDatas.insert(scanObjElement.second.begin(), scanObjElement.second.end());
@@ -406,10 +438,9 @@ namespace control::special
 					}
 				}
 
-				if (!filePath.empty() && std::filesystem::exists(filePath))
+				if (!filePath.empty())
 					importantObject[importantData] = { QString::fromStdWString(name), QString::fromStdWString(filePath.wstring()) };
-
-				if (!std::filesystem::exists(filePath))
+				else
 					otherDatas.insert(importantData);
 			}
 			controller.updateInfo(new GuiDataDeleteFileDependantObjectDialog(importantObject, otherDatas));

--- a/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
+++ b/src/controller/functionSystem/ContextMeshObjectDuplication.cpp
@@ -9,6 +9,40 @@
 
 #include "models/graph/MeshObjectNode.h"
 #include "models/graph/GraphManager.h"
+#include <algorithm>
+#include <regex>
+
+namespace
+{
+std::wstring getMeshCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    std::wstring baseName = sourceName;
+    std::wsmatch match;
+    static const std::wregex copySuffix(LR"(^(.*)_copy([0-9]+)$)");
+    if (std::regex_match(sourceName, match, copySuffix) && match.size() > 1)
+        baseName = match[1].str();
+
+    int maxIndex = 0;
+    std::unordered_set<SafePtr<AGraphNode>> allMeshes = graphManager.getNodesByTypes({ ElementType::MeshObject }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& meshNode : allMeshes)
+    {
+        ReadPtr<MeshObjectNode> rMesh = static_pointer_cast<MeshObjectNode>(meshNode).cget();
+        if (!rMesh)
+            continue;
+        const std::wstring& existingName = rMesh->getName();
+        if (existingName == baseName)
+        {
+            maxIndex = std::max(maxIndex, 0);
+            continue;
+        }
+        if (std::regex_match(existingName, match, copySuffix) && match.size() > 2 && match[1].str() == baseName)
+        {
+            maxIndex = std::max(maxIndex, std::stoi(match[2].str()));
+        }
+    }
+    return baseName + L"_copy" + std::to_wstring(maxIndex + 1);
+}
+}
 
 ContextMeshObjectDuplication::ContextMeshObjectDuplication(const ContextId& id)
 	: ARayTracingContext(id)
@@ -86,9 +120,8 @@ ContextState ContextMeshObjectDuplication::launch(Controller& controller)
     wNewObj->setModificationTime(time(&timeNow));
     wNewObj->setAuthor(controller.getContext().getActiveAuthor());
     wNewObj->setUserIndex(controller.getNextUserId(wNewObj->getType()));
+    wNewObj->setName(getMeshCopyName(wNewObj->getName(), graphManager));
     setObjectParameters(controller, *&wNewObj, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale * glm::dvec3(dim));
-
-    MeshManager::getInstance().addMeshInstance(wNewObj->getMeshId());
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newObj));
 

--- a/src/controller/functionSystem/ContextPCODuplication.cpp
+++ b/src/controller/functionSystem/ContextPCODuplication.cpp
@@ -8,6 +8,40 @@
 #include "models/graph/PointCloudNode.h"
 #include "models/graph/GraphManager.h"
 #include "utils/Logger.h"
+#include <algorithm>
+#include <regex>
+
+namespace
+{
+std::wstring getPCOCopyName(const std::wstring& sourceName, const GraphManager& graphManager)
+{
+    std::wstring baseName = sourceName;
+    std::wsmatch match;
+    static const std::wregex copySuffix(LR"(^(.*)_copy([0-9]+)$)");
+    if (std::regex_match(sourceName, match, copySuffix) && match.size() > 1)
+        baseName = match[1].str();
+
+    int maxIndex = 0;
+    std::unordered_set<SafePtr<AGraphNode>> allPcos = graphManager.getNodesByTypes({ ElementType::PCO }, ObjectStatusFilter::ALL);
+    for (const SafePtr<AGraphNode>& pcoNode : allPcos)
+    {
+        ReadPtr<PointCloudNode> rPco = static_pointer_cast<PointCloudNode>(pcoNode).cget();
+        if (!rPco)
+            continue;
+        const std::wstring& existingName = rPco->getName();
+        if (existingName == baseName)
+        {
+            maxIndex = std::max(maxIndex, 0);
+            continue;
+        }
+        if (std::regex_match(existingName, match, copySuffix) && match.size() > 2 && match[1].str() == baseName)
+        {
+            maxIndex = std::max(maxIndex, std::stoi(match[2].str()));
+        }
+    }
+    return baseName + L"_copy" + std::to_wstring(maxIndex + 1);
+}
+}
 
 
 ContextPCODuplication::ContextPCODuplication(const ContextId& id)
@@ -87,6 +121,7 @@ ContextState ContextPCODuplication::launch(Controller& controller)
     wNewPco->setModificationTime(time(&timeNow));
     wNewPco->setAuthor(controller.getContext().getActiveAuthor());
     wNewPco->setUserIndex(controller.getNextUserId(wNewPco->getType()));
+    wNewPco->setName(getPCOCopyName(wNewPco->getName(), graphManager));
     setObjectParameters(controller, *&wNewPco, m_clickResults.empty() ? glm::dvec3() : m_clickResults[0].position, scale);
 
     controller.getControlListener()->notifyUIControl(new control::function::AddNodes(newPco));

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -8,6 +8,7 @@
 #include "io/exports/DataSerializer.h"
 #include "io/imports/DataDeserializer.h"
 #include "pointCloudEngine/PCE_core.h"
+#include "pointCloudEngine/TlScanOverseer.h"
 
 #include "utils/Config.h"
 #include "utils/Logger.h"
@@ -61,6 +62,8 @@
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 #define SAVELOADSYSTEMVERSION 2.0f
 
@@ -1270,12 +1273,33 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
 
     std::filesystem::path filename(filePath.filename());
     std::filesystem::path dst_path = context.cgetProjectInternalInfo().getPointCloudFolderPath(is_object) / filename;
-    // Asynchronous copy
-    // The availability of the name in the filesystem is checked by the PCE
-    if (!std::filesystem::exists(dst_path))
-        tlCopyScanFile(scanGuid, dst_path, true, false, false);
-    else
-        IOLOG << "INFO: " << filePath << " already exist." << LOGENDL;
+    // Copy to project folder and force destination update to avoid keeping a source path
+    // when a file with the same name already exists in destination.
+    tlCopyScanFile(scanGuid, dst_path, true, true, false);
+
+    // Ensure copy queue is processed and the active scan path points to project storage
+    // before exposing the node to delete workflows.
+    std::filesystem::path currentPath;
+    bool copiedToProjectPath = false;
+    constexpr int maxRetry = 100; // 100 * 50ms = 5s max wait
+    for (int i = 0; i < maxRetry; ++i)
+    {
+        TlScanOverseer::getInstance().resourceManagement_sync();
+        if (tlGetCurrentScanPath(scanGuid, currentPath) && currentPath == dst_path)
+        {
+            copiedToProjectPath = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    if (!copiedToProjectPath)
+    {
+        IOLOG << "Error: TLS import copy to project path failed or timed out. Source [" << filePath
+            << "], destination [" << dst_path << "], current [" << currentPath << "]." << LOGENDL;
+        errorCode = ErrorCode::Failed_Write_Permission;
+        return SafePtr<PointCloudNode>();
+    }
 
     uint64_t nbScanBeforeImport = controller.getGraphManager().getNodesByTypes({ ElementType::Scan }).size();
     SafePtr<PointCloudNode> pc = make_safe<PointCloudNode>(is_object);

--- a/src/models/data/Scan/ScanData.cpp
+++ b/src/models/data/Scan/ScanData.cpp
@@ -1,6 +1,25 @@
 #include "models/data/Scan/ScanData.h"
 #include "utils/time.h"
 #include "pointCloudEngine/PCE_core.h"
+#include <ctime>
+
+namespace
+{
+bool getScanHeaderSafe(const tls::ScanGuid& scanGuid, tls::ScanHeader& header)
+{
+    header = tls::ScanHeader{};
+    return tlGetScanHeader(scanGuid, header);
+}
+
+bool toLocalTimeSafe(time_t t, std::tm& outTm)
+{
+#ifdef _WIN32
+    return localtime_s(&outTm, &t) == 0;
+#else
+    return localtime_r(&t, &outTm) != nullptr;
+#endif
+}
+}
 
 
 ScanData::ScanData()
@@ -68,7 +87,8 @@ bool ScanData::getTlsPresent() const
 tls::PointFormat ScanData::getPointFormat() const
 {
     tls::ScanHeader header;
-    tlGetScanHeader(m_scanGuid, header);
+    if (!getScanHeaderSafe(m_scanGuid, header))
+        return tls::PointFormat::TL_POINT_FORMAT_UNDEFINED;
     return header.format;
 }
 
@@ -89,41 +109,50 @@ bool ScanData::getIntensityAvailable() const
 uint64_t ScanData::getNbPoint() const
 {
     tls::ScanHeader header;
-    tlGetScanHeader(m_scanGuid, header);
+    if (!getScanHeaderSafe(m_scanGuid, header))
+        return 0;
     return header.pointCount;
 }
 
 std::wstring ScanData::getSensorModel() const
 {
     tls::ScanHeader header;
-    tlGetScanHeader(m_scanGuid, header);
+    if (!getScanHeaderSafe(m_scanGuid, header))
+        return L"";
     return header.sensorModel;
 }
 
 std::wstring ScanData::getSensorSerialNumber() const
 {
     tls::ScanHeader header;
-    tlGetScanHeader(m_scanGuid, header);
+    if (!getScanHeaderSafe(m_scanGuid, header))
+        return L"";
     return header.sensorSerialNumber;
 }
 
 time_t ScanData::getAcquisitionTime() const
 {
     tls::ScanHeader header;
-    tlGetScanHeader(m_scanGuid, header);
+    if (!getScanHeaderSafe(m_scanGuid, header))
+        return 0;
     return header.acquisitionDate;
 }
 
 const std::wstring ScanData::getStringAcquisitionTime() const
 {
     time_t t = getAcquisitionTime();
-    if (t == 0)
+    if (t <= 0)
         return L"Not available";
     else
     {
         wchar_t strDate[128];
-        std::wcsftime(strDate, sizeof(strDate), DISPLAY_WIDE_TIME_FORMAT, std::localtime(&t));
-        return (std::wstring(strDate));
+        std::tm localTm{};
+        if (!toLocalTimeSafe(t, localTm))
+            return L"Not available";
+
+        if (std::wcsftime(strDate, sizeof(strDate) / sizeof(wchar_t), DISPLAY_WIDE_TIME_FORMAT, &localTm) == 0)
+            return L"Not available";
+        return std::wstring(strDate);
     }
 }
 

--- a/src/models/graph/GraphManager.cpp
+++ b/src/models/graph/GraphManager.cpp
@@ -595,12 +595,21 @@ uint32_t GraphManager::getActiveClippingAndRampCount() const
 
 uint32_t GraphManager::getPCOcounters(const tls::ScanGuid& scan) const
 {
+    return getPCOcounters(scan, true);
+}
+
+uint32_t GraphManager::getPCOcounters(const tls::ScanGuid& scan, bool includeDeadNodes) const
+{
     return (uint32_t)getNodesOnFilter<PointCloudNode>(
-            [](ReadPtr<AGraphNode>& node)
-            { return node->getType() == ElementType::PCO || node->getType() == ElementType::Scan; },
-            [&scan](ReadPtr<PointCloudNode>& node)
-            { return node->getScanGuid() == scan; }
-        ).size();
+        [](ReadPtr<AGraphNode>& node)
+        { return node->getType() == ElementType::PCO || node->getType() == ElementType::Scan; },
+        [&scan, includeDeadNodes](ReadPtr<PointCloudNode>& node)
+        {
+            if (!includeDeadNodes && node->isDead())
+                return false;
+            return node->getScanGuid() == scan;
+        }
+    ).size();
 }
 
 std::unordered_set<SafePtr<TagNode>> GraphManager::getTagsWithTemplate(SafePtr<sma::TagTemplate> tagTemplate) const

--- a/src/models/graph/MeshObjectNode.cpp
+++ b/src/models/graph/MeshObjectNode.cpp
@@ -7,7 +7,8 @@ MeshObjectNode::MeshObjectNode(const MeshObjectNode& node)
     : AGraphNode(node)
     , MeshObjectData(node)
 {
-
+    if (m_meshId.isValid())
+        addMeshInstance();
 }
 
 MeshObjectNode::MeshObjectNode()

--- a/src/vulkan/MeshManager.cpp
+++ b/src/vulkan/MeshManager.cpp
@@ -522,6 +522,34 @@ uint64_t MeshManager::getMeshCounters(const MeshId& id)
     return m_meshesCounters[id];
 }
 
+void MeshManager::invalidateLoadedCacheForPath(const std::filesystem::path& meshPath)
+{
+    if (meshPath.empty())
+        return;
+
+    const std::filesystem::path targetFilename = meshPath.filename();
+    for (auto it = m_loaded.begin(); it != m_loaded.end(); )
+    {
+        bool invalidate = false;
+        for (const auto& meshInfo : it->second.meshIdInfo)
+        {
+            const std::filesystem::path& cachedPath = meshInfo.second.path;
+            if (cachedPath.empty())
+                continue;
+            if (cachedPath == meshPath || cachedPath.filename() == targetFilename)
+            {
+                invalidate = true;
+                break;
+            }
+        }
+
+        if (invalidate)
+            it = m_loaded.erase(it);
+        else
+            ++it;
+    }
+}
+
 ObjectAllocation::ReturnCode MeshManager::getBoxId(GenericMeshId& id)
 {
     id.type = GenericMeshType::Cube;
@@ -1149,7 +1177,7 @@ bool MeshManager::removeMeshInstance(MeshId id)
         return false;
     if (m_meshesCounters.find(id) == m_meshesCounters.end())
     {
-        assert(false);
+        GRAPH_LOG << "Warning: removeMeshInstance called on unknown MeshId {" << id << "}." << Logger::endl;
         return false;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental physical deletion of TLS/mesh files that live outside the project folder and avoid exposing nodes that still reference source files during import.  
- Ensure duplicated Mesh/PCO objects receive unique names (append `_copyN`) to avoid collisions in the project.  
- Harden scan header/time access and provide an option to exclude dead nodes from PCO counting for deletion logic.

### Description
- Added `GraphManager::getPCOcounters(const tls::ScanGuid&, bool includeDeadNodes)` and updated call sites to pass `includeDeadNodes=false` when deciding to free/delete resources.  
- Introduced `MeshManager::invalidateLoadedCacheForPath(const std::filesystem::path&)` and call it before removing mesh files to purge cached entries that reference the removed file.  
- In delete flows, block physical TLS deletion when the scan file is outside the project point-cloud folder and call `freeScanFile()` instead while logging a warning.  
- Updated TLS import (`ImportNewTlsFile`) to always copy into the project location, force destination update, wait for the scan overseer to sync and verify the active scan path (with a retry loop) before exposing the node.  
- Implemented safe wrappers around `tlGetScanHeader` and thread-safe localtime conversion in `ScanData` to avoid crashes and return safe defaults when headers are not available.  
- Added unique-copy name generation for mesh and PCO duplication contexts using a `_copyN` suffix, and set the generated name on duplicated objects.  
- Ensured mesh instance accounting when copying `MeshObjectNode` by adding an instance in the copy constructor, and softened an assert into a logged warning when removing unknown mesh instances.  

### Testing
- Built the project after changes and the build completed successfully.  
- Exercised TLS import and delete flows to validate copy-then-sync behavior and guarded deletion, and confirmed expected code paths executed.  
- Ran existing unit/integration tests relevant to graph/mesh/scan operations and observed no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46b301d20832f81eea9b208a63f2a)