### PR TITLE
Mark project dirty when view-point animations or polygon selector change

### DIFF
--- a/include/controller/ControllerContext.h
+++ b/include/controller/ControllerContext.h
@@ -112,6 +112,8 @@ public:
 
 	void setActiveIcon(scs::MarkerIcon icon);
 	void setIsCurrentProjectSaved(bool value);
+	// ProjectDataChange (A-ready, B-migration anchor)
+	void markCurrentProjectDataChanged();
 	bool setStandards(std::vector<StandardList> list, const StandardType& type, bool reset = false);
 	void setPolyLineOptions(const PolyLineOptions& options);
 

--- a/src/controller/ControllerContext.cpp
+++ b/src/controller/ControllerContext.cpp
@@ -258,6 +258,12 @@ void ControllerContext::setIsCurrentProjectSaved(bool value)
 	m_isCurrentProjectSaved = value;
 }
 
+void ControllerContext::markCurrentProjectDataChanged()
+{
+	// ProjectDataChange (A-ready, B-migration anchor)
+	setIsCurrentProjectSaved(false);
+}
+
 bool ControllerContext::setUserLists(std::vector<UserList> list, bool reset)
 {
 	if (list.empty())

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -341,6 +341,9 @@ namespace control::animation
         if (inserted.second)
             configs[m_config.getId()].setOrder(static_cast<uint32_t>(configs.size() - 1));
 
+        // ProjectDataChange (A-ready, B-migration anchor)
+        controller.getContext().markCurrentProjectDataChanged();
+
         normalizeAnimationConfigs(controller);
         controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
     }
@@ -371,6 +374,9 @@ namespace control::animation
             if (pair.second.getOrder() > deletedOrder)
                 pair.second.setOrder(pair.second.getOrder() - 1);
         }
+
+        // ProjectDataChange (A-ready, B-migration anchor)
+        controller.getContext().markCurrentProjectDataChanged();
 
         controller.updateInfo(new GuiDataSendViewPointAnimationData(getSortedAnimationConfigs(controller), collectAllViewpointInfos(controller)));
     }

--- a/src/controller/controls/ControlViewPoint.cpp
+++ b/src/controller/controls/ControlViewPoint.cpp
@@ -1,5 +1,6 @@
 #include "controller/controls/ControlViewPoint.h"
 #include "controller/Controller.h"
+#include "controller/ControllerContext.h"
 #include "controller/functionSystem/FunctionManager.h"
 #include "controller/messages/DataIDListMessage.h"
 
@@ -390,6 +391,7 @@ namespace control::viewpoint
 
         GraphManager& graphManager = controller.getGraphManager();
         std::unordered_set<SafePtr<AGraphNode>> viewpoints = graphManager.getNodesByTypes({ ElementType::ViewPoint }, ObjectStatusFilter::ALL);
+        bool removedAnyPolygon = false;
 
         for (const SafePtr<AGraphNode>& vpNode : viewpoints)
         {
@@ -405,6 +407,7 @@ namespace control::viewpoint
                 continue;
 
             selector.polygons.erase(removeIt, selector.polygons.end());
+            removedAnyPolygon = true;
             selector.appliedPolygonCount = std::min<uint32_t>(selector.appliedPolygonCount, static_cast<uint32_t>(selector.polygons.size()));
             selector.pendingApply = selector.appliedPolygonCount < selector.polygons.size();
             selector.nextPolygonId = computeNextPolygonId(selector);
@@ -416,6 +419,12 @@ namespace control::viewpoint
                 selector.highlightedPolygonIndex = -1;
                 selector.manageMode = false;
             }
+        }
+
+        if (removedAnyPolygon)
+        {
+            // ProjectDataChange (A-ready, B-migration anchor)
+            controller.getContext().markCurrentProjectDataChanged();
         }
 
         CONTROLLOG << "control::viewpoint::DeletePolygonFromProject do " << m_polygonName << LOGENDL;

--- a/src/controller/functionSystem/ContextPolygonalSelector.cpp
+++ b/src/controller/functionSystem/ContextPolygonalSelector.cpp
@@ -1,6 +1,7 @@
 #include "controller/functionSystem/ContextPolygonalSelector.h"
 
 #include "controller/Controller.h"
+#include "controller/ControllerContext.h"
 #include "controller/controls/ControlFunction.h"
 #include "controller/messages/FullClickMessage.h"
 #include "controller/messages/IMessage.h"
@@ -185,6 +186,9 @@ ContextState ContextPolygonalSelector::validate(Controller& controller)
             ++m_settings.nextPolygonId;
             m_settings.enabled = true;
             m_settings.pendingApply = true;
+
+            // ProjectDataChange (A-ready, B-migration anchor)
+            controller.getContext().markCurrentProjectDataChanged();
         }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the project "dirty"/unsaved state is updated when the user modifies view-point animations or polygonal selectors so the UI/save logic accurately reflects data changes.

### Description
- Add `ControllerContext::markCurrentProjectDataChanged()` which sets `m_isCurrentProjectSaved` to false via `setIsCurrentProjectSaved(false)`.
- Call `markCurrentProjectDataChanged()` from `CreateEditViewPointAnimation::doFunction` and `DeleteViewPointAnimation::doFunction` to mark changes when animations are added/removed.
- Call `markCurrentProjectDataChanged()` from `ContextPolygonalSelector::validate()` when a new polygon is created and from `DeletePolygonFromProject::doFunction()` when at least one polygon was removed, and add a `removedAnyPolygon` flag to avoid marking when nothing changed.
- Add necessary `#include "controller/ControllerContext.h"` where the new API is used.

### Testing
- Performed a full project build and executed the automated test suite with `make` and `ctest`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f5fe5bc8832f81acae150259aa0e)