### PR TITLE
Stabilize ray-tracing: add tolerances, handle degenerate rays, and deterministic octree ties

### DIFF
--- a/src/controller/functionSystem/ARayTracingContext.cpp
+++ b/src/controller/functionSystem/ARayTracingContext.cpp
@@ -566,7 +566,9 @@ glm::dvec3 ARayTracingContext::rayTracePointClouds(Controller& controller, Click
     ClippingAssembly clipAssembly;
     controller.getGraphManager().getClippingAssembly(clipAssembly, true, false);
 
-    bool isOrtho = (std::fabs(abs(clickInfo.fov)) <= std::numeric_limits<double>::epsilon());
+    // Keep a practical tolerance: view mode can leave tiny residual values around zero.
+    constexpr double kOrthoFovEpsilon = 1e-10;
+    bool isOrtho = (std::abs(clickInfo.fov) <= kOrthoFovEpsilon);
     TlScanOverseer::setWorkingScansTransfo(controller.getGraphManager().getVisiblePointCloudInstances(clickInfo.panoramic, true, true));
 
     double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * clickInfo.height)); // angle across a visible point in the viewport

--- a/src/controller/functionSystem/ContextPickColorimetric.cpp
+++ b/src/controller/functionSystem/ContextPickColorimetric.cpp
@@ -100,7 +100,9 @@ namespace
     {
         double height = std::max(1.0, static_cast<double>(clickInfo.height));
         double pointSize = controller.cgetContext().getRenderPointSize() + 2.0;
-        bool isOrtho = (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+        // Keep a practical tolerance: view mode can leave tiny residual values around zero.
+        constexpr double kOrthoFovEpsilon = 1e-10;
+        bool isOrtho = (std::abs(clickInfo.fov) <= kOrthoFovEpsilon);
         double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * height));
         cosAngleThreshold = isOrtho ? clickInfo.heightAt1m * pointSize / (1.0 * height) : cos(cosAngleThreshold);
 

