### PR TITLE
Hash cartoon uniform settings so UI edits immediately refresh point clouds

### DIFF
--- a/src/pointCloudEngine/RenderingEcoSystem.cpp
+++ b/src/pointCloudEngine/RenderingEcoSystem.cpp
@@ -113,6 +113,11 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
     hash += hash_fn_f(display.m_saturation);
     hash += hash_fn_f(display.m_luminance);
     hash += hash_fn_f(display.m_hue);
+    // Keep Cartoon uniforms in the frame hash so editing these UI settings triggers
+    // an immediate point-cloud refresh without requiring camera interaction.
+    hash += hash_fn_i(display.m_cartoonValueLevels);
+    hash += hash_fn_i(display.m_cartoonSaturationMinPercent);
+    hash += hash_fn_i(display.m_cartoonSaturationLevels);
     hash += hash_vec3(display.m_flatColor);
     hash += hash_fn_f(display.m_distRampMin);
     hash += hash_fn_f(display.m_distRampMax);


### PR DESCRIPTION
### Motivation
- Ensure modifying cartoon-related UI parameters causes an immediate point-cloud refresh without needing camera interaction by including them in the frame hash.

### Description
- Added `hash_fn_i` calls for `display.m_cartoonValueLevels`, `display.m_cartoonSaturationMinPercent`, and `display.m_cartoonSaturationLevels` to `HashFrame::hashRenderingData` in `RenderingEcoSystem.cpp`.

### Testing
- Built the project with `cmake`/`make` and ran automated unit tests via `ctest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5a58b644832f90b85401eb5debb0)