### PR TITLE
Fix clipping-mode UI sync and persist ortho grid linewidth correctly

### DIFF
--- a/src/gui/toolBars/ToolBarClippingParameters.cpp
+++ b/src/gui/toolBars/ToolBarClippingParameters.cpp
@@ -74,7 +74,10 @@ void ToolBarClippingParameters::onValues(IGuiData* data)
     m_ui.lineEdit_defaultMin->setValue(castData->m_minClipDistance);
     m_ui.lineEdit_defaultMax->setValue(castData->m_maxClipDistance);
     m_ui.lineEdit_defaultLengthThreshold->setValue(castData->m_lengthThresholdClip);
+    // Keep both radio buttons explicitly synchronized with the persisted mode.
+    // Relying on only one side is fragile when UI state evolves.
     m_ui.exteriorRadioButton->setChecked(castData->m_mode == ClippingMode::showExterior);
+    m_ui.interiorRadioButton->setChecked(castData->m_mode == ClippingMode::showInterior);
 
     blockAllSignals(false);
 }
@@ -84,6 +87,10 @@ void ToolBarClippingParameters::blockAllSignals(bool value)
     m_ui.lineEdit_defaultMin->blockSignals(value);
     m_ui.lineEdit_defaultMax->blockSignals(value);
     m_ui.lineEdit_defaultLengthThreshold->blockSignals(value);
+    // Block radio button signals while restoring persisted values
+    // to avoid spurious SetDefaultClippingMode controls.
+    m_ui.exteriorRadioButton->blockSignals(value);
+    m_ui.interiorRadioButton->blockSignals(value);
 }
 
 void ToolBarClippingParameters::sendDefaultDistances()

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -471,7 +471,9 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 	json[Key_Ortho_Grid_Active] = params.m_orthoGridActive;
 	json[Key_Ortho_Grid_Color] = { params.m_orthoGridColor.r, params.m_orthoGridColor.g, params.m_orthoGridColor.b, params.m_orthoGridColor.a };
 	json[Key_Ortho_Grid_Step] = params.m_orthoGridStep;
-	json[Key_Ortho_Grid_Step] = params.m_orthoGridLineWidth;
+	// NOTE: linewidth must be persisted under its dedicated key.
+	// Writing it to Key_Ortho_Grid_Step corrupts both step/linewidth on reload.
+	json[Key_Ortho_Grid_Linewidth] = params.m_orthoGridLineWidth;
 }
 
 void ExportViewPointData(nlohmann::json& json, const ViewPointData& data)

--- a/src/models/project/ProjectInfos.cpp
+++ b/src/models/project/ProjectInfos.cpp
@@ -9,6 +9,7 @@ ProjectInfos::ProjectInfos()
 	, m_defaultMinClipDistance(0.0)
 	, m_defaultMaxClipDistance(0.5)
 	, m_defaultLengthThresholdClip(0.0)
+	, m_defaultClipMode(ClippingMode::showExterior)
 	, m_defaultMinRampDistance(0.0)
 	, m_defaultMaxRampDistance(0.5)
 {
@@ -32,8 +33,12 @@ ProjectInfos::ProjectInfos(const ProjectInfos& p)
 	this->m_defaultMinClipDistance = p.m_defaultMinClipDistance;
 	this->m_defaultMaxClipDistance = p.m_defaultMaxClipDistance;
 	this->m_defaultLengthThresholdClip = p.m_defaultLengthThresholdClip;
+	// Keep clipping defaults consistent across ProjectInfos copies.
+	this->m_defaultClipMode = p.m_defaultClipMode;
 	this->m_defaultMinRampDistance = p.m_defaultMinRampDistance;
 	this->m_defaultMaxRampDistance = p.m_defaultMaxRampDistance;
+	// Keep ramp defaults consistent across ProjectInfos copies.
+	this->m_defaultRampSteps = p.m_defaultRampSteps;
 	this->m_defaultScan = p.m_defaultScan;
 	this->m_importScanTranslation = p.m_importScanTranslation;
 	this->m_id = p.m_id;


### PR DESCRIPTION
### Motivation
- Ensure the default clipping mode is consistently restored in the UI and avoid spurious controls firing while restoring state.
- Fix a serialization bug that wrote the orthographic grid line width under the wrong JSON key, which corrupted values on reload.
- Ensure `ProjectInfos` carries the default clipping mode and ramp steps when constructed or copied so defaults remain consistent.

### Description
- In `ToolBarClippingParameters.cpp` explicitly set both `exteriorRadioButton` and `interiorRadioButton` from persisted `m_mode` and block their signals during restore to avoid emitting `SetDefaultClippingMode` while loading values.
- In `DataSerializer.cpp` write `params.m_orthoGridLineWidth` to `Key_Ortho_Grid_Linewidth` instead of overwriting `Key_Ortho_Grid_Step`, with a comment explaining the fix.
- In `ProjectInfos.cpp` initialize `m_defaultClipMode` in the default constructor and copy `m_defaultClipMode` and `m_defaultRampSteps` in the copy constructor to preserve clipping/ramp defaults across copies.

### Testing
- Ran the automated test suite (`ctest`) after the change and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9163dbb6c832f8aec24b1c73fcf73)