### PR TITLE
Improve ray-picking robustness: orthographic detection, numeric guards, and voxel traversal fixes

### DIFF
--- a/src/controller/functionSystem/ARayTracingContext.cpp
+++ b/src/controller/functionSystem/ARayTracingContext.cpp
@@ -26,6 +26,8 @@
 
 namespace
 {
+constexpr bool kRayTracingPickDebug = false;
+
 RayTracingDisplayFilterSettings buildRayTracingDisplayFilterSettings(const ClickInfo& clickInfo)
 {
     RayTracingDisplayFilterSettings settings;
@@ -39,6 +41,17 @@ RayTracingDisplayFilterSettings buildRayTracingDisplayFilterSettings(const Click
     settings.colorimetricFilter = display.m_colorimetricFilter;
     settings.polygonalSelector = display.m_polygonalSelector;
     return settings;
+}
+
+bool isOrthographicPick(const ClickInfo& clickInfo)
+{
+    // Use camera projection mode as source of truth; fov can be stale/ambiguous in orthographic workflows.
+    ReadPtr<CameraNode> rCamera = clickInfo.viewport.cget();
+    if (rCamera)
+        return rCamera->getProjectionMode() == ProjectionMode::Orthographic;
+
+    // Fallback kept for safety if the viewport pointer is unavailable.
+    return (std::fabs(abs(clickInfo.fov)) <= std::numeric_limits<double>::epsilon());
 }
 }
 
@@ -566,7 +579,15 @@ glm::dvec3 ARayTracingContext::rayTracePointClouds(Controller& controller, Click
     ClippingAssembly clipAssembly;
     controller.getGraphManager().getClippingAssembly(clipAssembly, true, false);
 
-    bool isOrtho = (std::fabs(abs(clickInfo.fov)) <= std::numeric_limits<double>::epsilon());
+    bool isOrtho = isOrthographicPick(clickInfo);
+    if (kRayTracingPickDebug)
+    {
+        ReadPtr<CameraNode> rCamera = clickInfo.viewport.cget();
+        ProjectionMode mode = rCamera ? rCamera->getProjectionMode() : ProjectionMode::Perspective;
+        Logger::log(LoggerMode::rayTracingLog) << "[PickDebug] mode=" << static_cast<int>(mode)
+            << " fov=" << clickInfo.fov << " isOrtho=" << isOrtho
+            << " heightAt1m=" << clickInfo.heightAt1m << Logger::endl;
+    }
     TlScanOverseer::setWorkingScansTransfo(controller.getGraphManager().getVisiblePointCloudInstances(clickInfo.panoramic, true, true));
 
     double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * clickInfo.height)); // angle across a visible point in the viewport

--- a/src/controller/functionSystem/ContextPickColorimetric.cpp
+++ b/src/controller/functionSystem/ContextPickColorimetric.cpp
@@ -61,6 +61,16 @@ namespace
         return settings;
     }
 
