### PR TITLE
Compute total frames from viewpoint timings and defer splash init until frames known

### DIFF
--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -284,10 +284,6 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
         m_totalFrames = std::max<long>(1, static_cast<long>(m_parameters.length) * static_cast<long>(m_parameters.fps));
         m_animFrame = 1;
-        m_frameDigits = std::max<uint8_t>(1, static_cast<uint8_t>(std::log10(std::max<long>(1, m_totalFrames)) + 1));
-
-        controller.updateInfo(new GuiDataProcessingSplashScreenStart(m_totalFrames, TEXT_CONTEXT_EXPORT_VIDEO, TEXT_CONTEXT_EXPORT_VIDEO_STEPS.arg(0).arg(m_totalFrames)));
-        m_tpStart = std::chrono::steady_clock::now();
 
         if (m_parameters.animMode == VideoAnimationMode::BETWEENVIEWPOINTS)
         {
@@ -311,6 +307,9 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
                 const double offset = m_viewpointControlTimes.front();
                 for (double& value : m_viewpointControlTimes)
                     value -= offset;
+
+                const double effectiveDuration = std::max(0.0, m_viewpointControlTimes.back());
+                m_totalFrames = std::max<long>(1, static_cast<long>(std::ceil(effectiveDuration * static_cast<double>(std::max(1, m_parameters.fps)))));
             }
             else if (mode == ViewPointAnimationMode::ConstantSpeed)
             {
@@ -381,6 +380,10 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
             m_orbitalRealAppliedRad = 0.0;
             m_orbitalUsesExamine = wCam->isExamineActive();
         }
+
+        m_frameDigits = std::max<uint8_t>(1, static_cast<uint8_t>(std::log10(std::max<long>(1, m_totalFrames)) + 1));
+        controller.updateInfo(new GuiDataProcessingSplashScreenStart(m_totalFrames, TEXT_CONTEXT_EXPORT_VIDEO, TEXT_CONTEXT_EXPORT_VIDEO_STEPS.arg(0).arg(m_totalFrames)));
+        m_tpStart = std::chrono::steady_clock::now();
 
         m_exportState = 1;
         return m_state = ContextState::ready_for_using;


### PR DESCRIPTION
### Motivation
- Ensure the total number of export frames reflects viewpoint timing when using `PositionAsTime` animation mode.
- Prevent initializing UI progress and timestamping before `m_totalFrames` is finalized by viewpoint-specific logic.
- Avoid incorrect digit-counting for frame filenames when the total frame count can be changed by viewpoint calculations.

### Description
- Added computation of `effectiveDuration` and set `m_totalFrames = ceil(effectiveDuration * fps)` for `ViewPointAnimationMode::PositionAsTime` so frame count is derived from viewpoint control times. 
- Shifted initialization of `m_frameDigits`, the `GuiDataProcessingSplashScreenStart` call, and `m_tpStart` to after viewpoint/orbital processing so they use the final `m_totalFrames` value. 
- Retained existing handling for other animation modes and orbital setup while ensuring `m_exportState` and `m_state` are set consistently after initialization. 
- Preserved existing safety checks and abort paths when required nodes are missing or viewpoints are incompatible.

### Testing
- Built the project with `make` and the build completed successfully. 
- Ran the unit/integration test suite with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52aeb6390832fbb89931ba7e196ac)