### PR TITLE
Stabilize ray-tracing and picking for orthographic/degenerate views

### DIFF
--- a/src/controller/functionSystem/ARayTracingContext.cpp
+++ b/src/controller/functionSystem/ARayTracingContext.cpp
@@ -40,6 +40,33 @@ RayTracingDisplayFilterSettings buildRayTracingDisplayFilterSettings(const Click
     settings.polygonalSelector = display.m_polygonalSelector;
     return settings;
 }
+
+bool prepareStableRayForScene(const Controller& controller, const ClickInfo& clickInfo, bool isOrtho, glm::dvec3& outRay, glm::dvec3& outRayOrigin)
+{
+    outRay = clickInfo.ray;
+    const double rayLength = glm::length(outRay);
+    if (rayLength <= 1e-12)
+        return false;
+    outRay /= rayLength;
+
+    outRayOrigin = clickInfo.rayOrigin;
+    if (!isOrtho)
+        return true;
+
+    // In orthographic mode, move the ray origin behind the visible scene so all
+    // candidate points remain in front of the ray, independent of near/far setup.
+    const BoundingBoxD visibleScansBBox = controller.cgetGraphManager().getScanBoundingBox(ObjectStatusFilter::VISIBLE);
+    if (visibleScansBBox.isValid())
+    {
+        const double backOffset = std::max(1.0, glm::length(visibleScansBBox.size()) * 1.25);
+        outRayOrigin -= outRay * backOffset;
+    }
+    else
+    {
+        outRayOrigin -= outRay * 50.0;
+    }
+    return true;
+}
 }
 
 ARayTracingContext::ARayTracingContext(const ContextId& id)
@@ -566,7 +593,9 @@ glm::dvec3 ARayTracingContext::rayTracePointClouds(Controller& controller, Click
     ClippingAssembly clipAssembly;
     controller.getGraphManager().getClippingAssembly(clipAssembly, true, false);
 
-    bool isOrtho = (std::fabs(abs(clickInfo.fov)) <= std::numeric_limits<double>::epsilon());
+    // Keep a practical tolerance: view mode can leave tiny residual values around zero.
+    constexpr double kOrthoFovEpsilon = 1e-10;
+    bool isOrtho = (std::abs(clickInfo.fov) <= kOrthoFovEpsilon);
     TlScanOverseer::setWorkingScansTransfo(controller.getGraphManager().getVisiblePointCloudInstances(clickInfo.panoramic, true, true));
 
     double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * clickInfo.height)); // angle across a visible point in the viewport
@@ -574,9 +603,16 @@ glm::dvec3 ARayTracingContext::rayTracePointClouds(Controller& controller, Click
     cosAngleThreshold = isOrtho ? clickInfo.heightAt1m * pointSize / (1.0 * clickInfo.height) : cos(cosAngleThreshold);
 
     RayTracingDisplayFilterSettings displayFilterSettings = buildRayTracingDisplayFilterSettings(clickInfo);
+    glm::dvec3 stableRay = clickInfo.ray;
+    glm::dvec3 stableRayOrigin = clickInfo.rayOrigin;
+    if (!prepareStableRayForScene(controller, clickInfo, isOrtho, stableRay, stableRayOrigin))
+    {
+        controller.updateInfo(new GuiDataTmpMessage(TEXT_RAYTRACING_FAILED));
+        return glm::dvec3(NAN);
+    }
 
     TlStreamLock streamLock;
-    if (TlScanOverseer::getInstance().rayTracing(clickInfo.ray, clickInfo.rayOrigin, result, cosAngleThreshold, clipAssembly, isOrtho, scanName, &displayFilterSettings) == false)
+    if (TlScanOverseer::getInstance().rayTracing(stableRay, stableRayOrigin, result, cosAngleThreshold, clipAssembly, isOrtho, scanName, &displayFilterSettings) == false)
     {
         controller.updateInfo(new GuiDataTmpMessage(TEXT_RAYTRACING_FAILED));
         FUNCLOG << "picking nan detected" << LOGENDL;

--- a/src/controller/functionSystem/ContextPickColorimetric.cpp
+++ b/src/controller/functionSystem/ContextPickColorimetric.cpp
@@ -61,6 +61,31 @@ namespace
         return settings;
     }
 
+    bool prepareStableRayForScene(const Controller& controller, const ClickInfo& clickInfo, bool isOrtho, glm::dvec3& outRay, glm::dvec3& outRayOrigin)
+    {
+        outRay = clickInfo.ray;
+        const double rayLength = glm::length(outRay);
+        if (rayLength <= 1e-12)
+            return false;
+        outRay /= rayLength;
+
+        outRayOrigin = clickInfo.rayOrigin;
+        if (!isOrtho)
+            return true;
+
+        const BoundingBoxD visibleScansBBox = controller.cgetGraphManager().getScanBoundingBox(ObjectStatusFilter::VISIBLE);
+        if (visibleScansBBox.isValid())
+        {
+            const double backOffset = std::max(1.0, glm::length(visibleScansBBox.size()) * 1.25);
+            outRayOrigin -= outRay * backOffset;
+        }
+        else
+        {
+            outRayOrigin -= outRay * 50.0;
+        }
+        return true;
+    }
+
     bool tryFindNearestPoint(const Controller& controller, const ClickInfo& clickInfo, const glm::dvec3& point, PointXYZIRGB& outPoint)
     {
         double radius = computePickRadius(controller, clickInfo, point);
@@ -100,7 +125,9 @@ namespace
     {
         double height = std::max(1.0, static_cast<double>(clickInfo.height));
         double pointSize = controller.cgetContext().getRenderPointSize() + 2.0;
-        bool isOrtho = (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+        // Keep a practical tolerance: view mode can leave tiny residual values around zero.
+        constexpr double kOrthoFovEpsilon = 1e-10;
+        bool isOrtho = (std::abs(clickInfo.fov) <= kOrthoFovEpsilon);
         double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * height));
         cosAngleThreshold = isOrtho ? clickInfo.heightAt1m * pointSize / (1.0 * height) : cos(cosAngleThreshold);
 
@@ -109,9 +136,13 @@ namespace
 
         TlScanOverseer::setWorkingScansTransfo(controller.cgetGraphManager().getVisiblePointCloudInstances(clickInfo.panoramic, true, true));
         glm::dvec3 bestPoint;
+        glm::dvec3 stableRay = clickInfo.ray;
+        glm::dvec3 stableRayOrigin = clickInfo.rayOrigin;
+        if (!prepareStableRayForScene(controller, clickInfo, isOrtho, stableRay, stableRayOrigin))
+            return false;
         std::string scanName;
         RayTracingDisplayFilterSettings displayFilterSettings = buildRayTracingDisplayFilterSettings(clickInfo);
-        return TlScanOverseer::getInstance().rayTracingWithPoint(clickInfo.ray, clickInfo.rayOrigin, bestPoint, outPoint, cosAngleThreshold, clipAssembly, isOrtho, scanName, &displayFilterSettings);
+        return TlScanOverseer::getInstance().rayTracingWithPoint(stableRay, stableRayOrigin, bestPoint, outPoint, cosAngleThreshold, clipAssembly, isOrtho, scanName, &displayFilterSettings);
     }
 }
 