+    bool isOrthographicPick(const ClickInfo& clickInfo)
+    {
+        // Projection mode is more robust than testing fov == 0 for orthographic picks.
+        ReadPtr<CameraNode> rCamera = clickInfo.viewport.cget();
+        if (rCamera)
+            return rCamera->getProjectionMode() == ProjectionMode::Orthographic;
+
+        return (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+    }
+
     bool tryFindNearestPoint(const Controller& controller, const ClickInfo& clickInfo, const glm::dvec3& point, PointXYZIRGB& outPoint)
     {
         double radius = computePickRadius(controller, clickInfo, point);
@@ -100,7 +110,7 @@ namespace
     {
         double height = std::max(1.0, static_cast<double>(clickInfo.height));
         double pointSize = controller.cgetContext().getRenderPointSize() + 2.0;
-        bool isOrtho = (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+        bool isOrtho = isOrthographicPick(clickInfo);
         double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * height));
         cosAngleThreshold = isOrtho ? clickInfo.heightAt1m * pointSize / (1.0 * height) : cos(cosAngleThreshold);
 

--- a/src/controller/functionSystem/ContextPickTemperature.cpp
+++ b/src/controller/functionSystem/ContextPickTemperature.cpp
@@ -64,6 +64,16 @@ namespace
         return settings;
     }
 
+    bool isOrthographicPick(const ClickInfo& clickInfo)
+    {
+        // Projection mode is more robust than testing fov == 0 for orthographic picks.
+        ReadPtr<CameraNode> rCamera = clickInfo.viewport.cget();
+        if (rCamera)
+            return rCamera->getProjectionMode() == ProjectionMode::Orthographic;
+
+        return (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+    }
+
     bool tryFindNearestColor(const Controller& controller, const ClickInfo& clickInfo, const glm::dvec3& point, PointXYZIRGB& outPoint)
     {
         double radius = computePickRadius(controller, clickInfo, point);
@@ -103,7 +113,7 @@ namespace
     {
         double height = std::max(1.0, static_cast<double>(clickInfo.height));
         double pointSize = controller.cgetContext().getRenderPointSize() + 2.0;
-        bool isOrtho = (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+        bool isOrtho = isOrthographicPick(clickInfo);
         double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * height));
         cosAngleThreshold = isOrtho ? clickInfo.heightAt1m * pointSize / (1.0 * height) : cos(cosAngleThreshold);
 

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -32,6 +32,7 @@ using namespace std::chrono;
 namespace
 {
     constexpr float kColorimetricMaxDistance = 1.7320508f;
+    constexpr bool kRayTracingPickDebug = false;
 
     struct PreparedRayTracingDisplayFilter
     {
@@ -2896,6 +2897,13 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
 
     std::vector<uint32_t> leafList;
     if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
+    if (kRayTracingPickDebug)
+    {
+        Logger::log(LoggerMode::rayTracingLog) << "[PickDebug] beginRayTracing isOrtho=" << isOrtho
+            << " max0=" << max0 << " min1=" << min1
+            << " enteredRoot=" << (max0 < min1)
+            << " leafCount=" << leafList.size() << Logger::endl;
+    }
 
     //leafList has been computed, now make the list of points 
 	double rayRadius = 0.0015;
@@ -2974,6 +2982,13 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
 
     std::vector<uint32_t> leafList;
     if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
+    if (kRayTracingPickDebug)
+    {
+        Logger::log(LoggerMode::rayTracingLog) << "[PickDebug] beginRayTracingWithPoint isOrtho=" << isOrtho
+            << " max0=" << max0 << " min1=" << min1
+            << " enteredRoot=" << (max0 < min1)
+            << " leafCount=" << leafList.size() << Logger::endl;
+    }
 
     double rayRadius = 0.0015;
     bool success = false;
@@ -3036,11 +3051,30 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
                 glm::dot(rayDirection, pointRay / currDistance);
 
             double projLength = glm::length(proj);
-            proj = proj / projLength;
 
 
             if (!isOrtho)
             {
+                if (projLength <= std::numeric_limits<double>::epsilon())
+                {
+                    // Ray goes through the point: treat as best angular match and avoid NaN from proj normalization.
+                    hasGoodAngle = true;
+                    currCosAngle = 1.0;
+                    if (currDistance < (dMin * 1.05))
+                        goodAnglePoints.push_back(point);
+                    if (currDistance < dMin)
+                        dMin = currDistance;
+                    if (currCosAngle > bestCosAngle)
+                    {
+                        bestCosAngle = currCosAngle;
+                        bestAnglePoint = point;
+                        distanceBestAnglePoint = currDistance;
+                        realBestCosAngle = currCosAngle;
+                    }
+                    continue;
+                }
+
+                proj = proj / projLength;
                 if ((rayRadius / projLength) >= 1.0) {
                     hasGoodAngle = true;
                     currCosAngle = rayRadius / projLength;
@@ -3121,8 +3155,13 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
 			currCosAngle = glm::dot(rayDirection, pointRay / currDistance);
 			if(isOrtho)
 				currCosAngle = glm::length(glm::cross(rayDirection, pointRay)) / glm::length(rayDirection);
-			if (((rayRadius / glm::length(proj)) >= 1)&&(!isOrtho)) {
-				currCosAngle = rayRadius / glm::length(proj);
+            double projLength = glm::length(proj);
+			if ((projLength <= std::numeric_limits<double>::epsilon()) && (!isOrtho))
+            {
+                currCosAngle = 1.0;
+            }
+			if ((projLength > std::numeric_limits<double>::epsilon()) && ((rayRadius / projLength) >= 1) && (!isOrtho)) {
+				currCosAngle = rayRadius / projLength;
 			}
 			/*if ((currDistance < (dMin * 1.05)) && (currCosAngle > bestCosAngle) && (!isOrtho))
 			{
@@ -3200,11 +3239,29 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
                 glm::dot(rayDirection, pointRay / currDistance);
 
             double projLength = glm::length(proj);
-            proj = proj / projLength;
 
 
             if (!isOrtho)
             {
+                if (projLength <= std::numeric_limits<double>::epsilon())
+                {
+                    // Ray goes through the point: treat as best angular match and avoid NaN from proj normalization.
+                    hasGoodAngle = true;
+                    currCosAngle = 1.0;
+                    if (currDistance < (dMin * 1.05))
+                        goodAnglePoints.push_back(pointData);
+                    if (currDistance < dMin)
+                        dMin = currDistance;
+                    if (currCosAngle > bestCosAngle)
+                    {
+                        bestCosAngle = currCosAngle;
+                        bestAnglePointPos = point;
+                        bestAnglePointRaw = pointData;
+                    }
+                    continue;
+                }
+
+                proj = proj / projLength;
                 if ((rayRadius / projLength) >= 1.0) {
                     hasGoodAngle = true;
                     currCosAngle = rayRadius / projLength;
@@ -3287,8 +3344,13 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
             currCosAngle = glm::dot(rayDirection, pointRay / currDistance);
             if (isOrtho)
                 currCosAngle = glm::length(glm::cross(rayDirection, pointRay)) / glm::length(rayDirection);
-            if (((rayRadius / glm::length(proj)) >= 1) && (!isOrtho)) {
-                currCosAngle = rayRadius / glm::length(proj);
+            double projLength = glm::length(proj);
+            if ((projLength <= std::numeric_limits<double>::epsilon()) && (!isOrtho))
+            {
+                currCosAngle = 1.0;
+            }
+            if ((projLength > std::numeric_limits<double>::epsilon()) && ((rayRadius / projLength) >= 1) && (!isOrtho)) {
+                currCosAngle = rayRadius / projLength;
             }
             currScore = 1.7 * glm::length(proj) + currDistance;
             if (i == 0)
@@ -4838,11 +4900,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4884,11 +4946,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                 
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4929,11 +4991,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4974,11 +5036,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5019,11 +5081,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5064,11 +5126,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5109,11 +5171,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5154,11 +5216,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                 
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5273,11 +5335,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5319,11 +5381,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5364,11 +5426,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5409,11 +5471,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5454,11 +5516,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5499,11 +5561,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5544,11 +5606,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5589,11 +5651,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position


### PR DESCRIPTION
### Motivation

- Orthographic pick detection relying on `fov == 0` is fragile and can produce incorrect pick behavior in some camera workflows.
- Several ray-tracing paths could produce NaN or divide-by-zero when a ray passes exactly through a point, leading to incorrect picks.
- Voxel traversal used the wrong component checks in several places which could cause incorrect next-voxel computation and traversal errors. 
- Add lightweight debug logging to assist diagnosing pick/ray-tracing issues during development.

### Description

- Introduce a reusable `isOrthographicPick` helper and replace existing `fov`-zero checks with camera `getProjectionMode()` lookups in `ARayTracingContext`, `ContextPickColorimetric`, and `ContextPickTemperature`.
- Add `kRayTracingPickDebug` flags and conditional `Logger::log` calls in `ARayTracingContext` and `EmbeddedScan` to emit pick-related diagnostics when enabled.
- In `EmbeddedScan`, add numeric guards around projection normalization by computing `projLength` once and skipping normalization when `projLength <= std::numeric_limits<double>::epsilon()`, treating the ray-through-point case as the best angular match (`currCosAngle = 1.0`).
- Fix multiple incorrect component checks in voxel/ octree traversal loops by replacing repeated `ray.x` checks with the correct `ray.y` and `ray.z` comparisons so each time calculation uses the appropriate ray component.
- Adjust several scoring/angle computations to use the new `projLength` handling and avoid NaNs and unstable comparisons for both `findBestPointIterative` and `findBestPointIterativeWithPoint` code paths.

### Testing

- Ran the repository unit test suite and relevant ray-picking integration tests; all tests completed successfully.
- Executed a selection of point-picking scenarios (perspective and orthographic) with debug logging enabled to validate `isOrthographicPick` behavior and numeric-guard handling, and observed stable, expected pick results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7efecfb70832fbb9332cd00d4255b)