### PR TITLE
Mark project as modified when editing animations or polygonal selectors

### DIFF
--- a/include/controller/ControllerContext.h
+++ b/include/controller/ControllerContext.h
@@ -112,6 +112,8 @@ public:
 
 	void setActiveIcon(scs::MarkerIcon icon);
 	void setIsCurrentProjectSaved(bool value);
+	// ProjectDataChange (A-ready, B-migration anchor)
+	void markCurrentProjectDataChanged();
 	bool setStandards(std::vector<StandardList> list, const StandardType& type, bool reset = false);
 	void setPolyLineOptions(const PolyLineOptions& options);
 

--- a/src/controller/ControllerContext.cpp
+++ b/src/controller/ControllerContext.cpp
@@ -258,6 +258,12 @@ void ControllerContext::setIsCurrentProjectSaved(bool value)
 	m_isCurrentProjectSaved = value;
 }
 
+void ControllerContext::markCurrentProjectDataChanged()
+{
+	// ProjectDataChange (A-ready, B-migration anchor)
+	setIsCurrentProjectSaved(false);
+}
+
 bool ControllerContext::setUserLists(std::vector<UserList> list, bool reset)
 {
 	if (list.empty())

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -341,6 +341,9 @@ namespace control::animation
         if (inserted.second)
             configs[m_config.getId()].setOrder(static_cast<uint32_t>(configs.size() - 1));
 
+        // ProjectDataChange (A-ready, B-migration anchor)
+        controller.getContext().markCurrentProjectDataChanged();
+
         normalizeAnimationConfigs(controller);
         controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
     }
@@ -371,6 +374,9 @@ namespace control::animation
             if (pair.second.getOrder() > deletedOrder)
                 pair.second.setOrder(pair.second.getOrder() - 1);
         }
+
+        // ProjectDataChange (A-ready, B-migration anchor)
+        controller.getContext().markCurrentProjectDataChanged();
 
         controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
     }

--- a/src/controller/controls/ControlViewPoint.cpp
+++ b/src/controller/controls/ControlViewPoint.cpp
@@ -390,6 +390,7 @@ namespace control::viewpoint
 
         GraphManager& graphManager = controller.getGraphManager();
         std::unordered_set<SafePtr<AGraphNode>> viewpoints = graphManager.getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+        bool removedAnyPolygon = false;
 
         for (const SafePtr<AGraphNode>& vpNode : viewpoints)
         {
@@ -405,6 +406,7 @@ namespace control::viewpoint
                 continue;
 
             selector.polygons.erase(removeIt, selector.polygons.end());
+            removedAnyPolygon = true;
             selector.appliedPolygonCount = std::min<uint32_t>(selector.appliedPolygonCount, static_cast<uint32_t>(selector.polygons.size()));
             selector.pendingApply = selector.appliedPolygonCount < selector.polygons.size();
             selector.nextPolygonId = computeNextPolygonId(selector);
@@ -416,6 +418,12 @@ namespace control::viewpoint
                 selector.highlightedPolygonIndex = -1;
                 selector.manageMode = false;
             }
+        }
+
+        if (removedAnyPolygon)
+        {
+            // ProjectDataChange (A-ready, B-migration anchor)
+            controller.getContext().markCurrentProjectDataChanged();
         }
 
         CONTROLLOG << "control::viewpoint::DeletePolygonFromProject do " << m_polygonName << LOGENDL;

--- a/src/controller/functionSystem/ContextPolygonalSelector.cpp
+++ b/src/controller/functionSystem/ContextPolygonalSelector.cpp
@@ -185,6 +185,9 @@ ContextState ContextPolygonalSelector::validate(Controller& controller)
             ++m_settings.nextPolygonId;
             m_settings.enabled = true;
             m_settings.pendingApply = true;
+
+            // ProjectDataChange (A-ready, B-migration anchor)
+            controller.getContext().markCurrentProjectDataChanged();
         }
     }
 


### PR DESCRIPTION
### Motivation

- Ensure the project "dirty"/unsaved state is updated whenever users modify viewpoint animations or polygonal selectors to prevent losing changes and to provide a clear migration anchor for project data changes labeled "ProjectDataChange (A-ready, B-migration anchor)".

### Description

- Add `ControllerContext::markCurrentProjectDataChanged()` which marks the current project as unsaved by calling `setIsCurrentProjectSaved(false)`.
- Call `markCurrentProjectDataChanged()` after creating or editing viewpoint animations in `CreateEditViewPointAnimation::doFunction` and after deleting animations in `DeleteViewPointAnimation::doFunction`.
- Track polygon removals in `DeletePolygonFromProject::doFunction` with a `removedAnyPolygon` flag and call `markCurrentProjectDataChanged()` when at least one polygon was removed.
- Call `markCurrentProjectDataChanged()` when a new polygon is created in `ContextPolygonalSelector::validate` and add the minimal bookkeeping changes required for polygon handling.

### Testing

- Performed a full project build to verify compilation, and the build completed successfully. 
- Ran the automated unit test suite, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f5fe5bc8832f81acae150259aa0e)