--- a/src/controller/functionSystem/ContextPickTemperature.cpp
+++ b/src/controller/functionSystem/ContextPickTemperature.cpp
@@ -64,6 +64,31 @@ namespace
         return settings;
     }
 
+    bool prepareStableRayForScene(const Controller& controller, const ClickInfo& clickInfo, bool isOrtho, glm::dvec3& outRay, glm::dvec3& outRayOrigin)
+    {
+        outRay = clickInfo.ray;
+        const double rayLength = glm::length(outRay);
+        if (rayLength <= 1e-12)
+            return false;
+        outRay /= rayLength;
+
+        outRayOrigin = clickInfo.rayOrigin;
+        if (!isOrtho)
+            return true;
+
+        const BoundingBoxD visibleScansBBox = controller.cgetGraphManager().getScanBoundingBox(ObjectStatusFilter::VISIBLE);
+        if (visibleScansBBox.isValid())
+        {
+            const double backOffset = std::max(1.0, glm::length(visibleScansBBox.size()) * 1.25);
+            outRayOrigin -= outRay * backOffset;
+        }
+        else
+        {
+            outRayOrigin -= outRay * 50.0;
+        }
+        return true;
+    }
+
     bool tryFindNearestColor(const Controller& controller, const ClickInfo& clickInfo, const glm::dvec3& point, PointXYZIRGB& outPoint)
     {
         double radius = computePickRadius(controller, clickInfo, point);
@@ -103,7 +128,9 @@ namespace
     {
         double height = std::max(1.0, static_cast<double>(clickInfo.height));
         double pointSize = controller.cgetContext().getRenderPointSize() + 2.0;
-        bool isOrtho = (std::abs(clickInfo.fov) <= std::numeric_limits<double>::epsilon());
+        // Keep a practical tolerance: view mode can leave tiny residual values around zero.
+        constexpr double kOrthoFovEpsilon = 1e-10;
+        bool isOrtho = (std::abs(clickInfo.fov) <= kOrthoFovEpsilon);
         double cosAngleThreshold = atan(clickInfo.heightAt1m * pointSize / (1.0 * height));
         cosAngleThreshold = isOrtho ? clickInfo.heightAt1m * pointSize / (1.0 * height) : cos(cosAngleThreshold);
 
@@ -112,9 +139,13 @@ namespace
 
         TlScanOverseer::setWorkingScansTransfo(controller.cgetGraphManager().getVisiblePointCloudInstances(clickInfo.panoramic, true, true));
         glm::dvec3 bestPoint;
+        glm::dvec3 stableRay = clickInfo.ray;
+        glm::dvec3 stableRayOrigin = clickInfo.rayOrigin;
+        if (!prepareStableRayForScene(controller, clickInfo, isOrtho, stableRay, stableRayOrigin))
+            return false;
         std::string scanName;
         RayTracingDisplayFilterSettings displayFilterSettings = buildRayTracingDisplayFilterSettings(clickInfo);
-        return TlScanOverseer::getInstance().rayTracingWithPoint(clickInfo.ray, clickInfo.rayOrigin, bestPoint, outPoint, cosAngleThreshold, clipAssembly, isOrtho, scanName, &displayFilterSettings);
+        return TlScanOverseer::getInstance().rayTracingWithPoint(stableRay, stableRayOrigin, bestPoint, outPoint, cosAngleThreshold, clipAssembly, isOrtho, scanName, &displayFilterSettings);
     }
 }
 

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -476,14 +476,19 @@ ClickInfo VulkanViewport::generateRaytracingInfos(const WritePtr<CameraNode>& wC
 {
     assert(wCam);
 
-    glm::dvec4 eyeCoord = wCam->getEyeCoord((double)(m_MI.lastX), (double)(m_MI.lastY), 1.0f, (double)width(), (double)height());
-    glm::dvec4 pickPos = wCam->getModelMatrix() * eyeCoord;
-    glm::dvec4 eyeCoord0 = wCam->getEyeCoord((double)(m_MI.lastX), (double)(m_MI.lastY), 0.0f, (double)width(), (double)height());
-    glm::dvec4 pickPos0 = wCam->getModelMatrix() * eyeCoord0;
-
-    glm::dvec3 rayOrigin = glm::dvec3(pickPos0.x, pickPos0.y, pickPos0.z);
-
-    glm::dvec3 ray = glm::dvec3(pickPos.x - pickPos0.x, pickPos.y - pickPos0.y, pickPos.z - pickPos0.z);
+    glm::dvec3 rayOrigin(0.0), ray(0.0);
+    // Use the camera's dedicated conversion to keep ray generation consistent
+    // with camera/view conventions (including orthographic mode).
+    wCam->getScreenToViewDirection(
+        glm::dvec2((double)m_MI.lastX, (double)m_MI.lastY),
+        glm::ivec2((int)width(), (int)height()),
+        rayOrigin,
+        ray
+    );
+    if (glm::length(ray) > 0.0)
+    {
+        ray = glm::normalize(ray);
+    }
 
     uint32_t w = m_framebuffer->extent.width;
     uint32_t h = m_framebuffer->extent.height;

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -19,6 +19,7 @@
 #include <set>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #ifndef PORTABLE
 #include "io/exports/IScanFileWriter.h"
 #endif
@@ -32,6 +33,37 @@ using namespace std::chrono;
 namespace
 {
     constexpr float kColorimetricMaxDistance = 1.7320508f;
+    // Ray-tracing tolerance: numeric_limits<double>::epsilon() is too strict once
+    // camera/orientation transforms introduce tiny floating-point noise.
+    constexpr double kRayAxisEpsilon = 1e-12;
+    constexpr double kRayIntersectionEpsilon = 1e-12;
+
+    inline bool isNearlyZeroRayComponent(double value)
+    {
+        return std::abs(value) <= kRayAxisEpsilon;
+    }
+
+    bool buildPerpendicularBasis(const glm::dvec3& dir, glm::dvec3& axisU, glm::dvec3& axisV)
+    {
+        const double dirNorm = glm::length(dir);
+        if (dirNorm <= kRayAxisEpsilon)
+            return false;
+
+        const glm::dvec3 nDir = dir / dirNorm;
+        const glm::dvec3 ref = (std::abs(nDir.z) < 0.9) ? glm::dvec3(0.0, 0.0, 1.0) : glm::dvec3(0.0, 1.0, 0.0);
+        axisU = glm::cross(nDir, ref);
+        const double uNorm = glm::length(axisU);
+        if (uNorm <= kRayAxisEpsilon)
+            return false;
+        axisU /= uNorm;
+
+        axisV = glm::cross(nDir, axisU);
+        const double vNorm = glm::length(axisV);
+        if (vNorm <= kRayAxisEpsilon)
+            return false;
+        axisV /= vNorm;
+        return true;
+    }
 
     struct PreparedRayTracingDisplayFilter
     {
@@ -2838,6 +2870,11 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
     TreeCell root = m_vTreeCells[m_uRootCell];
     double rootSize = root.m_size;
     glm::dvec3 localRay = glm::inverse(m_rotationToGlobal) * glm::dvec3(globalRay.x, globalRay.y, globalRay.z);
+    if (glm::length(localRay) <= kRayAxisEpsilon)
+    {
+        // Degenerate ray (can happen with unstable view state): avoid undefined behavior.
+        return false;
+    }
     glm::dvec3 localRayOrigin = getLocalCoord(globalRayOrigin);
 
     // Rayon local non altérée pour la détection
@@ -2850,52 +2887,63 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
     int rayModifier = updateRay(localRay, localRayOrigin, rootSize);
 
 
-    double tx0, ty0, tz0, tx1, ty1, tz1;
-    tx0 = (root.m_position[0] - localRayOrigin.x) / localRay.x;
-    ty0 = (root.m_position[1] - localRayOrigin.y) / localRay.y;
-    tz0 = (root.m_position[2] - localRayOrigin.z) / localRay.z;
-    tx1 = (root.m_position[0] + rootSize - localRayOrigin.x) / localRay.x;
-    ty1 = (root.m_position[1] + rootSize - localRayOrigin.y) / localRay.y;
-    tz1 = (root.m_position[2] + rootSize - localRayOrigin.z) / localRay.z;
-	//if a coordinate of local ray is 0, we want still want this times to be definite
-	if (std::fabs(abs(localRay.x)) <= std::numeric_limits<double>::epsilon())
-	{
-		if (root.m_position[0] > localRayOrigin.x)
-			tx0 = DBL_MAX;
-		else tx0 = -DBL_MAX;
-		if (root.m_position[0] + rootSize - localRayOrigin.x>0)
-			tx1 = DBL_MAX;
-		else tx1 = -DBL_MAX;
-	}
-	if (std::fabs(abs(localRay.y)) <= std::numeric_limits<double>::epsilon())
-	{
-		if (root.m_position[1] > localRayOrigin.y)
-			ty0 = DBL_MAX;
-		else ty0 = -DBL_MAX;
-		if (root.m_position[1] + rootSize - localRayOrigin.y > 0)
-			ty1 = DBL_MAX;
-		else ty1 = -DBL_MAX;
-	}
-	if (std::fabs(abs(localRay.z)) <= std::numeric_limits<double>::epsilon())
-	{
-		if (root.m_position[2] > localRayOrigin.z)
-			tz0 = DBL_MAX;
-		else tz0 = -DBL_MAX;
-		if (root.m_position[2] + rootSize - localRayOrigin.z > 0)
-			tz1 = DBL_MAX;
-		else tz1 = -DBL_MAX;
-	}
-
-    double max0, min1;
-    max0 = tx0;
-    if (ty0 > max0) { max0 = ty0; }
-    if (tz0 > max0) { max0 = tz0; }
-    min1 = tx1;
-    if (ty1 < min1) { min1 = ty1; }
-    if (tz1 < min1) { min1 = tz1; }
-
     std::vector<uint32_t> leafList;
-    if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
+    std::unordered_set<uint32_t> uniqueLeafs;
+    auto traceRayFromOrigin = [&](const glm::dvec3& origin)
+    {
+        double rtx0 = (root.m_position[0] - origin.x) / localRay.x;
+        double rty0 = (root.m_position[1] - origin.y) / localRay.y;
+        double rtz0 = (root.m_position[2] - origin.z) / localRay.z;
+        double rtx1 = (root.m_position[0] + rootSize - origin.x) / localRay.x;
+        double rty1 = (root.m_position[1] + rootSize - origin.y) / localRay.y;
+        double rtz1 = (root.m_position[2] + rootSize - origin.z) / localRay.z;
+
+        if (isNearlyZeroRayComponent(localRay.x))
+        {
+            rtx0 = (root.m_position[0] > origin.x) ? DBL_MAX : -DBL_MAX;
+            rtx1 = (root.m_position[0] + rootSize - origin.x > 0) ? DBL_MAX : -DBL_MAX;
+        }
+        if (isNearlyZeroRayComponent(localRay.y))
+        {
+            rty0 = (root.m_position[1] > origin.y) ? DBL_MAX : -DBL_MAX;
+            rty1 = (root.m_position[1] + rootSize - origin.y > 0) ? DBL_MAX : -DBL_MAX;
+        }
+        if (isNearlyZeroRayComponent(localRay.z))
+        {
+            rtz0 = (root.m_position[2] > origin.z) ? DBL_MAX : -DBL_MAX;
+            rtz1 = (root.m_position[2] + rootSize - origin.z > 0) ? DBL_MAX : -DBL_MAX;
+        }
+
+        double max0 = std::max(rtx0, std::max(rty0, rtz0));
+        double min1 = std::min(rtx1, std::min(rty1, rtz1));
+        if (max0 > min1 + kRayIntersectionEpsilon)
+            return;
+
+        std::vector<uint32_t> rayLeafs;
+        traceRay(rtx0, rty0, rtz0, rtx1, rty1, rtz1, m_uRootCell, rayModifier, rayLeafs, localAssembly, origin);
+        for (uint32_t id : rayLeafs)
+        {
+            if (uniqueLeafs.insert(id).second)
+                leafList.push_back(id);
+        }
+    };
+
+    // Central ray.
+    traceRayFromOrigin(localRayOrigin);
+
+    // Supercover strategy: in orthographic mode, trace small origin offsets in the
+    // plane orthogonal to the ray to cover octree boundary edge-cases.
+    if (isOrtho)
+    {
+        glm::dvec3 axisU, axisV;
+        if (buildPerpendicularBasis(trueLocalRay, axisU, axisV))
+        {
+            const double supercoverOffset = std::max(rootSize * 1e-7, 1e-5);
+            const std::array<glm::dvec3, 4> offsets{ axisU, -axisU, axisV, -axisV };
+            for (const glm::dvec3& offsetDir : offsets)
+                traceRayFromOrigin(localRayOrigin + offsetDir * supercoverOffset);
+        }
+    }
 
     //leafList has been computed, now make the list of points 
 	double rayRadius = 0.0015;
@@ -2917,6 +2965,11 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
     TreeCell root = m_vTreeCells[m_uRootCell];
     double rootSize = root.m_size;
     glm::dvec3 localRay = glm::inverse(m_rotationToGlobal) * glm::dvec3(globalRay.x, globalRay.y, globalRay.z);
+    if (glm::length(localRay) <= kRayAxisEpsilon)
+    {
+        // Degenerate ray (can happen with unstable view state): avoid undefined behavior.
+        return false;
+    }
     glm::dvec3 localRayOrigin = getLocalCoord(globalRayOrigin);
 
     // Rayon local non altérée pour la détection
@@ -2928,52 +2981,59 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
 
     int rayModifier = updateRay(localRay, localRayOrigin, rootSize);
 
-    double tx0, ty0, tz0, tx1, ty1, tz1;
-    tx0 = (root.m_position[0] - localRayOrigin.x) / localRay.x;
-    ty0 = (root.m_position[1] - localRayOrigin.y) / localRay.y;
-    tz0 = (root.m_position[2] - localRayOrigin.z) / localRay.z;
-    tx1 = (root.m_position[0] + rootSize - localRayOrigin.x) / localRay.x;
-    ty1 = (root.m_position[1] + rootSize - localRayOrigin.y) / localRay.y;
-    tz1 = (root.m_position[2] + rootSize - localRayOrigin.z) / localRay.z;
-    //if a coordinate of local ray is 0, we want still want this times to be definite
-    if (std::fabs(abs(localRay.x)) <= std::numeric_limits<double>::epsilon())
-    {
-        if (root.m_position[0] > localRayOrigin.x)
-            tx0 = DBL_MAX;
-        else tx0 = -DBL_MAX;
-        if (root.m_position[0] + rootSize - localRayOrigin.x > 0)
-            tx1 = DBL_MAX;
-        else tx1 = -DBL_MAX;
-    }
-    if (std::fabs(abs(localRay.y)) <= std::numeric_limits<double>::epsilon())
-    {
-        if (root.m_position[1] > localRayOrigin.y)
-            ty0 = DBL_MAX;
-        else ty0 = -DBL_MAX;
-        if (root.m_position[1] + rootSize - localRayOrigin.y > 0)
-            ty1 = DBL_MAX;
-        else ty1 = -DBL_MAX;
-    }
-    if (std::fabs(abs(localRay.z)) <= std::numeric_limits<double>::epsilon())
-    {
-        if (root.m_position[2] > localRayOrigin.z)
-            tz0 = DBL_MAX;
-        else tz0 = -DBL_MAX;
-        if (root.m_position[2] + rootSize - localRayOrigin.z > 0)
-            tz1 = DBL_MAX;
-        else tz1 = -DBL_MAX;
-    }
-
-    double max0, min1;
-    max0 = tx0;
-    if (ty0 > max0) { max0 = ty0; }
-    if (tz0 > max0) { max0 = tz0; }
-    min1 = tx1;
-    if (ty1 < min1) { min1 = ty1; }
-    if (tz1 < min1) { min1 = tz1; }
-
     std::vector<uint32_t> leafList;
-    if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
+    std::unordered_set<uint32_t> uniqueLeafs;
+    auto traceRayFromOrigin = [&](const glm::dvec3& origin)
+    {
+        double rtx0 = (root.m_position[0] - origin.x) / localRay.x;
+        double rty0 = (root.m_position[1] - origin.y) / localRay.y;
+        double rtz0 = (root.m_position[2] - origin.z) / localRay.z;
+        double rtx1 = (root.m_position[0] + rootSize - origin.x) / localRay.x;
+        double rty1 = (root.m_position[1] + rootSize - origin.y) / localRay.y;
+        double rtz1 = (root.m_position[2] + rootSize - origin.z) / localRay.z;
+
+        if (isNearlyZeroRayComponent(localRay.x))
+        {
+            rtx0 = (root.m_position[0] > origin.x) ? DBL_MAX : -DBL_MAX;
+            rtx1 = (root.m_position[0] + rootSize - origin.x > 0) ? DBL_MAX : -DBL_MAX;
+        }
+        if (isNearlyZeroRayComponent(localRay.y))
+        {
+            rty0 = (root.m_position[1] > origin.y) ? DBL_MAX : -DBL_MAX;
+            rty1 = (root.m_position[1] + rootSize - origin.y > 0) ? DBL_MAX : -DBL_MAX;
+        }
+        if (isNearlyZeroRayComponent(localRay.z))
+        {
+            rtz0 = (root.m_position[2] > origin.z) ? DBL_MAX : -DBL_MAX;
+            rtz1 = (root.m_position[2] + rootSize - origin.z > 0) ? DBL_MAX : -DBL_MAX;
+        }
+
+        double max0 = std::max(rtx0, std::max(rty0, rtz0));
+        double min1 = std::min(rtx1, std::min(rty1, rtz1));
+        if (max0 > min1 + kRayIntersectionEpsilon)
+            return;
+
+        std::vector<uint32_t> rayLeafs;
+        traceRay(rtx0, rty0, rtz0, rtx1, rty1, rtz1, m_uRootCell, rayModifier, rayLeafs, localAssembly, origin);
+        for (uint32_t id : rayLeafs)
+        {
+            if (uniqueLeafs.insert(id).second)
+                leafList.push_back(id);
+        }
+    };
+
+    traceRayFromOrigin(localRayOrigin);
+    if (isOrtho)
+    {
+        glm::dvec3 axisU, axisV;
+        if (buildPerpendicularBasis(trueLocalRay, axisU, axisV))
+        {
+            const double supercoverOffset = std::max(rootSize * 1e-7, 1e-5);
+            const std::array<glm::dvec3, 4> offsets{ axisU, -axisU, axisV, -axisV };
+            for (const glm::dvec3& offsetDir : offsets)
+                traceRayFromOrigin(localRayOrigin + offsetDir * supercoverOffset);
+        }
+    }
 
     double rayRadius = 0.0015;
     bool success = false;
@@ -3036,14 +3096,16 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
                 glm::dot(rayDirection, pointRay / currDistance);
 
             double projLength = glm::length(proj);
-            proj = proj / projLength;
+            const bool hasValidProjection = projLength > kRayAxisEpsilon;
+            if (hasValidProjection)
+                proj = proj / projLength;
 
 
             if (!isOrtho)
             {
-                if ((rayRadius / projLength) >= 1.0) {
+                if (!hasValidProjection || (rayRadius / projLength) >= 1.0) {
                     hasGoodAngle = true;
-                    currCosAngle = rayRadius / projLength;
+                    currCosAngle = hasValidProjection ? rayRadius / projLength : 1.0;
                     if (currDistance < (dMin*1.05))
                         goodAnglePoints.push_back(point);
                     if (currDistance < dMin)
@@ -3121,8 +3183,9 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
 			currCosAngle = glm::dot(rayDirection, pointRay / currDistance);
 			if(isOrtho)
 				currCosAngle = glm::length(glm::cross(rayDirection, pointRay)) / glm::length(rayDirection);
-			if (((rayRadius / glm::length(proj)) >= 1)&&(!isOrtho)) {
-				currCosAngle = rayRadius / glm::length(proj);
+            double projLength = glm::length(proj);
+			if ((!isOrtho) && (projLength <= kRayAxisEpsilon || (rayRadius / projLength) >= 1)) {
+				currCosAngle = (projLength <= kRayAxisEpsilon) ? 1.0 : rayRadius / projLength;
 			}
 			/*if ((currDistance < (dMin * 1.05)) && (currCosAngle > bestCosAngle) && (!isOrtho))
 			{
@@ -3200,14 +3263,16 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
                 glm::dot(rayDirection, pointRay / currDistance);
 
             double projLength = glm::length(proj);
-            proj = proj / projLength;
+            const bool hasValidProjection = projLength > kRayAxisEpsilon;
+            if (hasValidProjection)
+                proj = proj / projLength;
 
 
             if (!isOrtho)
             {
-                if ((rayRadius / projLength) >= 1.0) {
+                if (!hasValidProjection || (rayRadius / projLength) >= 1.0) {
                     hasGoodAngle = true;
-                    currCosAngle = rayRadius / projLength;
+                    currCosAngle = hasValidProjection ? rayRadius / projLength : 1.0;
                     if (currDistance < (dMin * 1.05))
                         goodAnglePoints.push_back(pointData);
                     if (currDistance < dMin)
@@ -3287,8 +3352,9 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
             currCosAngle = glm::dot(rayDirection, pointRay / currDistance);
             if (isOrtho)
                 currCosAngle = glm::length(glm::cross(rayDirection, pointRay)) / glm::length(rayDirection);
-            if (((rayRadius / glm::length(proj)) >= 1) && (!isOrtho)) {
-                currCosAngle = rayRadius / glm::length(proj);
+            double projLength = glm::length(proj);
+            if ((!isOrtho) && (projLength <= kRayAxisEpsilon || (rayRadius / projLength) >= 1)) {
+                currCosAngle = (projLength <= kRayAxisEpsilon) ? 1.0 : rayRadius / projLength;
             }
             currScore = 1.7 * glm::length(proj) + currDistance;
             if (i == 0)
@@ -3320,6 +3386,12 @@ int EmbeddedScan::updateRay(glm::dvec3& localRay, glm::dvec3& localRayOrigin, co
     int result(0);
     TreeCell root = m_vTreeCells[m_uRootCell];
     double norm = glm::length(localRay);
+    if (norm <= kRayAxisEpsilon)
+    {
+        // Keep a stable default direction to avoid divide-by-zero.
+        localRay = glm::dvec3(0.0, 0.0, 1.0);
+        return result;
+    }
     localRay = localRay / norm;
     for (int loop = 0; loop < 3; loop++)
     {
@@ -3339,7 +3411,6 @@ void EmbeddedScan::traceRay(const double& tx0, const double& ty0, const double& 
     bool isNodeInteresting(false);
 
     double txm, tym, tzm;
-    int currNode;
 
     if ((tx1 < 0.0) || (ty1 < 0.0) || (tz1 < 0.0)) { return; }
     if (cell.m_isLeaf)
@@ -3358,7 +3429,7 @@ void EmbeddedScan::traceRay(const double& tx0, const double& ty0, const double& 
     txm = 0.5*(tx0 + tx1);
     tym = 0.5*(ty0 + ty1);
     tzm = 0.5*(tz0 + tz1);
-	if ((std::fabs(abs(txm)) <= std::numeric_limits<double>::epsilon()) && (abs(tx0) > (0.5*DBL_MAX)) && (abs(tx1) > (0.5*DBL_MAX)))
+	if ((std::abs(txm) <= kRayAxisEpsilon) && (std::abs(tx0) > (0.5*DBL_MAX)) && (std::abs(tx1) > (0.5*DBL_MAX)))
 	{
 		if (localRayOrigin.x < (cell.m_position[0] + 0.5*cell.m_size))
 			txm = DBL_MAX;
@@ -3366,7 +3437,7 @@ void EmbeddedScan::traceRay(const double& tx0, const double& ty0, const double& 
 			txm = -DBL_MAX;
 	}
 		
-	if ((std::fabs(abs(tym)) <= std::numeric_limits<double>::epsilon()) && (abs(ty0) > (0.5*DBL_MAX)) && (abs(ty1) > (0.5*DBL_MAX)))
+	if ((std::abs(tym) <= kRayAxisEpsilon) && (std::abs(ty0) > (0.5*DBL_MAX)) && (std::abs(ty1) > (0.5*DBL_MAX)))
 	{
 		if (localRayOrigin.y < (cell.m_position[1] + 0.5*cell.m_size))
 			tym = DBL_MAX;
@@ -3374,87 +3445,58 @@ void EmbeddedScan::traceRay(const double& tx0, const double& ty0, const double& 
 			tym = -DBL_MAX;
 	}
 
-	if ((std::fabs(abs(tzm)) <= std::numeric_limits<double>::epsilon()) && (abs(tz0) > (0.5*DBL_MAX)) && (abs(tz1) > (0.5*DBL_MAX)))
+	if ((std::abs(tzm) <= kRayAxisEpsilon) && (std::abs(tz0) > (0.5*DBL_MAX)) && (std::abs(tz1) > (0.5*DBL_MAX)))
 	{
 		if (localRayOrigin.z < (cell.m_position[2] + 0.5*cell.m_size))
 			tzm = DBL_MAX;
 		else
 			tzm = -DBL_MAX;
 	}
-    currNode = OctreeRayTracing::firstNode(tx0, ty0, tz0, txm, tym, tzm);
-
-    while (currNode < 8)
+    struct ChildCandidate
     {
-        int ourIndex = rayModifier ^ currNode;
-        bool hasChild(cell.m_children[ourIndex] != NO_CHILD);
+        uint32_t childId = NO_CHILD;
+        double tx0 = 0.0, ty0 = 0.0, tz0 = 0.0;
+        double tx1 = 0.0, ty1 = 0.0, tz1 = 0.0;
+        double tEnter = 0.0;
+    };
 
-        switch (currNode)
+    // Explicitly test every octant range. This supercover-friendly traversal
+    // avoids missing neighbors when rays lie on split boundaries.
+    std::vector<ChildCandidate> candidates;
+    candidates.reserve(8);
+    auto appendCandidate = [&](int traversalIndex, double c_tx0, double c_ty0, double c_tz0, double c_tx1, double c_ty1, double c_tz1)
+    {
+        const int ourIndex = rayModifier ^ traversalIndex;
+        const uint32_t childId = cell.m_children[ourIndex];
+        if (childId == NO_CHILD)
+            return;
+
+        const double tEnter = std::max(c_tx0, std::max(c_ty0, c_tz0));
+        const double tExit = std::min(c_tx1, std::min(c_ty1, c_tz1));
+        if (tEnter > tExit + kRayIntersectionEpsilon || tExit < 0.0)
+            return;
+
+        candidates.push_back({ childId, c_tx0, c_ty0, c_tz0, c_tx1, c_ty1, c_tz1, tEnter });
+    };
+
+    appendCandidate(0, tx0, ty0, tz0, txm, tym, tzm);
+    appendCandidate(1, tx0, ty0, tzm, txm, tym, tz1);
+    appendCandidate(2, tx0, tym, tz0, txm, ty1, tzm);
+    appendCandidate(3, tx0, tym, tzm, txm, ty1, tz1);
+    appendCandidate(4, txm, ty0, tz0, tx1, tym, tzm);
+    appendCandidate(5, txm, ty0, tzm, tx1, tym, tz1);
+    appendCandidate(6, txm, tym, tz0, tx1, ty1, tzm);
+    appendCandidate(7, txm, tym, tzm, tx1, ty1, tz1);
+
+    std::sort(candidates.begin(), candidates.end(),
+        [](const ChildCandidate& a, const ChildCandidate& b)
         {
-        case 0:
-        {
-            if (hasChild) {
-                traceRay(tx0, ty0, tz0, txm, tym, tzm, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = OctreeRayTracing::new_node(txm, tym, tzm, 4, 2, 1);
-            break;
-        }
-        case 1:
-        {
-            if (hasChild) {
-                traceRay(tx0, ty0, tzm, txm, tym, tz1, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = OctreeRayTracing::new_node(txm, tym, tz1, 5, 3, 8);
-            break;
-        }
-        case 2:
-        {
-            if (hasChild) {
-                traceRay(tx0, tym, tz0, txm, ty1, tzm, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = OctreeRayTracing::new_node(txm, ty1, tzm, 6, 8, 3);
-            break;
-        }
-        case 3:
-        {
-            if (hasChild) {
-                traceRay(tx0, tym, tzm, txm, ty1, tz1, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = OctreeRayTracing::new_node(txm, ty1, tz1, 7, 8, 8);
-            break;
-        }
-        case 4:
-        {
-            if (hasChild) {
-                traceRay(txm, ty0, tz0, tx1, tym, tzm, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = OctreeRayTracing::new_node(tx1, tym, tzm, 8, 6, 5);
-            break;
-        }
-        case 5:
-        {
-            if (hasChild) {
-                traceRay(txm, ty0, tzm, tx1, tym, tz1, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = OctreeRayTracing::new_node(tx1, tym, tz1, 8, 7, 8);
-            break;
-        }
-        case 6:
-        {
-            if (hasChild) {
-                traceRay(txm, tym, tz0, tx1, ty1, tzm, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = OctreeRayTracing::new_node(tx1, ty1, tzm, 8, 8, 7);
-            break;
-        }
-        case 7:
-        {
-            if (hasChild) {
-                traceRay(txm, tym, tzm, tx1, ty1, tz1, cell.m_children[ourIndex], rayModifier, leafList, clippingAssembly, localRayOrigin);
-            }
-            currNode = 8;
-            break;
-        }
-        }
+            return a.tEnter < b.tEnter;
+        });
+
+    for (const ChildCandidate& c : candidates)
+    {
+        traceRay(c.tx0, c.ty0, c.tz0, c.tx1, c.ty1, c.tz1, c.childId, rayModifier, leafList, clippingAssembly, localRayOrigin);
     }
 }
 
@@ -4838,11 +4880,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4884,11 +4926,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                 
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4929,11 +4971,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -4974,11 +5016,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                
             zTime = (voxelGrid.m_zMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5019,11 +5061,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5064,11 +5106,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5109,11 +5151,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
               
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
               
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5154,11 +5196,11 @@ void EmbeddedScan::rayTraversal(const glm::dvec3& targetPoint, const VoxelGrid& 
                 xTime = DBL_MAX;
                
             yTime = (voxelGrid.m_yMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
                 
             zTime = (voxelGrid.m_zMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5273,11 +5315,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5319,11 +5361,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5364,11 +5406,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5409,11 +5451,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ + 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5454,11 +5496,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5499,11 +5541,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY + 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5544,11 +5586,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position
@@ -5589,11 +5631,11 @@ void EmbeddedScan::octreeRayTraversal(const glm::dvec3& targetPoint, const Octre
                 xTime = DBL_MAX;
 
             yTime = (tMin + (currY - 1) * voxelSize - currPoint[1]) / ray[1];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.y)) <= std::numeric_limits<double>::epsilon())
                 yTime = DBL_MAX;
 
             zTime = (tMin + (currZ - 1) * voxelSize - currPoint[2]) / ray[2];
-            if (std::fabs(abs(ray.x)) <= std::numeric_limits<double>::epsilon())
+            if (std::fabs(abs(ray.z)) <= std::numeric_limits<double>::epsilon())
                 zTime = DBL_MAX;
 
             //minimal time defines next voxel, and next starting position

--- a/src/pointCloudEngine/OctreeRayTracing.cpp
+++ b/src/pointCloudEngine/OctreeRayTracing.cpp
@@ -10,21 +10,17 @@
 
 int OctreeRayTracing::computeExitPlane(const double& tx0, const double& ty0, const double& tz0)
 {
-	int result(3);
+	// Deterministic tie-breaking is important for orthographic / axis-aligned rays:
+	// when two components are equal we keep a stable priority (X, then Y, then Z).
 	if ((tx0 >= ty0) && (tx0 >= tz0))
 	{
-		result = 0;
+		return 0;
 	}
-	if ((ty0 >= tx0) && (ty0 >= tz0))
+	if (ty0 >= tz0)
 	{
-		result = 1;
+		return 1;
 	}
-	if ((tz0 >= tx0) && (tz0 >= ty0))
-	{
-		result = 2;
-	}
-
-	return result;
+	return 2;
 }
 
 int OctreeRayTracing::firstNode(const double& tx0, const double& ty0, const double& tz0, const double& txm, const double& tym, const double& tzm)
@@ -36,20 +32,26 @@ int OctreeRayTracing::firstNode(const double& tx0, const double& ty0, const doub
 	{
 	case 0:
 	{
-		if (tym < tx0) { result = result | 2; test++; }
-		if (tzm < tx0) { result = result | 1; test++; }
+		// NOTE: use <= so ties are handled consistently on octree boundaries.
+		if (tym <= tx0) { result = result | 2; test++; }
+		if (tzm <= tx0) { result = result | 1; test++; }
+		// Important: do not fall through, only evaluate the entry plane branch.
+		break;
 	}
 
 	case 1:
 	{
-		if (txm < ty0) { result = result | 4; test++; }
-		if (tzm < ty0) { result = result | 1; test++; }
+		if (txm <= ty0) { result = result | 4; test++; }
+		if (tzm <= ty0) { result = result | 1; test++; }
+		// Important: do not fall through, only evaluate the entry plane branch.
+		break;
 	}
 
 	case 2:
 	{
-		if (txm < tz0) { result = result | 4; test++; }
-		if (tym < tz0) { result = result | 2; test++; }
+		if (txm <= tz0) { result = result | 4; test++; }
+		if (tym <= tz0) { result = result | 2; test++; }
+		break;
 	}
 	}
 	return result;
@@ -57,14 +59,15 @@ int OctreeRayTracing::firstNode(const double& tx0, const double& ty0, const doub
 
 int OctreeRayTracing::new_node(const double& a, const double& b, const double& c, const int& p, const int& q, const int& r)
 {
-	if (a < b)
+	// NOTE: <= keeps deterministic behavior when crossing voxel/octree boundaries.
+	if (a <= b)
 	{
-		if (a < c) { return p; }
+		if (a <= c) { return p; }
 		else { return r; }
 	}
 	else
 	{
-		if (b < c) { return q; }
+		if (b <= c) { return q; }
 		else { return r; }
 	}
 }


### PR DESCRIPTION
### Motivation
- Ray-tracing and picking could fail or behave inconsistently for orthographic views or when the computed ray had tiny/zero components due to camera precision, causing NaNs or missed octree neighbors.
- Traversal and intersection logic relied on strict equality/tiny epsilons and could miss points on octree boundaries or produce undefined behavior on degenerate rays.

### Description
- Add `prepareStableRayForScene` helpers and use them in `ARayTracingContext`, `ContextPickColorimetric`, and `ContextPickTemperature` to normalize rays and shift the origin behind the visible bbox in orthographic mode to ensure consistent front-facing ray tests.
- Replace ad-hoc screen->ray math in `VulkanViewport::generateRaytracingInfos` with a single `getScreenToViewDirection` call to produce a normalized, consistent `ray` and `rayOrigin` that respect camera conventions.
- In `EmbeddedScan` introduce numeric tolerances (`kRayAxisEpsilon`, `kRayIntersectionEpsilon`), helper `buildPerpendicularBasis`, and robust checks for degenerate rays, and implement a supercover tracing strategy that probes small offsets in the plane orthogonal to the ray for orthographic mode to avoid missing edge cases.
- Make ray-octree traversal safer by collecting unique leaf IDs, replacing fragile per-axis zero checks with `isNearlyZeroRayComponent`, sorting child candidates by entry time and traversing all valid octants to provide stable supercover-friendly traversal, and add fallbacks for near-zero projection lengths in point selection logic.
- Improve determinism in `OctreeRayTracing` by using `<=` comparisons in `computeExitPlane`, `firstNode`, and `new_node` to ensure stable tie-breaking on axis-aligned rays.
- Add comments and small API/logic changes to avoid divide-by-zero and undefined behavior and to normalize results returned by ray-tracing calls (`rayTracing`/`rayTracingWithPoint`) when rays are invalid.

### Testing
- Verified the project builds successfully after changes by running `make` (local build) with no build errors.
- Executed the test suite via `ctest` and checked core ray-tracing related unit/integration tests; all executed tests passed with no regressions observed.
- Performed smoke checks on picking workflows (orthographic and perspective) to validate that colorimetric and temperature pickers return stable points under orthographic views and no NaNs are produced by ray-tracing functions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d810f74010832fb85412a2afe7a4a3)