--- a/src/controller/functionSystem/ContextPickTemperature.cpp
+++ b/src/controller/functionSystem/ContextPickTemperature.cpp
@@ -103,7 +103,9 @@ namespace
     {
         double height = std::max(1.0, static_cast<double>(clickInfo.height));
         double pointSize = controller.cgetContext().getRenderPointSize() + 2.0;
-        bool isOrtho = (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+        // Keep a practical tolerance: view mode can leave tiny residual values around zero.
+        constexpr double kOrthoFovEpsilon = 1e-10;
+        bool isOrtho = (std::abs(clickInfo.fov) <= kOrthoFovEpsilon);
         double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * height));
         cosAngleThreshold = isOrtho ? clickInfo.heightAt1m * pointSize / (1.0 * height) : cos(cosAngleThreshold);
 

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -32,6 +32,15 @@ using namespace std::chrono;
 namespace
 {
     constexpr float kColorimetricMaxDistance = 1.7320508f;
+    // Ray-tracing tolerance: numeric_limits<double>::epsilon() is too strict once
+    // camera/orientation transforms introduce tiny floating-point noise.
+    constexpr double kRayAxisEpsilon = 1e-12;
+    constexpr double kRayIntersectionEpsilon = 1e-12;
+
+    inline bool isNearlyZeroRayComponent(double value)
+    {
+        return std::abs(value) <= kRayAxisEpsilon;
+    }
 
     struct PreparedRayTracingDisplayFilter
     {
@@ -2838,6 +2847,11 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
     TreeCell root = m_vTreeCells[m_uRootCell];
     double rootSize = root.m_size;
     glm::dvec3 localRay = glm::inverse(m_rotationToGlobal) * glm::dvec3(globalRay.x, globalRay.y, globalRay.z);
+    if (glm::length(localRay) <= kRayAxisEpsilon)
+    {
+        // Degenerate ray (can happen with unstable view state): avoid undefined behavior.
+        return false;
+    }
     glm::dvec3 localRayOrigin = getLocalCoord(globalRayOrigin);
 
     // Rayon local non altérée pour la détection
@@ -2858,7 +2872,7 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
     ty1 = (root.m_position[1] + rootSize - localRayOrigin.y) / localRay.y;
     tz1 = (root.m_position[2] + rootSize - localRayOrigin.z) / localRay.z;
 	//if a coordinate of local ray is 0, we want still want this times to be definite
-	if (std::fabs(abs(localRay.x)) <= std::numeric_limits<double>::epsilon())
+	if (isNearlyZeroRayComponent(localRay.x))
 	{
 		if (root.m_position[0] > localRayOrigin.x)
 			tx0 = DBL_MAX;
@@ -2867,7 +2881,7 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
 			tx1 = DBL_MAX;
 		else tx1 = -DBL_MAX;
 	}
-	if (std::fabs(abs(localRay.y)) <= std::numeric_limits<double>::epsilon())
+	if (isNearlyZeroRayComponent(localRay.y))
 	{
 		if (root.m_position[1] > localRayOrigin.y)
 			ty0 = DBL_MAX;
@@ -2876,7 +2890,7 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
 			ty1 = DBL_MAX;
 		else ty1 = -DBL_MAX;
 	}
-	if (std::fabs(abs(localRay.z)) <= std::numeric_limits<double>::epsilon())
+	if (isNearlyZeroRayComponent(localRay.z))
 	{
 		if (root.m_position[2] > localRayOrigin.z)
 			tz0 = DBL_MAX;
@@ -2895,7 +2909,8 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
     if (tz1 < min1) { min1 = tz1; }
 
     std::vector<uint32_t> leafList;
-    if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
+    // Include a small tolerance so boundary hits are not dropped by strict comparisons.
+    if (max0 <= min1 + kRayIntersectionEpsilon) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
 
     //leafList has been computed, now make the list of points 
 	double rayRadius = 0.0015;
@@ -2917,6 +2932,11 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
     TreeCell root = m_vTreeCells[m_uRootCell];
     double rootSize = root.m_size;
     glm::dvec3 localRay = glm::inverse(m_rotationToGlobal) * glm::dvec3(globalRay.x, globalRay.y, globalRay.z);
+    if (glm::length(localRay) <= kRayAxisEpsilon)
+    {
+        // Degenerate ray (can happen with unstable view state): avoid undefined behavior.
+        return false;
+    }
     glm::dvec3 localRayOrigin = getLocalCoord(globalRayOrigin);
 
     // Rayon local non altérée pour la détection
@@ -2936,7 +2956,7 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
     ty1 = (root.m_position[1] + rootSize - localRayOrigin.y) / localRay.y;
     tz1 = (root.m_position[2] + rootSize - localRayOrigin.z) / localRay.z;
     //if a coordinate of local ray is 0, we want still want this times to be definite
-    if (std::fabs(abs(localRay.x)) <= std::numeric_limits<double>::epsilon())
+    if (isNearlyZeroRayComponent(localRay.x))
     {
         if (root.m_position[0] > localRayOrigin.x)
             tx0 = DBL_MAX;
@@ -2945,7 +2965,7 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
             tx1 = DBL_MAX;
         else tx1 = -DBL_MAX;
     }
-    if (std::fabs(abs(localRay.y)) <= std::numeric_limits<double>::epsilon())
+    if (isNearlyZeroRayComponent(localRay.y))
     {
         if (root.m_position[1] > localRayOrigin.y)
             ty0 = DBL_MAX;
@@ -2954,7 +2974,7 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
             ty1 = DBL_MAX;
         else ty1 = -DBL_MAX;
     }
-    if (std::fabs(abs(localRay.z)) <= std::numeric_limits<double>::epsilon())
+    if (isNearlyZeroRayComponent(localRay.z))
     {
         if (root.m_position[2] > localRayOrigin.z)
             tz0 = DBL_MAX;
@@ -2973,7 +2993,8 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
     if (tz1 < min1) { min1 = tz1; }
 
     std::vector<uint32_t> leafList;
-    if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
+    // Include a small tolerance so boundary hits are not dropped by strict comparisons.
+    if (max0 <= min1 + kRayIntersectionEpsilon) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
 
     double rayRadius = 0.0015;
     bool success = false;
@@ -3320,6 +3341,12 @@ int EmbeddedScan::updateRay(glm::dvec3& localRay, glm::dvec3& localRayOrigin, co
     int result(0);
     TreeCell root = m_vTreeCells[m_uRootCell];
     double norm = glm::length(localRay);
+    if (norm <= kRayAxisEpsilon)
+    {
+        // Keep a stable default direction to avoid divide-by-zero.
+        localRay = glm::dvec3(0.0, 0.0, 1.0);
+        return result;
+    }
     localRay = localRay / norm;
     for (int loop = 0; loop < 3; loop++)
     {
@@ -3358,7 +3385,7 @@ void EmbeddedScan::traceRay(const double& tx0, const double& ty0, const double& 
     txm = 0.5*(tx0 + tx1);
     tym = 0.5*(ty0 + ty1);
     tzm = 0.5*(tz0 + tz1);
-	if ((std::fabs(abs(txm)) <= std::numeric_limits<double>::epsilon()) && (abs(tx0) > (0.5*DBL_MAX)) && (abs(tx1) > (0.5*DBL_MAX)))
+	if ((std::abs(txm) <= kRayAxisEpsilon) && (std::abs(tx0) > (0.5*DBL_MAX)) && (std::abs(tx1) > (0.5*DBL_MAX)))
 	{
 		if (localRayOrigin.x < (cell.m_position[0] + 0.5*cell.m_size))
 			txm = DBL_MAX;
@@ -3366,7 +3393,7 @@ void EmbeddedScan::traceRay(const double& tx0, const double& ty0, const double& 
 			txm = -DBL_MAX;
 	}
 		
-	if ((std::fabs(abs(tym)) <= std::numeric_limits<double>::epsilon()) && (abs(ty0) > (0.5*DBL_MAX)) && (abs(ty1) > (0.5*DBL_MAX)))
+	if ((std::abs(tym) <= kRayAxisEpsilon) && (std::abs(ty0) > (0.5*DBL_MAX)) && (std::abs(ty1) > (0.5*DBL_MAX)))
 	{
 		if (localRayOrigin.y < (cell.m_position[1] + 0.5*cell.m_size))
 			tym = DBL_MAX;
@@ -3374,7 +3401,7 @@ void EmbeddedScan::traceRay(const double& tx0, const double& ty0, const double& 
 			tym = -DBL_MAX;
 	}
 
-	if ((std::fabs(abs(tzm)) <= std::numeric_limits<double>::epsilon()) && (abs(tz0) > (0.5*DBL_MAX)) && (abs(tz1) > (0.5*DBL_MAX)))
+	if ((std::abs(tzm) <= kRayAxisEpsilon) && (std::abs(tz0) > (0.5*DBL_MAX)) && (std::abs(tz1) > (0.5*DBL_MAX)))
 	{
 		if (localRayOrigin.z < (cell.m_position[2] + 0.5*cell.m_size))
 			tzm = DBL_MAX;
@@ -4838,11 +4865,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4884,11 +4911,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                 
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4929,11 +4956,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4974,11 +5001,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5019,11 +5046,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5064,11 +5091,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5109,11 +5136,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5154,11 +5181,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                 
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5273,11 +5300,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5319,11 +5346,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5364,11 +5391,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5409,11 +5436,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5454,11 +5481,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5499,11 +5526,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5544,11 +5571,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5589,11 +5616,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position

--- a/src/pointCloudEngine/OctreeRayTracing.cpp
+++ b/src/pointCloudEngine/OctreeRayTracing.cpp
@@ -10,21 +10,17 @@
 
 int OctreeRayTracing::computeExitPlane(const double& tx0, const double& ty0, const double& tz0)
 {
-	int result(3);
+	// Deterministic tie-breaking is important for orthographic / axis-aligned rays:
+	// when two components are equal we keep a stable priority (X, then Y, then Z).
 	if ((tx0 >= ty0) && (tx0 >= tz0))
 	{
-		result = 0;
+		return 0;
 	}
-	if ((ty0 >= tx0) && (ty0 >= tz0))
+	if (ty0 >= tz0)
 	{
-		result = 1;
+		return 1;
 	}
-	if ((tz0 >= tx0) && (tz0 >= ty0))
-	{
-		result = 2;
-	}
-
-	return result;
+	return 2;
 }
 
 int OctreeRayTracing::firstNode(const double& tx0, const double& ty0, const double& tz0, const double& txm, const double& tym, const double& tzm)
@@ -36,20 +32,26 @@ int OctreeRayTracing::firstNode(const double& tx0, const double& ty0, const doub
 	{
 	case 0:
 	{
-		if (tym < tx0) { result = result | 2; test++; }
-		if (tzm < tx0) { result = result | 1; test++; }
+		// NOTE: use <= so ties are handled consistently on octree boundaries.
+		if (tym <= tx0) { result = result | 2; test++; }
+		if (tzm <= tx0) { result = result | 1; test++; }
+		// Important: do not fall through, only evaluate the entry plane branch.
+		break;
 	}
 
 	case 1:
 	{
-		if (txm < ty0) { result = result | 4; test++; }
-		if (tzm < ty0) { result = result | 1; test++; }
+		if (txm <= ty0) { result = result | 4; test++; }
+		if (tzm <= ty0) { result = result | 1; test++; }
+		// Important: do not fall through, only evaluate the entry plane branch.
+		break;
 	}
 
 	case 2:
 	{
-		if (txm < tz0) { result = result | 4; test++; }
-		if (tym < tz0) { result = result | 2; test++; }
+		if (txm <= tz0) { result = result | 4; test++; }
+		if (tym <= tz0) { result = result | 2; test++; }
+		break;
 	}
 	}
 	return result;
@@ -57,14 +59,15 @@ int OctreeRayTracing::firstNode(const double& tx0, const double& ty0, const doub
 
 int OctreeRayTracing::new_node(const double& a, const double& b, const double& c, const int& p, const int& q, const int& r)
 {
-	if (a < b)
+	// NOTE: <= keeps deterministic behavior when crossing voxel/octree boundaries.
+	if (a <= b)
 	{
-		if (a < c) { return p; }
+		if (a <= c) { return p; }
 		else { return r; }
 	}
 	else
 	{
-		if (b < c) { return q; }
+		if (b <= c) { return q; }
 		else { return r; }
 	}
 }


### PR DESCRIPTION
### Motivation
- Ray-tracing and picking were fragile around axis-aligned or near-zero view parameters because comparisons used machine epsilon and left possibility for divide-by-zero or dropped boundary hits. 
- Deterministic behavior is required when rays align with octree/voxel boundaries to avoid non-reproducible misses or undefined behavior.

### Description
- Introduced practical tolerances `kOrthoFovEpsilon`, `kRayAxisEpsilon`, and `kRayIntersectionEpsilon` and replaced brittle `std::numeric_limits<double>::epsilon()` checks with these constants in `ARayTracingContext.cpp`, `ContextPickColorimetric.cpp`, and `ContextPickTemperature.cpp`. 
- Added `isNearlyZeroRayComponent()` helper and early guards against degenerate/near-zero rays in `EmbeddedScan.cpp`, and provided a stable fallback in `updateRay()` to avoid divide-by-zero. 
- Relaxed intersection boundary comparison to include a small epsilon (`max0 <= min1 + kRayIntersectionEpsilon`) so boundary hits are not dropped, and replaced repeated/incorrect `abs` usages with consistent `std::abs` checks. 
- Made octree traversal deterministic by enforcing stable tie-breaking and inclusive comparisons in `OctreeRayTracing.cpp` by updating `computeExitPlane()`, `firstNode()`, and `new_node()` to use well-defined ordering and `<=` where appropriate.

### Testing
- Performed a full project build as an automated check and the build completed successfully. 
- Executed the repository's automated unit/integration test suite including ray-tracing related tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d810f74010832fb85412a2afe7a4a3)