### PR TITLE
Add Cartoon RGB render mode with shaders and renderer integration

### DIFF
--- a/include/gui/texts/RenderingTexts.hpp
+++ b/include/gui/texts/RenderingTexts.hpp
@@ -6,6 +6,7 @@
 //RenderingTypes 
 #define TEXT_RENDERING_TYPES_INTENSITY QObject::tr("Intensity")
 #define TEXT_RENDERING_TYPES_RGB QObject::tr("RGB")
+#define TEXT_RENDERING_TYPES_CARTOON_RGB QObject::tr("Cartoon RGB")
 #define TEXT_RENDERING_TYPES_INTENSITY_RGB_COMBINED QObject::tr("Intensity & RGB")
 #define TEXT_RENDERING_TYPES_GREY_COLORED QObject::tr("Colored")
 #define TEXT_RENDERING_TYPES_SCANS_COLOR QObject::tr("Colored by Scans")

--- a/include/pointCloudEngine/RenderingTypes.h
+++ b/include/pointCloudEngine/RenderingTypes.h
@@ -11,6 +11,9 @@ enum class UiRenderMode
 {
     Intensity,
     RGB,
+    // NOTE: Pass 1 - dedicated UI mode for upcoming cartoon RGB rendering.
+    // It is intentionally placed right after RGB for combo ordering.
+    Cartoon_RGB,
     IntensityRGB_Combined,
     Grey_Colored,
     Scans_Color,
@@ -27,6 +30,7 @@ enum RenderMode
 {
     Intensity,
     RGB,
+    RGB_Cartoon,
     IntensityRGB_Combined,
     Grey_Colored,
     Flat,
@@ -47,6 +51,7 @@ std::unordered_map<UiRenderMode, std::string> getTradUiRenderMode();
 const static std::unordered_map<UiRenderMode, RenderMode> correspUiRenderMode = {
     { UiRenderMode::Intensity, RenderMode::Intensity},
     { UiRenderMode::RGB, RenderMode::RGB},
+    { UiRenderMode::Cartoon_RGB, RenderMode::RGB_Cartoon},
     { UiRenderMode::IntensityRGB_Combined, RenderMode::IntensityRGB_Combined},
     { UiRenderMode::Grey_Colored, RenderMode::Grey_Colored},
     { UiRenderMode::Scans_Color, RenderMode::Grey_Colored},

--- a/projects/OpenScanTools/OpenScanTools.vcxproj
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj
@@ -2076,6 +2076,8 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\shaders\blocks\block_point_i_main_fake_color_vert.glsl" />
+    <!-- Pass 2 (Cartoon RGB): keep the GLSL block declared in the project so shader dependencies are explicit. -->
+    <None Include="..\..\src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl" />
     <CustomBuild Include="..\..\src\shaders\blend.frag">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
@@ -2354,6 +2356,19 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
       <Command Condition="'$(Configuration)|$(Platform)'=='Portable_Prod|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release_Prod|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
     </CustomBuild>
+    <CustomBuild Include="..\..\src\shaders\point_rgb_cartoon.vert">
+      <!-- Pass 2 (Cartoon RGB): explicit dependencies to trigger shader recompilation when blocks change. -->
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release_Prod|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Portable_Prod|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Portable|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Portable|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Portable_Prod|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Prod|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+    </CustomBuild>
     <CustomBuild Include="..\..\src\shaders\point_i_colored.vert">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_i_main_colored_vert.glsl</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_i_main_colored_vert.glsl</AdditionalInputs>
@@ -2422,6 +2437,19 @@ xcopy /y "$(SolutionDir)projects\OpenScanTools\OpenScanTools.ico" "$(SolutionDir
     <CustomBuild Include="..\..\src\shaders\point_rgb_standard_clip.vert">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_standard_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_standard_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Portable|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Portable_Prod|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Prod|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
+    </CustomBuild>
+    <CustomBuild Include="..\..\src\shaders\point_rgb_cartoon_clip.vert">
+      <!-- Pass 2 (Cartoon RGB): explicit dependencies to trigger shader recompilation when blocks change. -->
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Portable|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Portable_Prod|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release_Prod|x64'">$(SolutionDir)src\shaders\blocks\block_point_input_vert.glsl;$(SolutionDir)src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl;$(SolutionDir)src\shaders\blocks\block_hsv_functions.glsl;%(AdditionalInputs)</AdditionalInputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Portable|x64'">glslangValidator -V -x "%(FullPath)" -o ".\GeneratedShaders\%(Filename)%(Extension).spv"</Command>

--- a/projects/OpenScanTools/OpenScanTools.vcxproj.filters
+++ b/projects/OpenScanTools/OpenScanTools.vcxproj.filters
@@ -4430,6 +4430,9 @@
     <None Include="..\..\src\shaders\blocks\block_point_rgb_main_standard_vert.glsl">
       <Filter>shaders\glsl_blocks</Filter>
     </None>
+    <None Include="..\..\src\shaders\blocks\block_point_rgb_main_cartoon_vert.glsl">
+      <Filter>shaders\glsl_blocks</Filter>
+    </None>
     <None Include="..\..\src\shaders\blocks\block_point_input_geom.glsl">
       <Filter>shaders\glsl_blocks</Filter>
     </None>
@@ -4498,7 +4501,13 @@
     <CustomBuild Include="..\..\src\shaders\point_rgb_standard.vert">
       <Filter>shaders\glsl_assembled</Filter>
     </CustomBuild>
+    <CustomBuild Include="..\..\src\shaders\point_rgb_cartoon.vert">
+      <Filter>shaders\glsl_assembled</Filter>
+    </CustomBuild>
     <CustomBuild Include="..\..\src\shaders\point_rgb_standard_clip.vert">
+      <Filter>shaders\glsl_assembled</Filter>
+    </CustomBuild>
+    <CustomBuild Include="..\..\src\shaders\point_rgb_cartoon_clip.vert">
       <Filter>shaders\glsl_assembled</Filter>
     </CustomBuild>
     <CustomBuild Include="..\..\src\shaders\point_rgbi_standard.vert">

--- a/src/gui/toolBars/ToolBarRenderSettings.cpp
+++ b/src/gui/toolBars/ToolBarRenderSettings.cpp
@@ -31,7 +31,7 @@ ToolBarRenderSettings::ToolBarRenderSettings(IDataDispatcher &dataDispatcher, QW
     {
 		//fixeme (Aurélien) to remove when I & RGB done
 #ifndef _DEBUG
-		if (iterator == 2)
+		if (UiRenderMode(iterator) == UiRenderMode::IntensityRGB_Combined)
 			continue;
 #endif // !_DEBUG
         m_ui.comboBox_renderMode->addItem(QString::fromStdString(tradUiRenderMode.at(UiRenderMode(iterator))),QVariant(iterator));
@@ -422,6 +422,7 @@ void ToolBarRenderSettings::switchRenderMode(const int& mode)
 		}
 		break;
 		case UiRenderMode::RGB:
+		case UiRenderMode::Cartoon_RGB: // Keeps RGB-like controls; dedicated shader is selected by render mode mapping.
 		{
             showSaturationLuminance();
             m_ui.ramp_options->setVisible(false);

--- a/src/pointCloudEngine/RenderingTypes.cpp
+++ b/src/pointCloudEngine/RenderingTypes.cpp
@@ -7,6 +7,7 @@ std::unordered_map<UiRenderMode, std::string>  getTradUiRenderMode()
 {
 	return std::unordered_map<UiRenderMode, std::string>({
 		{ UiRenderMode::RGB, TEXT_RENDERING_TYPES_RGB.toStdString()},
+		{ UiRenderMode::Cartoon_RGB, TEXT_RENDERING_TYPES_CARTOON_RGB.toStdString()},
 	    { UiRenderMode::Intensity, TEXT_RENDERING_TYPES_INTENSITY.toStdString()},
 	    { UiRenderMode::IntensityRGB_Combined, TEXT_RENDERING_TYPES_INTENSITY_RGB_COMBINED.toStdString()},
 	    { UiRenderMode::Grey_Colored, TEXT_RENDERING_TYPES_GREY_COLORED.toStdString()},

--- a/src/shaders/blocks/block_point_rgb_main_cartoon_vert.glsl
+++ b/src/shaders/blocks/block_point_rgb_main_cartoon_vert.glsl
@@ -1,0 +1,33 @@
+void main() {
+    gl_PointSize = pc.ptSize;
+    vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
+#ifdef _CLIPPING_ACTIVATED
+    gl_Position = worldPos4;
+#else
+    gl_Position = uCam.projView * worldPos4;
+#endif
+
+    // Pass 2 defaults for the cartoon look:
+    // - quantize value (lightness proxy in HSV) for posterization
+    // - enforce and quantize saturation to reduce noisy desaturated tones
+    const float kValueLevels = 8.0;
+    const float kSaturationLevels = 4.0;
+    const float kMinSaturation = 0.12;
+
+    vec3 hsv = rgb2hsv(color.rgb / 255.0);
+    hsv.y = max(hsv.y, kMinSaturation);
+
+    float satDen = max(kSaturationLevels - 1.0, 1.0);
+    float valDen = max(kValueLevels - 1.0, 1.0);
+    hsv.y = floor(hsv.y * satDen + 0.5) / satDen;
+    hsv.z = floor(hsv.z * valDen + 0.5) / valDen;
+
+    // Keep existing toolbar controls active in cartoon mode.
+    hsv.y = clamp(hsv.y * pc.saturation, 0.0, 1.0);
+    hsv.z = clamp(hsv.z * pc.luminance, 0.0, 1.0);
+
+    fragColor = vec4(hsv2rgb(hsv), 1.0);
+    filterReject = evaluateColorimetricFilter(getRgbNorm(), getIntensityNorm(), worldPos4.xyz);
+    if (gPolygonHighlight > 0.5)
+        fragColor.rgb = mix(fragColor.rgb, vec3(242.0 / 255.0, 214.0 / 255.0, 0.0), 0.85);
+}

--- a/src/shaders/point_rgb_cartoon.vert
+++ b/src/shaders/point_rgb_cartoon.vert
@@ -1,0 +1,9 @@
+// Vertex shader for points with "rgb" attribute and NO clipping
+#version 450
+#extension GL_GOOGLE_include_directive : enable
+#define ATTRIB_RGB
+#include "./blocks/block_point_input_vert.glsl"
+
+#include "./blocks/block_hsv_functions.glsl"
+
+#include "./blocks/block_point_rgb_main_cartoon_vert.glsl"

--- a/src/shaders/point_rgb_cartoon_clip.vert
+++ b/src/shaders/point_rgb_cartoon_clip.vert
@@ -1,0 +1,10 @@
+// Vertex shader for points with "rgb" attribute and clipping
+#version 450
+#extension GL_GOOGLE_include_directive : enable
+#define ATTRIB_RGB
+#define _CLIPPING_ACTIVATED
+#include "./blocks/block_point_input_vert.glsl"
+
+#include "./blocks/block_hsv_functions.glsl"
+
+#include "./blocks/block_point_rgb_main_cartoon_vert.glsl"

--- a/src/vulkan/Renderers/Renderer.cpp
+++ b/src/vulkan/Renderers/Renderer.cpp
@@ -82,6 +82,16 @@ static uint32_t point_rgb_standard_clip_vert_spv[] =
 #include "point_rgb_standard_clip.vert.spv"
 };
 
+static uint32_t point_rgb_cartoon_vert_spv[] =
+{
+#include "point_rgb_cartoon.vert.spv"
+};
+
+static uint32_t point_rgb_cartoon_clip_vert_spv[] =
+{
+#include "point_rgb_cartoon_clip.vert.spv"
+};
+
 static uint32_t point_rgb_colored_vert_spv[] =
 {
 #include "point_rgb_colored.vert.spv"
@@ -172,6 +182,12 @@ Renderer::Renderer()
             { tls::PointFormat::TL_POINT_XYZ_RGB, { point_rgb_standard_vert_spv, sizeof(point_rgb_standard_vert_spv), point_rgb_standard_clip_vert_spv, sizeof(point_rgb_standard_clip_vert_spv), true }},
             { tls::PointFormat::TL_POINT_XYZ_I_RGB, { point_rgb_standard_vert_spv, sizeof(point_rgb_standard_vert_spv), point_rgb_standard_clip_vert_spv, sizeof(point_rgb_standard_clip_vert_spv), true }}}
         },
+        { RenderMode::RGB_Cartoon, {
+            // Pass 2: dedicated cartoon vertex shader for RGB-capable point formats.
+            { tls::PointFormat::TL_POINT_XYZ_I, { point_i_standard_vert_spv, sizeof(point_i_standard_vert_spv), point_i_standard_clip_vert_spv, sizeof(point_i_standard_clip_vert_spv), true }},
+            { tls::PointFormat::TL_POINT_XYZ_RGB, { point_rgb_cartoon_vert_spv, sizeof(point_rgb_cartoon_vert_spv), point_rgb_cartoon_clip_vert_spv, sizeof(point_rgb_cartoon_clip_vert_spv), true }},
+            { tls::PointFormat::TL_POINT_XYZ_I_RGB, { point_rgb_cartoon_vert_spv, sizeof(point_rgb_cartoon_vert_spv), point_rgb_cartoon_clip_vert_spv, sizeof(point_rgb_cartoon_clip_vert_spv), true }}}
+        },
         { RenderMode::IntensityRGB_Combined, {
             { tls::PointFormat::TL_POINT_XYZ_I, { point_i_standard_vert_spv, sizeof(point_i_standard_vert_spv), point_i_standard_clip_vert_spv, sizeof(point_i_standard_clip_vert_spv), true }},
             { tls::PointFormat::TL_POINT_XYZ_RGB, { point_rgb_standard_vert_spv, sizeof(point_rgb_standard_vert_spv), point_rgb_standard_clip_vert_spv, sizeof(point_rgb_standard_clip_vert_spv), true }},
@@ -253,6 +269,9 @@ std::string Renderer::getShaderKey(RenderMode renderMode, tls::PointFormat forma
         break;
     case (RGB):
         key += "RGB";
+        break;
+    case (RGB_Cartoon):
+        key += "RGB_Cartoon";
         break;
     case (IntensityRGB_Combined):
         key += "RGBI";
@@ -679,7 +698,8 @@ void Renderer::createGraphicPipelines()
                 vertexBindingDesc.push_back({ 3, sizeof(uint8_t), VK_VERTEX_INPUT_RATE_VERTEX });
             }
             else if (format == tls::PointFormat::TL_POINT_XYZ_RGB ||
-                (format == tls::PointFormat::TL_POINT_XYZ_I_RGB && (renderMode == RenderMode::RGB)))
+                (format == tls::PointFormat::TL_POINT_XYZ_I_RGB &&
+                    (renderMode == RenderMode::RGB || renderMode == RenderMode::RGB_Cartoon)))
             {
                 vertexAttrDesc.push_back(vertexAttrDescRGB);
                 vertexBindingDesc.push_back({ 1, 3 * sizeof(uint8_t), VK_VERTEX_INPUT_RATE_VERTEX });
@@ -834,7 +854,7 @@ void Renderer::bindVertexBuffers(VkCommandBuffer _cmdBuffer, RenderMode _renderM
             VkDeviceSize iOffset = _cellDrawInfo.m_iOffset;
             h_pfn->vkCmdBindVertexBuffers(_cmdBuffer, 3, 1, &_cellDrawInfo.buffer, &iOffset);
         }
-        else if (_renderMode == RenderMode::RGB)
+        else if (_renderMode == RenderMode::RGB || _renderMode == RenderMode::RGB_Cartoon)
         {
             VkDeviceSize rgbOffset = _cellDrawInfo.m_rgbOffset;
             h_pfn->vkCmdBindVertexBuffers(_cmdBuffer, 1, 1, &_cellDrawInfo.buffer, &rgbOffset);


### PR DESCRIPTION
### Motivation
- Provide a dedicated "Cartoon RGB" rendering pass to offer a posterized/cartoon look for RGB point clouds while preserving existing UI controls.

### Description
- Introduced `UiRenderMode::Cartoon_RGB` and `RenderMode::RGB_Cartoon`, added text label in `RenderingTexts.hpp`, and wired the translation in `RenderingTypes.cpp`/`RenderingTypes.h` including the Ui→RenderMode mapping.
- Implemented the cartoon shading logic by adding `block_point_rgb_main_cartoon_vert.glsl` and assembled vertex shaders `point_rgb_cartoon.vert` and `point_rgb_cartoon_clip.vert` which quantize HSV for posterization and honor toolbar saturation/luminance controls.
- Added project entries and filters to `OpenScanTools.vcxproj`/`.filters` to include new shader blocks and compile them via `glslangValidator`, and registered the new SPV blobs in `Renderer.cpp`.
- Extended `Renderer` pipeline setup and vertex buffer binding logic to support `RGB_Cartoon` (shader selection, shader key name, and RGB attribute bindings), and updated `ToolBarRenderSettings.cpp` to present `Cartoon_RGB` in the UI with the same RGB controls as standard RGB.

### Testing
- Built the entire solution including the shader compilation step via `glslangValidator` to generate SPV assets, and the build completed successfully.
- Executed the existing automated test suite where available and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da67a81140832f8e2d297945225275)