### PR TITLE
Make Cartoon controls visibility robust and include cartoon params in frame hash

### DIFF
--- a/include/gui/toolBars/ToolBarRenderSettings.h
+++ b/include/gui/toolBars/ToolBarRenderSettings.h
@@ -57,11 +57,12 @@ private:
 
     void showContrastBrightness();
     void showSaturationLuminance();
-        void updateCartoonOptionsVisibility();
-        void enableFalseColor(bool);
-        bool rampValidValue(float& min, float& max, int& step);
-        void sendTransparency();
-        void changeEvent(QEvent* event) override;
+    void updateCartoonOptionsVisibility();
+    void setCartoonControlsVisible(bool visible);
+    void enableFalseColor(bool);
+    bool rampValidValue(float& min, float& max, int& step);
+    void sendTransparency();
+    void changeEvent(QEvent* event) override;
 
 private slots:
 	void slotBrightnessLuminanceValueChanged(int value);

--- a/src/gui/toolBars/ToolBarRenderSettings.cpp
+++ b/src/gui/toolBars/ToolBarRenderSettings.cpp
@@ -457,7 +457,26 @@ void ToolBarRenderSettings::switchRenderMode(const int& mode)
 
 void ToolBarRenderSettings::updateCartoonOptionsVisibility()
 {
-    m_ui.cartoon_options->setVisible(m_currentRenderMode == UiRenderMode::Cartoon_RGB);
+    const bool showCartoonControls = (m_currentRenderMode == UiRenderMode::Cartoon_RGB);
+
+    // The .ui currently places Cartoon widgets directly in the root grid layout,
+    // so toggling only "cartoon_options" is not enough. Explicitly toggling all
+    // Cartoon widgets guarantees robust behavior regardless of layout structure.
+    setCartoonControlsVisible(showCartoonControls);
+}
+
+void ToolBarRenderSettings::setCartoonControlsVisible(bool visible)
+{
+    // Keep the dedicated placeholder in sync in case the UI is refactored later.
+    m_ui.cartoon_options->setVisible(visible);
+
+    // Explicit controls used by Cartoon mode.
+    m_ui.label_cartoonLevels->setVisible(visible);
+    m_ui.spinBox_cartoonLevels->setVisible(visible);
+    m_ui.label_cartoonSatMin->setVisible(visible);
+    m_ui.spinBox_cartoonSaturationMin->setVisible(visible);
+    m_ui.label_cartoonSatLevels->setVisible(visible);
+    m_ui.spinBox_cartoonSaturationLevels->setVisible(visible);
 }
 
 void ToolBarRenderSettings::setDisplayPresetNames(const QStringList& names, const QString& selectedName)

--- a/src/pointCloudEngine/RenderingEcoSystem.cpp
+++ b/src/pointCloudEngine/RenderingEcoSystem.cpp
@@ -113,6 +113,11 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
     hash += hash_fn_f(display.m_saturation);
     hash += hash_fn_f(display.m_luminance);
     hash += hash_fn_f(display.m_hue);
+    // Keep Cartoon uniforms in the frame hash so editing these UI settings triggers
+    // an immediate point-cloud refresh without requiring camera interaction.
+    hash += hash_fn_i(display.m_cartoonValueLevels);
+    hash += hash_fn_i(display.m_cartoonSaturationMinPercent);
+    hash += hash_fn_i(display.m_cartoonSaturationLevels);
     hash += hash_vec3(display.m_flatColor);
     hash += hash_fn_f(display.m_distRampMin);
     hash += hash_fn_f(display.m_distRampMax);


### PR DESCRIPTION
### Motivation
- Cartoon-mode widgets were not reliably hidden because individual controls were placed directly in the root UI layout rather than inside a single container.  
- Changing Cartoon-related UI sliders did not always force a point-cloud refresh because Cartoon uniforms were not part of the frame hash.

### Description
- Add `setCartoonControlsVisible(bool)` and update `updateCartoonOptionsVisibility()` to explicitly toggle each Cartoon control instead of relying on the placeholder alone.  
- Implement `setCartoonControlsVisible` to sync the placeholder `cartoon_options` and explicitly show/hide `label_cartoonLevels`, `spinBox_cartoonLevels`, `label_cartoonSatMin`, `spinBox_cartoonSaturationMin`, `label_cartoonSatLevels`, and `spinBox_cartoonSaturationLevels`.  
- Expose the new helper in `ToolBarRenderSettings.h` and adjust surrounding declarations.  
- Add Cartoon-related display parameters (`m_cartoonValueLevels`, `m_cartoonSaturationMinPercent`, `m_cartoonSaturationLevels`) into `HashFrame::hashRenderingData` so updates to those UI settings change the frame hash and trigger immediate refresh.

### Testing
- Project built successfully with `cmake`/build system after changes.  
- Automated unit/regression tests including the renderer/hash tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5a58b644832f90b85401eb5debb0)