### PR TITLE
Improve ray-picking stability and add detailed ray-tracing diagnostics

### DIFF
--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -485,6 +485,17 @@ ClickInfo VulkanViewport::generateRaytracingInfos(const WritePtr<CameraNode>& wC
 
     glm::dvec3 ray = glm::dvec3(pickPos.x - pickPos0.x, pickPos.y - pickPos0.y, pickPos.z - pickPos0.z);
 
+    // PASS-1 instrumentation:
+    // Log raw picking ray generation at the viewport boundary to correlate camera angle
+    // with downstream octree traversal behavior.
+    Logger::log(LoggerMode::rayTracingLog)
+        << "[PICK_DBG][ViewportRay] mouse=(" << m_MI.lastX << "," << m_MI.lastY << ")"
+        << " rayOrigin=(" << rayOrigin.x << "," << rayOrigin.y << "," << rayOrigin.z << ")"
+        << " ray=(" << ray.x << "," << ray.y << "," << ray.z << ")"
+        << " fov=" << wCam->getFovy()
+        << " heightAt1m=" << wCam->getHeightAt1m()
+        << Logger::endl;
+
     uint32_t w = m_framebuffer->extent.width;
     uint32_t h = m_framebuffer->extent.height;
 

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -32,6 +32,9 @@ using namespace std::chrono;
 namespace
 {
     constexpr float kColorimetricMaxDistance = 1.7320508f;
+    // Pass-2 stability epsilon used to classify near-zero normalized ray components.
+    // This avoids sign flips caused by floating noise in orthographic axis-aligned views.
+    constexpr double kRaySignEpsilon = 1e-12;
 
     struct PreparedRayTracingDisplayFilter
     {
@@ -2897,6 +2900,24 @@ bool EmbeddedScan::beginRayTracing(const glm::dvec3& globalRay, const glm::dvec3
     std::vector<uint32_t> leafList;
     if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
 
+    // PASS-1 instrumentation:
+    // Capture the complete setup of octree ray traversal to diagnose angular failures in ortho mode.
+    Logger::log(LoggerMode::rayTracingLog)
+        << "[PICK_DBG][BeginRayTracing]"
+        << " isOrtho=" << isOrtho
+        << " globalRay=(" << globalRay.x << "," << globalRay.y << "," << globalRay.z << ")"
+        << " globalRayOrigin=(" << globalRayOrigin.x << "," << globalRayOrigin.y << "," << globalRayOrigin.z << ")"
+        << " localRayNormalized=(" << trueLocalRay.x << "," << trueLocalRay.y << "," << trueLocalRay.z << ")"
+        << " localRayTraversal=(" << localRay.x << "," << localRay.y << "," << localRay.z << ")"
+        << " localRayOriginTraversal=(" << localRayOrigin.x << "," << localRayOrigin.y << "," << localRayOrigin.z << ")"
+        << " rayModifier=" << rayModifier
+        << " tx0/ty0/tz0=(" << tx0 << "," << ty0 << "," << tz0 << ")"
+        << " tx1/ty1/tz1=(" << tx1 << "," << ty1 << "," << tz1 << ")"
+        << " max0=" << max0
+        << " min1=" << min1
+        << " leafCount=" << leafList.size()
+        << Logger::endl;
+
     //leafList has been computed, now make the list of points 
 	double rayRadius = 0.0015;
 
@@ -2975,6 +2996,24 @@ bool EmbeddedScan::beginRayTracingWithPoint(const glm::dvec3& globalRay, const g
     std::vector<uint32_t> leafList;
     if (max0 < min1) { traceRay(tx0, ty0, tz0, tx1, ty1, tz1, m_uRootCell, rayModifier, leafList, localAssembly, localRayOrigin); }
 
+    // PASS-1 instrumentation:
+    // Same diagnostics path for feature variants that require point payload (temperature/colorimetric).
+    Logger::log(LoggerMode::rayTracingLog)
+        << "[PICK_DBG][BeginRayTracingWithPoint]"
+        << " isOrtho=" << isOrtho
+        << " globalRay=(" << globalRay.x << "," << globalRay.y << "," << globalRay.z << ")"
+        << " globalRayOrigin=(" << globalRayOrigin.x << "," << globalRayOrigin.y << "," << globalRayOrigin.z << ")"
+        << " localRayNormalized=(" << trueLocalRay.x << "," << trueLocalRay.y << "," << trueLocalRay.z << ")"
+        << " localRayTraversal=(" << localRay.x << "," << localRay.y << "," << localRay.z << ")"
+        << " localRayOriginTraversal=(" << localRayOrigin.x << "," << localRayOrigin.y << "," << localRayOrigin.z << ")"
+        << " rayModifier=" << rayModifier
+        << " tx0/ty0/tz0=(" << tx0 << "," << ty0 << "," << tz0 << ")"
+        << " tx1/ty1/tz1=(" << tx1 << "," << ty1 << "," << tz1 << ")"
+        << " max0=" << max0
+        << " min1=" << min1
+        << " leafCount=" << leafList.size()
+        << Logger::endl;
+
     double rayRadius = 0.0015;
     bool success = false;
     tls::Point localPoint{};
@@ -3002,6 +3041,10 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
 
 	glm::dvec3 result(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
     const PreparedRayTracingDisplayFilter preparedFilter = prepareRayTracingDisplayFilter(displayFilterSettings);
+    uint64_t testedPoints = 0;
+    uint64_t clippedOutPoints = 0;
+    uint64_t displayFilteredOutPoints = 0;
+    uint64_t backFacingRejectedPoints = 0;
 
 	for (int leafStep = 0; leafStep < (int)leafList.size(); leafStep++)
 	{
@@ -3012,13 +3055,16 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
 
         for (const tls::Point& pointData : cellPoints)
         {
+            ++testedPoints;
             glm::dvec3 point(pointData.x, pointData.y, pointData.z);
             if (!localClippingAssembly.testPoint(glm::dvec4(point, 1.0)))
             {
+                ++clippedOutPoints;
                 continue;
             }
             if (preparedFilter.anyFilterEnabled && isPointRejectedByDisplayFilters(preparedFilter, pointData, getGlobalCoord(point)))
             {
+                ++displayFilteredOutPoints;
                 continue;
             }
 
@@ -3026,6 +3072,7 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
             currDistance = glm::length(pointRay);
             if (glm::dot(pointRay, rayDirection) < 0)
             {
+                ++backFacingRejectedPoints;
                 continue;
             }
             success = true;
@@ -3150,6 +3197,17 @@ glm::dvec3 EmbeddedScan::findBestPointIterative(const std::vector<uint32_t>& lea
 			}
 		}
 	}
+    Logger::log(LoggerMode::rayTracingLog)
+        << "[PICK_DBG][FindBestPointIterative]"
+        << " isOrtho=" << isOrtho
+        << " leafCount=" << leafList.size()
+        << " tested=" << testedPoints
+        << " clippedOut=" << clippedOutPoints
+        << " displayFilteredOut=" << displayFilteredOutPoints
+        << " rejectedDot=" << backFacingRejectedPoints
+        << " success=" << success
+        << " result=(" << result.x << "," << result.y << "," << result.z << ")"
+        << Logger::endl;
 	return getGlobalCoord(result);
 }
 
@@ -3166,6 +3224,10 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
 
     glm::dvec3 result(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
     const PreparedRayTracingDisplayFilter preparedFilter = prepareRayTracingDisplayFilter(displayFilterSettings);
+    uint64_t testedPoints = 0;
+    uint64_t clippedOutPoints = 0;
+    uint64_t displayFilteredOutPoints = 0;
+    uint64_t backFacingRejectedPoints = 0;
 
     for (int leafStep = 0; leafStep < (int)leafList.size(); leafStep++)
     {
@@ -3176,13 +3238,16 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
 
         for (const tls::Point& pointData : cellPoints)
         {
+            ++testedPoints;
             glm::dvec3 point(pointData.x, pointData.y, pointData.z);
             if (!localClippingAssembly.testPoint(glm::dvec4(point, 1.0)))
             {
+                ++clippedOutPoints;
                 continue;
             }
             if (preparedFilter.anyFilterEnabled && isPointRejectedByDisplayFilters(preparedFilter, pointData, getGlobalCoord(point)))
             {
+                ++displayFilteredOutPoints;
                 continue;
             }
 
@@ -3190,6 +3255,7 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
             currDistance = glm::length(pointRay);
             if (glm::dot(pointRay, rayDirection) < 0)
             {
+                ++backFacingRejectedPoints;
                 continue;
             }
             success = true;
@@ -3312,6 +3378,17 @@ glm::dvec3 EmbeddedScan::findBestPointIterativeWithPoint(const std::vector<uint3
             }
         }
     }
+    Logger::log(LoggerMode::rayTracingLog)
+        << "[PICK_DBG][FindBestPointIterativeWithPoint]"
+        << " isOrtho=" << isOrtho
+        << " leafCount=" << leafList.size()
+        << " tested=" << testedPoints
+        << " clippedOut=" << clippedOutPoints
+        << " displayFilteredOut=" << displayFilteredOutPoints
+        << " rejectedDot=" << backFacingRejectedPoints
+        << " success=" << success
+        << " result=(" << result.x << "," << result.y << "," << result.z << ")"
+        << Logger::endl;
     return getGlobalCoord(result);
 }
 
@@ -3320,16 +3397,46 @@ int EmbeddedScan::updateRay(glm::dvec3& localRay, glm::dvec3& localRayOrigin, co
     int result(0);
     TreeCell root = m_vTreeCells[m_uRootCell];
     double norm = glm::length(localRay);
+    glm::dvec3 localRayBeforeNormalization = localRay;
+    if (norm <= std::numeric_limits<double>::epsilon())
+    {
+        // Defensive guard: should not happen in normal picking flow, but avoids undefined
+        // behavior if an invalid zero-length ray reaches this stage.
+        Logger::log(LoggerMode::rayTracingLog)
+            << "[PICK_DBG][UpdateRay] invalid ray norm=" << norm
+            << " inputRay=(" << localRayBeforeNormalization.x << "," << localRayBeforeNormalization.y << "," << localRayBeforeNormalization.z << ")"
+            << Logger::endl;
+        return result;
+    }
     localRay = localRay / norm;
+    glm::dvec3 localRayOriginBeforeRemap = localRayOrigin;
     for (int loop = 0; loop < 3; loop++)
     {
-        if (localRay[loop] < 0)
+        // Pass-2 fix: treat near-zero values as exact zero before sign remapping.
+        // Without this, tiny negative noise (e.g. -1e-17) flips octree parity.
+        if (std::abs(localRay[loop]) <= kRaySignEpsilon)
+        {
+            localRay[loop] = 0.0;
+            continue;
+        }
+
+        if (localRay[loop] < -kRaySignEpsilon)
         {
             localRay[loop] = -localRay[loop];
             localRayOrigin[loop] = 2 * root.m_position[loop] + rootSize - localRayOrigin[loop];
             result += 1 << (2 - loop);
         }
     }
+    // PASS-1 instrumentation:
+    // Log remapping decisions (rayModifier and mirrored origin) which are critical for octree child indexing.
+    Logger::log(LoggerMode::rayTracingLog)
+        << "[PICK_DBG][UpdateRay]"
+        << " inputRay=(" << localRayBeforeNormalization.x << "," << localRayBeforeNormalization.y << "," << localRayBeforeNormalization.z << ")"
+        << " normalizedRay=(" << localRay.x << "," << localRay.y << "," << localRay.z << ")"
+        << " originBefore=(" << localRayOriginBeforeRemap.x << "," << localRayOriginBeforeRemap.y << "," << localRayOriginBeforeRemap.z << ")"
+        << " originAfter=(" << localRayOrigin.x << "," << localRayOrigin.y << "," << localRayOrigin.z << ")"
+        << " rayModifier=" << result
+        << Logger::endl;
     return result;
 }
 


### PR DESCRIPTION
### Motivation
- Add diagnostic instrumentation to capture ray generation and octree traversal state to diagnose picking failures, especially in orthographic views. 
- Prevent unstable sign flips and undefined behavior caused by tiny floating-point noise in ray components during octree traversal. 

### Description
- Added verbose PASS-1 logging in `VulkanViewport::generateRaytracingInfos`, `EmbeddedScan::beginRayTracing`, and `EmbeddedScan::beginRayTracingWithPoint` to record mouse, ray, origin, normalized/local rays, traversal parameters and leaf counts using `Logger::log(LoggerMode::rayTracingLog)`. 
- Added counters and logging in `findBestPointIterative` and `findBestPointIterativeWithPoint` to report `tested`, `clippedOut`, `displayFilteredOut`, `rejectedDot`, `leafCount`, `success` and resulting point for visibility diagnostics. 
- Implemented a stability epsilon `kRaySignEpsilon` and a defensive guard in `updateRay` to treat near-zero ray components as exact zero and to early-return/log on zero-length rays, preventing parity flips during octree child remapping; also added remapping instrumentation log. 

### Testing
- Built the codebase successfully with the modified files using the project build system (`cmake`/`make`).
- Ran the automated test suite (`ctest` / `make test`) and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c7ae16fc832faf33fec63003fde3)