### PR TITLE
Calculate total frames from viewpoint control times in PositionAsTime mode

### DIFF
--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -311,6 +311,9 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
                 const double offset = m_viewpointControlTimes.front();
                 for (double& value : m_viewpointControlTimes)
                     value -= offset;
+
+                const double effectiveDuration = std::max(0.0, m_viewpointControlTimes.back());
+                m_totalFrames = std::max<long>(1, static_cast<long>(std::ceil(effectiveDuration * static_cast<double>(std::max(1, m_parameters.fps)))));
             }
             else if (mode == ViewPointAnimationMode::ConstantSpeed)
             {


### PR DESCRIPTION
### Motivation
- Ensure the export frame count is derived from viewpoint control times when using `PositionAsTime` animation mode so exports never produce zero frames and respect the configured `fps`.

### Description
- After normalizing control times by the initial offset, compute `effectiveDuration = max(0.0, m_viewpointControlTimes.back())` and set `m_totalFrames = max(1, ceil(effectiveDuration * max(1, m_parameters.fps)))` inside the `PositionAsTime` branch.

### Testing
- Built the project and ran the automated unit test suite; the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52aeb6390832fbb89931ba7e196ac)