### PR TITLE
Stabilize ray sign handling and guard against zero-length rays in EmbeddedScan

### DIFF
--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -32,6 +32,8 @@ using namespace std::chrono;
 namespace
 {
     constexpr float kColorimetricMaxDistance = 1.7320508f;
+    // Stabilize ray sign classification for near-zero components (orthographic axis-aligned views).
+    constexpr double kRaySignEpsilon = 1e-12;
 
     struct PreparedRayTracingDisplayFilter
     {
@@ -3319,11 +3321,21 @@ int EmbeddedScan::updateRay(glm::dvec3& localRay, glm::dvec3& localRayOrigin, co
 {
     int result(0);
     TreeCell root = m_vTreeCells[m_uRootCell];
-    double norm = glm::length(localRay);
+    const double norm = glm::length(localRay);
+
+    // Defensive guard: degenerate ray cannot be normalized safely.
+    if (norm <= std::numeric_limits<double>::epsilon())
+        return result;
+
     localRay = localRay / norm;
     for (int loop = 0; loop < 3; loop++)
     {
-        if (localRay[loop] < 0)
+        // Freeze near-zero components to avoid unstable sign flips around +/- epsilon.
+        if (std::abs(localRay[loop]) <= kRaySignEpsilon)
+            localRay[loop] = 0.0;
+
+        // Mirror remapping must only apply to robustly negative components.
+        if (localRay[loop] < -kRaySignEpsilon)
         {
             localRay[loop] = -localRay[loop];
             localRayOrigin[loop] = 2 * root.m_position[loop] + rootSize - localRayOrigin[loop];


### PR DESCRIPTION
### Motivation
- Ray sign flips and normalization of degenerate rays caused unstable behavior for near-axis-aligned (orthographic) views and could produce nondeterministic cell mirroring.

### Description
- Added a `kRaySignEpsilon` constant and hardened `updateRay` to freeze near-zero ray components by snapping values with `abs(component) <= kRaySignEpsilon` to `0.0` to avoid unstable sign flips.
- Added a defensive guard in `updateRay` to skip normalization when the computed `norm` is effectively zero using `std::numeric_limits<double>::epsilon()`.
- Modified the mirror remapping logic in `updateRay` to only treat components as negative when they are less than `-kRaySignEpsilon`, and made the local `norm` variable `const` for clarity.

### Testing
- Project build and compilation were executed and completed successfully.
- Ran the unit test suite and the point-cloud ray-tracing regression tests, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e8a04650832fae7a65cfedfb7550)