### PR TITLE
Add 'Cartoon RGB' UI render mode (temporary routing to RGB pipeline)

### DIFF
--- a/include/gui/texts/RenderingTexts.hpp
+++ b/include/gui/texts/RenderingTexts.hpp
@@ -6,6 +6,7 @@
 //RenderingTypes 
 #define TEXT_RENDERING_TYPES_INTENSITY QObject::tr("Intensity")
 #define TEXT_RENDERING_TYPES_RGB QObject::tr("RGB")
+#define TEXT_RENDERING_TYPES_CARTOON_RGB QObject::tr("Cartoon RGB")
 #define TEXT_RENDERING_TYPES_INTENSITY_RGB_COMBINED QObject::tr("Intensity & RGB")
 #define TEXT_RENDERING_TYPES_GREY_COLORED QObject::tr("Colored")
 #define TEXT_RENDERING_TYPES_SCANS_COLOR QObject::tr("Colored by Scans")

--- a/include/pointCloudEngine/RenderingTypes.h
+++ b/include/pointCloudEngine/RenderingTypes.h
@@ -11,6 +11,9 @@ enum class UiRenderMode
 {
     Intensity,
     RGB,
+    // NOTE: Pass 1 - dedicated UI mode for upcoming cartoon RGB rendering.
+    // It is intentionally placed right after RGB for combo ordering.
+    Cartoon_RGB,
     IntensityRGB_Combined,
     Grey_Colored,
     Scans_Color,
@@ -47,6 +50,9 @@ std::unordered_map<UiRenderMode, std::string> getTradUiRenderMode();
 const static std::unordered_map<UiRenderMode, RenderMode> correspUiRenderMode = {
     { UiRenderMode::Intensity, RenderMode::Intensity},
     { UiRenderMode::RGB, RenderMode::RGB},
+    // NOTE: Pass 1 - temporary routing to RGB pipeline.
+    // A dedicated GPU RenderMode/shader is introduced in pass 2.
+    { UiRenderMode::Cartoon_RGB, RenderMode::RGB},
     { UiRenderMode::IntensityRGB_Combined, RenderMode::IntensityRGB_Combined},
     { UiRenderMode::Grey_Colored, RenderMode::Grey_Colored},
     { UiRenderMode::Scans_Color, RenderMode::Grey_Colored},

--- a/src/gui/toolBars/ToolBarRenderSettings.cpp
+++ b/src/gui/toolBars/ToolBarRenderSettings.cpp
@@ -31,7 +31,7 @@ ToolBarRenderSettings::ToolBarRenderSettings(IDataDispatcher &dataDispatcher, QW
     {
 		//fixeme (Aurélien) to remove when I & RGB done
 #ifndef _DEBUG
-		if (iterator == 2)
+		if (UiRenderMode(iterator) == UiRenderMode::IntensityRGB_Combined)
 			continue;
 #endif // !_DEBUG
         m_ui.comboBox_renderMode->addItem(QString::fromStdString(tradUiRenderMode.at(UiRenderMode(iterator))),QVariant(iterator));
@@ -422,6 +422,7 @@ void ToolBarRenderSettings::switchRenderMode(const int& mode)
 		}
 		break;
 		case UiRenderMode::RGB:
+		case UiRenderMode::Cartoon_RGB: // Pass 1: UI behavior aligned with RGB until cartoon shader pass.
 		{
             showSaturationLuminance();
             m_ui.ramp_options->setVisible(false);

--- a/src/pointCloudEngine/RenderingTypes.cpp
+++ b/src/pointCloudEngine/RenderingTypes.cpp
@@ -7,6 +7,7 @@ std::unordered_map<UiRenderMode, std::string>  getTradUiRenderMode()
 {
 	return std::unordered_map<UiRenderMode, std::string>({
 		{ UiRenderMode::RGB, TEXT_RENDERING_TYPES_RGB.toStdString()},
+		{ UiRenderMode::Cartoon_RGB, TEXT_RENDERING_TYPES_CARTOON_RGB.toStdString()},
 	    { UiRenderMode::Intensity, TEXT_RENDERING_TYPES_INTENSITY.toStdString()},
 	    { UiRenderMode::IntensityRGB_Combined, TEXT_RENDERING_TYPES_INTENSITY_RGB_COMBINED.toStdString()},
 	    { UiRenderMode::Grey_Colored, TEXT_RENDERING_TYPES_GREY_COLORED.toStdString()},


### PR DESCRIPTION
### Motivation
- Introduce a UI entry for the upcoming "Cartoon RGB" rendering mode while keeping the current GPU pipeline stable by temporarily routing the new UI mode to the existing RGB rendering path.

### Description
- Adds `TEXT_RENDERING_TYPES_CARTOON_RGB`, the `UiRenderMode::Cartoon_RGB` enum, and registers it in `getTradUiRenderMode()`, maps it to `RenderMode::RGB` in `correspUiRenderMode` as a temporary routing, adds the mode to the render-mode combo and treats it like `RGB` in `ToolBarRenderSettings::switchRenderMode`, and replaces a hardcoded combo exclusion index with an enum-based check for `IntensityRGB_Combined`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da67a81140832f8e2d297945225275)