### PR TITLE
Stabilize ray sign detection and guard against zero-length rays in updateRay

### DIFF
--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -32,6 +32,9 @@ using namespace std::chrono;
 namespace
 {
     constexpr float kColorimetricMaxDistance = 1.7320508f;
+    // Pass-2 stability epsilon used to classify near-zero normalized ray components.
+    // This avoids sign flips caused by floating noise in orthographic axis-aligned views.
+    constexpr double kRaySignEpsilon = 1e-12;
 
     struct PreparedRayTracingDisplayFilter
     {
@@ -3320,10 +3323,24 @@ int EmbeddedScan::updateRay(glm::dvec3& localRay, glm::dvec3& localRayOrigin, co
     int result(0);
     TreeCell root = m_vTreeCells[m_uRootCell];
     double norm = glm::length(localRay);
+    if (norm <= std::numeric_limits<double>::epsilon())
+    {
+        // Defensive guard: should not happen in normal picking flow, but avoids undefined
+        // behavior if an invalid zero-length ray reaches this stage.
+        return result;
+    }
     localRay = localRay / norm;
     for (int loop = 0; loop < 3; loop++)
     {
-        if (localRay[loop] < 0)
+        // Pass-2 fix: treat near-zero values as exact zero before sign remapping.
+        // Without this, tiny negative noise (e.g. -1e-17) flips octree parity.
+        if (std::abs(localRay[loop]) <= kRaySignEpsilon)
+        {
+            localRay[loop] = 0.0;
+            continue;
+        }
+
+        if (localRay[loop] < -kRaySignEpsilon)
         {
             localRay[loop] = -localRay[loop];
             localRayOrigin[loop] = 2 * root.m_position[loop] + rootSize - localRayOrigin[loop];


### PR DESCRIPTION
### Motivation

- Prevent unstable octree parity flips caused by tiny floating-point noise on axis-aligned/orthographic rays and avoid undefined behavior when a zero-length ray is encountered.

### Description

- Introduce `kRaySignEpsilon` to classify near-zero normalized ray components and avoid sign flips due to floating-point noise. 
- Add a defensive guard in `updateRay` that returns early if the input ray has (near-)zero length to avoid division by zero. 
- Treat components with absolute value <= `kRaySignEpsilon` as exact zero and adjust the sign test to compare against `-kRaySignEpsilon` for stability; add explanatory comments. 

### Testing

- Project was built successfully using the normal build system (`cmake`/`make`).
- Existing unit and integration tests (including point-picking related tests) were executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c7ae16fc832faf33fec63003fde3)