### PR TITLE
Replace Edge-Aware Blur with Color Noise Reduction (rename, UI, shader, serialization)

### DIFF
--- a/include/controller/controls/AnimationHelper.h
+++ b/include/controller/controls/AnimationHelper.h
@@ -53,7 +53,7 @@ namespace control::animation::helper
             reference.m_postRenderingNormals.show == candidate.m_postRenderingNormals.show &&
             reference.m_postRenderingAmbientOcclusion.enabled == candidate.m_postRenderingAmbientOcclusion.enabled &&
             reference.m_postRenderingNormals.blendColor == candidate.m_postRenderingNormals.blendColor &&
-            reference.m_edgeAwareBlur.enabled == candidate.m_edgeAwareBlur.enabled &&
+            reference.m_colorNoiseReduction.enabled == candidate.m_colorNoiseReduction.enabled &&
             reference.m_depthLining.enabled == candidate.m_depthLining.enabled &&
             reference.m_depthLining.strongMode == candidate.m_depthLining.strongMode;
     }

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -344,15 +344,15 @@ public:
 	PostRenderingAmbientOcclusion m_ao;
 };
 
-class GuiDataEdgeAwareBlur : public GuiDataActiveCamera
+class GuiDataColorNoiseReduction : public GuiDataActiveCamera
 {
 public:
-        GuiDataEdgeAwareBlur(const EdgeAwareBlur& blurSettings, SafePtr<CameraNode> camera);
-        ~GuiDataEdgeAwareBlur() {};
+        GuiDataColorNoiseReduction(const ColorNoiseReduction& blurSettings, SafePtr<CameraNode> camera);
+        ~GuiDataColorNoiseReduction() {};
         virtual guiDType getType() override;
 
 public:
-        EdgeAwareBlur m_blur;
+        ColorNoiseReduction m_blur;
 };
 
 class GuiDataDepthLining : public GuiDataActiveCamera

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -76,7 +76,7 @@ enum class guiDType
         renderAlphaObjectsRendering,
         renderPostRenderingNormals,
         renderAmbientOcclusion,
-        renderEdgeAwareBlur,
+        renderColorNoiseReduction,
         renderDepthLining,
         renderRampScale,
         renderColorimetricFilter,

--- a/include/gui/toolBars/ToolBarRenderEnhance.h
+++ b/include/gui/toolBars/ToolBarRenderEnhance.h
@@ -25,8 +25,8 @@ private:
 	void onActiveCamera(IGuiData* data);
 	void onFocusViewport(IGuiData* data);
 	void blockAllSignals(bool block);
-	void updateEdgeAwareBlurUi(bool enabled);
-	EdgeAwareBlur getEdgeAwareBlurFromUi() const;
+	void updateColorNoiseReductionUi(bool enabled);
+	ColorNoiseReduction getColorNoiseReductionFromUi() const;
 	void updateDepthLiningUi(bool enabled);
 	DepthLining getDepthLiningFromUi() const;
 
@@ -43,8 +43,8 @@ private:
 	SafePtr<CameraNode> m_focusCamera;
 
 private slots:
-	void slotEdgeAwareBlurToggled(int state);
-	void slotEdgeAwareBlurValueChanged(int value);
+	void slotColorNoiseReductionToggled(int state);
+	void slotColorNoiseReductionValueChanged(int value);
 	void slotDepthLiningToggled(int state);
 	void slotDepthLiningValueChanged(int value);
 	void slotDepthLiningSensitivityChanged(int value);

--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -241,7 +241,9 @@
 
 #define Key_Post_Rendering_Normals		"PostRenderingNormals"
 #define Key_Post_Rendering_Ambient_Occlusion "PostRenderingAmbientOcclusion"
-#define Key_Edge_Aware_Blur			"EdgeAwareBlur"
+#define Key_Color_Noise_Reduction			"ColorNoiseReduction"
+// Legacy key kept for backward compatibility with old projects/viewpoints.
+#define Key_Edge_Aware_Blur_Legacy            "EdgeAwareBlur"
 #define Key_Depth_Lining			"DepthLining"
 #define Key_Display_Guizmo				"DisplayGuizmo"
 #define Key_Ramp_Scale_Options			"RampScaleOptions"

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -103,7 +103,7 @@ public:
     // Post processing
     PostRenderingNormals    m_postRenderingNormals = { true, false, true, 0.4f, 1.f };
     PostRenderingAmbientOcclusion m_postRenderingAmbientOcclusion = {};
-    EdgeAwareBlur           m_edgeAwareBlur = {};
+    ColorNoiseReduction           m_colorNoiseReduction = {};
     DepthLining             m_depthLining = {};
 
     // GUI

--- a/include/models/application/ViewPointAnimation.h
+++ b/include/models/application/ViewPointAnimation.h
@@ -62,7 +62,7 @@ struct AnimationViewpointInfo
     BlendMode blendMode = BlendMode::Opaque;
     bool normals = false;
     bool blendColor = false;
-    bool edgeAwareBlur = false;
+    bool colorNoiseReduction = false;
     bool depthLining = false;
     bool depthLiningStrongMode = false;
 };

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -300,7 +300,7 @@ private:
     void onRenderAlphaObjects(IGuiData* data);
     void onRenderNormals(IGuiData* data);
     void onRenderAmbientOcclusion(IGuiData* data);
-    void onRenderEdgeAwareBlur(IGuiData* data);
+    void onRenderColorNoiseReduction(IGuiData* data);
     void onRenderDepthLining(IGuiData* data);
     void onRenderRampScale(IGuiData* data);
     void onRenderColorimetricFilter(IGuiData* data);

--- a/include/pointCloudEngine/RenderingTypes.h
+++ b/include/pointCloudEngine/RenderingTypes.h
@@ -93,12 +93,15 @@ struct PostRenderingAmbientOcclusion
     float intensity = 0.4f;
 };
 
-struct EdgeAwareBlur
+struct ColorNoiseReduction
 {
     bool enabled = true;
     float radius = 2.0f;
-    float depthThreshold = 0.35f;
-    float blendStrength = 0.25f;
+    // Internal depth gate used to preserve geometric edges.
+    // Intentionally not exposed in the UI for pass 1.
+    float depthAwareThreshold = 0.05f;
+    // User-facing intensity of the spray/noise reduction.
+    float strength = 0.30f;
     float resolutionScale = 1.0f; // 1.0 = full res, 0.5 = half res
 };
 

--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -144,7 +144,7 @@ public:
     void beginPostTreatmentFilling(TlFramebuffer framebuffer);
     void beginPostTreatmentNormal(TlFramebuffer framebuffer);
     void beginPostTreatmentAmbientOcclusion(TlFramebuffer framebuffer);
-    void beginPostTreatmentEdgeAwareBlur(TlFramebuffer framebuffer);
+    void beginPostTreatmentColorNoiseReduction(TlFramebuffer framebuffer);
     void beginPostTreatmentDepthLining(TlFramebuffer framebuffer);
     void beginPostTreatmentTransparency(TlFramebuffer framebuffer);
 

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -42,7 +42,7 @@ namespace control::animation
                 info.blendMode = rViewpoint->m_blendMode;
                 info.normals = rViewpoint->m_postRenderingNormals.show;
                 info.blendColor = rViewpoint->m_postRenderingNormals.blendColor;
-                info.edgeAwareBlur = rViewpoint->m_edgeAwareBlur.enabled;
+                info.colorNoiseReduction = rViewpoint->m_colorNoiseReduction.enabled;
                 info.depthLining = rViewpoint->m_depthLining.enabled;
                 info.depthLiningStrongMode = rViewpoint->m_depthLining.strongMode;
                 viewpoints.push_back(info);

--- a/src/gui/Dialog/DialogAnimationConfig.cpp
+++ b/src/gui/Dialog/DialogAnimationConfig.cpp
@@ -455,7 +455,7 @@ void DialogAnimationConfig::checkRenderingConsistency(const xg::Guid& newViewpoi
         current.blendMode == ref.blendMode &&
         current.normals == ref.normals &&
         current.blendColor == ref.blendColor &&
-        current.edgeAwareBlur == ref.edgeAwareBlur &&
+        current.colorNoiseReduction == ref.colorNoiseReduction &&
         current.depthLining == ref.depthLining &&
         current.depthLiningStrongMode == ref.depthLiningStrongMode;
 

--- a/src/gui/DisplayPresetManager.cpp
+++ b/src/gui/DisplayPresetManager.cpp
@@ -83,7 +83,7 @@ namespace
 
 		json[Key_Post_Rendering_Normals] = { params.m_postRenderingNormals.show, params.m_postRenderingNormals.inverseTone, params.m_postRenderingNormals.blendColor, params.m_postRenderingNormals.normalStrength, params.m_postRenderingNormals.gloss };
 		json[Key_Post_Rendering_Ambient_Occlusion] = { params.m_postRenderingAmbientOcclusion.enabled, params.m_postRenderingAmbientOcclusion.radius, params.m_postRenderingAmbientOcclusion.intensity };
-		json[Key_Edge_Aware_Blur] = { params.m_edgeAwareBlur.enabled, params.m_edgeAwareBlur.radius, params.m_edgeAwareBlur.depthThreshold, params.m_edgeAwareBlur.blendStrength, params.m_edgeAwareBlur.resolutionScale };
+		json[Key_Color_Noise_Reduction] = { params.m_colorNoiseReduction.enabled, params.m_colorNoiseReduction.radius, params.m_colorNoiseReduction.depthAwareThreshold, params.m_colorNoiseReduction.strength, params.m_colorNoiseReduction.resolutionScale };
 		json[Key_Depth_Lining] = { params.m_depthLining.enabled, params.m_depthLining.strength, params.m_depthLining.threshold, params.m_depthLining.sensitivity, params.m_depthLining.strongMode };
 
 		json[Key_Display_Guizmo] = params.m_displayGizmo;
@@ -599,11 +599,18 @@ namespace
 				data.m_postRenderingAmbientOcclusion = { options[0], options[1], options[2] };
 		}
 
-		if (json.find(Key_Edge_Aware_Blur) != json.end())
+		if (json.find(Key_Color_Noise_Reduction) != json.end())
 		{
-			nlohmann::json options = json.at(Key_Edge_Aware_Blur);
+			nlohmann::json options = json.at(Key_Color_Noise_Reduction);
 			if (options.size() == 5)
-				data.m_edgeAwareBlur = { options[0], options[1], options[2], options[3], options[4] };
+				data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
+		}
+		else if (json.find(Key_Edge_Aware_Blur_Legacy) != json.end())
+		{
+			// Backward compatibility with legacy display presets.
+			nlohmann::json options = json.at(Key_Edge_Aware_Blur_Legacy);
+			if (options.size() == 5)
+				data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
 		}
 
 		if (json.find(Key_Depth_Lining) != json.end())
@@ -967,7 +974,7 @@ void DisplayPresetManager::applyPreset(const DisplayPreset& preset)
 	m_dataDispatcher.updateInformation(new GuiDataRenderTransparencyOptions(params.m_negativeEffect, params.m_reduceFlash, params.m_flashAdvanced, params.m_highlightKneeStart, params.m_highlightKneeSoftness, params.m_advancedFlashBoost, 0.f, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataPostRenderingNormals(params.m_postRenderingNormals, false, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderAmbientOcclusion(params.m_postRenderingAmbientOcclusion, m_focusCamera), this);
-	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(params.m_edgeAwareBlur, m_focusCamera), this);
+	m_dataDispatcher.updateInformation(new GuiDataColorNoiseReduction(params.m_colorNoiseReduction, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataDepthLining(params.m_depthLining, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderColorimetricFilter(params.m_colorimetricFilter, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(params.m_polygonalSelector, m_focusCamera), this);
@@ -1060,7 +1067,7 @@ DisplayPresetManager::DisplayPreset DisplayPresetManager::getRawPreset() const
 	parameters.m_saturation = 0.f;
 	parameters.m_postRenderingNormals.show = false;
 	parameters.m_postRenderingAmbientOcclusion.enabled = false;
-	parameters.m_edgeAwareBlur.enabled = false;
+	parameters.m_colorNoiseReduction.enabled = false;
 	parameters.m_depthLining.enabled = false;
 	preset.displayParameters = parameters;
 	preset.showHideState = getDefaultShowHideState();

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -348,14 +348,14 @@ guiDType GuiDataRenderAmbientOcclusion::getType()
 	return guiDType::renderAmbientOcclusion;
 }
 
-GuiDataEdgeAwareBlur::GuiDataEdgeAwareBlur(const EdgeAwareBlur& blurSettings, SafePtr<CameraNode> camera)
+GuiDataColorNoiseReduction::GuiDataColorNoiseReduction(const ColorNoiseReduction& blurSettings, SafePtr<CameraNode> camera)
         : GuiDataActiveCamera(camera)
         , m_blur(blurSettings)
 {}
 
-guiDType GuiDataEdgeAwareBlur::getType()
+guiDType GuiDataColorNoiseReduction::getType()
 {
-        return  guiDType::renderEdgeAwareBlur;
+        return  guiDType::renderColorNoiseReduction;
 }
 
 GuiDataDepthLining::GuiDataDepthLining(const DepthLining& liningSettings, SafePtr<CameraNode> camera)

--- a/src/gui/forms/toolbar_renderenhance.ui
+++ b/src/gui/forms/toolbar_renderenhance.ui
@@ -30,9 +30,9 @@
     <number>3</number>
    </property>
    <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="checkBox_edgeAwareBlur">
+   <widget class="QCheckBox" name="checkBox_colorNoiseReduction">
      <property name="text">
-      <string>Smooth render</string>
+      <string>Color noise reduction</string>
      </property>
     </widget>
    </item>
@@ -87,9 +87,9 @@
     <widget class="QSpinBox" name="spinBox_edgeAwareDepth"/>
    </item>
    <item row="2" column="2">
-    <widget class="QLabel" name="label_mix">
+   <widget class="QLabel" name="label_mix">
      <property name="text">
-      <string>Mix</string>
+      <string>Strength</string>
      </property>
     </widget>
    </item>

--- a/src/gui/forms/toolbar_renderenhancegroup.ui
+++ b/src/gui/forms/toolbar_renderenhancegroup.ui
@@ -57,12 +57,12 @@
     </widget>
    </item>
    <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="checkBox_edgeAwareBlur">
+   <widget class="QCheckBox" name="checkBox_colorNoiseReduction">
      <property name="toolTip">
-      <string>This function adds a slight blur that can help soften the rendering. It is best to keep the values fairly low. </string>
+      <string>Reduces color spray/noise on scans while preserving geometric edges.</string>
      </property>
      <property name="text">
-      <string>Smooth render</string>
+      <string>Color noise reduction</string>
      </property>
     </widget>
    </item>
@@ -184,9 +184,9 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_mix">
+   <widget class="QLabel" name="label_mix">
      <property name="text">
-      <string>Mix</string>
+      <string>Strength</string>
      </property>
     </widget>
    </item>

--- a/src/gui/toolBars/ToolBarRenderEnhance.cpp
+++ b/src/gui/toolBars/ToolBarRenderEnhance.cpp
@@ -12,9 +12,10 @@ namespace
 {
 	constexpr float DEPTH_LINING_STRENGTH_UI_SCALE = 1.5f;
 	constexpr float DEPTH_LINING_SENSITIVITY_UI_SCALE = 3.0f;
-	constexpr int EDGE_AWARE_DEPTH_FIXED = 5;
-	[[maybe_unused]] constexpr std::array<const char*, 3> EDGE_AWARE_RESOLUTION_LABELS = { "Full res", "Half res", "Quarter res" };
-	constexpr std::array<float, 3> EDGE_AWARE_RESOLUTION_SCALES = { 1.0f, 0.5f, 0.25f };
+	// Fixed depth gate for pass 1 (no dedicated UI control requested).
+	constexpr int COLOR_NOISE_REDUCTION_DEPTH_FIXED = 5;
+	[[maybe_unused]] constexpr std::array<const char*, 3> COLOR_NOISE_REDUCTION_RESOLUTION_LABELS = { "Full res", "Half res", "Quarter res" };
+	constexpr std::array<float, 3> COLOR_NOISE_REDUCTION_RESOLUTION_SCALES = { 1.0f, 0.5f, 0.25f };
 }
 
 ToolBarRenderEnhance::ToolBarRenderEnhance(IDataDispatcher& dataDispatcher, QWidget* parent, float guiScale)
@@ -26,14 +27,14 @@ ToolBarRenderEnhance::ToolBarRenderEnhance(IDataDispatcher& dataDispatcher, QWid
 	setEnabled(false);
 	(void)guiScale;
 
-	connect(m_ui.checkBox_edgeAwareBlur, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotEdgeAwareBlurToggled);
+	connect(m_ui.checkBox_colorNoiseReduction, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotColorNoiseReductionToggled);
 	connect(m_ui.slider_edgeAwareRadius, &QSlider::valueChanged, m_ui.spinBox_edgeAwareRadius, &QSpinBox::setValue);
 	connect(m_ui.spinBox_edgeAwareRadius, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_edgeAwareRadius, &QSlider::setValue);
-	connect(m_ui.slider_edgeAwareRadius, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotEdgeAwareBlurValueChanged);
+	connect(m_ui.slider_edgeAwareRadius, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotColorNoiseReductionValueChanged);
 
 	connect(m_ui.slider_edgeAwareBlend, &QSlider::valueChanged, m_ui.spinBox_edgeAwareBlend, &QSpinBox::setValue);
 	connect(m_ui.spinBox_edgeAwareBlend, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_edgeAwareBlend, &QSlider::setValue);
-	connect(m_ui.slider_edgeAwareBlend, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotEdgeAwareBlurValueChanged);
+	connect(m_ui.slider_edgeAwareBlend, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotColorNoiseReductionValueChanged);
 
 	connect(m_ui.checkBox_depthLining, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotDepthLiningToggled);
 	connect(m_ui.slider_depthLiningStrength, &QSlider::valueChanged, m_ui.spinBox_depthLiningStrength, &QSpinBox::setValue);
@@ -44,7 +45,7 @@ ToolBarRenderEnhance::ToolBarRenderEnhance(IDataDispatcher& dataDispatcher, QWid
 	connect(m_ui.slider_depthLiningSensitivity, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotDepthLiningSensitivityChanged);
 	connect(m_ui.checkBox_depthLiningStrongMode, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotDepthLiningStrongModeToggled);
 
-	updateEdgeAwareBlurUi(m_ui.checkBox_edgeAwareBlur->isChecked());
+	updateColorNoiseReductionUi(m_ui.checkBox_colorNoiseReduction->isChecked());
 	updateDepthLiningUi(m_ui.checkBox_depthLining->isChecked());
 
 	registerGuiDataFunction(guiDType::projectLoaded, &ToolBarRenderEnhance::onProjectLoad);
@@ -81,21 +82,21 @@ void ToolBarRenderEnhance::onActiveCamera(IGuiData* data)
 
 	blockAllSignals(true);
 
-	const EdgeAwareBlur& blurSettings = displayParameters.m_edgeAwareBlur;
-	int radiusValue = std::clamp(static_cast<int>(std::round(blurSettings.radius)), m_ui.slider_edgeAwareRadius->minimum(), m_ui.slider_edgeAwareRadius->maximum());
-	int blendValue = std::clamp(static_cast<int>(std::round(blurSettings.blendStrength * 100.f)), m_ui.slider_edgeAwareBlend->minimum(), m_ui.slider_edgeAwareBlend->maximum());
+	const ColorNoiseReduction& noiseReductionSettings = displayParameters.m_colorNoiseReduction;
+	int radiusValue = std::clamp(static_cast<int>(std::round(noiseReductionSettings.radius)), m_ui.slider_edgeAwareRadius->minimum(), m_ui.slider_edgeAwareRadius->maximum());
+	int strengthValue = std::clamp(static_cast<int>(std::round(noiseReductionSettings.strength * 100.f)), m_ui.slider_edgeAwareBlend->minimum(), m_ui.slider_edgeAwareBlend->maximum());
 
 	const DepthLining& liningSettings = displayParameters.m_depthLining;
 	int liningStrength = std::clamp(static_cast<int>(std::round((liningSettings.strength / DEPTH_LINING_STRENGTH_UI_SCALE) * 100.f)), m_ui.slider_depthLiningStrength->minimum(), m_ui.slider_depthLiningStrength->maximum());
 	int liningSensitivity = std::clamp(static_cast<int>(std::round((liningSettings.sensitivity / DEPTH_LINING_SENSITIVITY_UI_SCALE) * 100.f)), m_ui.slider_depthLiningSensitivity->minimum(), m_ui.slider_depthLiningSensitivity->maximum());
 
-	m_ui.checkBox_edgeAwareBlur->setChecked(blurSettings.enabled);
+	m_ui.checkBox_colorNoiseReduction->setChecked(noiseReductionSettings.enabled);
 	m_ui.slider_edgeAwareRadius->setValue(radiusValue);
 	m_ui.spinBox_edgeAwareRadius->setValue(radiusValue);
-	m_ui.slider_edgeAwareBlend->setValue(blendValue);
-	m_ui.spinBox_edgeAwareBlend->setValue(blendValue);
+	m_ui.slider_edgeAwareBlend->setValue(strengthValue);
+	m_ui.spinBox_edgeAwareBlend->setValue(strengthValue);
 
-	updateEdgeAwareBlurUi(blurSettings.enabled);
+	updateColorNoiseReductionUi(noiseReductionSettings.enabled);
 
 	m_ui.checkBox_depthLining->setChecked(liningSettings.enabled);
 	m_ui.slider_depthLiningStrength->setValue(liningStrength);
@@ -117,7 +118,7 @@ void ToolBarRenderEnhance::onFocusViewport(IGuiData* data)
 
 void ToolBarRenderEnhance::blockAllSignals(bool block)
 {
-	m_ui.checkBox_edgeAwareBlur->blockSignals(block);
+	m_ui.checkBox_colorNoiseReduction->blockSignals(block);
 	m_ui.slider_edgeAwareRadius->blockSignals(block);
 	m_ui.spinBox_edgeAwareRadius->blockSignals(block);
 	m_ui.slider_edgeAwareBlend->blockSignals(block);
@@ -130,7 +131,7 @@ void ToolBarRenderEnhance::blockAllSignals(bool block)
 	m_ui.checkBox_depthLiningStrongMode->blockSignals(block);
 }
 
-void ToolBarRenderEnhance::updateEdgeAwareBlurUi(bool enabled)
+void ToolBarRenderEnhance::updateColorNoiseReductionUi(bool enabled)
 {
 	m_ui.slider_edgeAwareRadius->setEnabled(enabled);
 	m_ui.spinBox_edgeAwareRadius->setEnabled(enabled);
@@ -138,14 +139,14 @@ void ToolBarRenderEnhance::updateEdgeAwareBlurUi(bool enabled)
 	m_ui.spinBox_edgeAwareBlend->setEnabled(enabled);
 }
 
-EdgeAwareBlur ToolBarRenderEnhance::getEdgeAwareBlurFromUi() const
+ColorNoiseReduction ToolBarRenderEnhance::getColorNoiseReductionFromUi() const
 {
-	EdgeAwareBlur settings = {};
-	settings.enabled = m_ui.checkBox_edgeAwareBlur->isChecked();
+	ColorNoiseReduction settings = {};
+	settings.enabled = m_ui.checkBox_colorNoiseReduction->isChecked();
 	settings.radius = static_cast<float>(m_ui.spinBox_edgeAwareRadius->value());
-	settings.depthThreshold = static_cast<float>(EDGE_AWARE_DEPTH_FIXED) / 100.f;
-	settings.blendStrength = m_ui.spinBox_edgeAwareBlend->value() / 100.f;
-	settings.resolutionScale = EDGE_AWARE_RESOLUTION_SCALES.front();
+	settings.depthAwareThreshold = static_cast<float>(COLOR_NOISE_REDUCTION_DEPTH_FIXED) / 100.f;
+	settings.strength = m_ui.spinBox_edgeAwareBlend->value() / 100.f;
+	settings.resolutionScale = COLOR_NOISE_REDUCTION_RESOLUTION_SCALES.front();
 
 	return settings;
 }
@@ -172,19 +173,19 @@ DepthLining ToolBarRenderEnhance::getDepthLiningFromUi() const
 	return settings;
 }
 
-void ToolBarRenderEnhance::slotEdgeAwareBlurToggled(int state)
+void ToolBarRenderEnhance::slotColorNoiseReductionToggled(int state)
 {
-	updateEdgeAwareBlurUi(state == Qt::Checked);
-	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(getEdgeAwareBlurFromUi(), m_focusCamera), this);
+	updateColorNoiseReductionUi(state == Qt::Checked);
+	m_dataDispatcher.updateInformation(new GuiDataColorNoiseReduction(getColorNoiseReductionFromUi(), m_focusCamera), this);
 }
 
-void ToolBarRenderEnhance::slotEdgeAwareBlurValueChanged(int value)
+void ToolBarRenderEnhance::slotColorNoiseReductionValueChanged(int value)
 {
 	(void)value;
-	if (!m_ui.checkBox_edgeAwareBlur->isChecked())
+	if (!m_ui.checkBox_colorNoiseReduction->isChecked())
 		return;
 
-	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(getEdgeAwareBlurFromUi(), m_focusCamera), this);
+	m_dataDispatcher.updateInformation(new GuiDataColorNoiseReduction(getColorNoiseReductionFromUi(), m_focusCamera), this);
 }
 
 void ToolBarRenderEnhance::slotDepthLiningToggled(int state)

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -376,7 +376,7 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 
     json[Key_Post_Rendering_Normals] = { params.m_postRenderingNormals.show, params.m_postRenderingNormals.inverseTone, params.m_postRenderingNormals.blendColor, params.m_postRenderingNormals.normalStrength, params.m_postRenderingNormals.gloss };
     json[Key_Post_Rendering_Ambient_Occlusion] = { params.m_postRenderingAmbientOcclusion.enabled, params.m_postRenderingAmbientOcclusion.radius, params.m_postRenderingAmbientOcclusion.intensity };
-    json[Key_Edge_Aware_Blur] = { params.m_edgeAwareBlur.enabled, params.m_edgeAwareBlur.radius, params.m_edgeAwareBlur.depthThreshold, params.m_edgeAwareBlur.blendStrength, params.m_edgeAwareBlur.resolutionScale };
+    json[Key_Color_Noise_Reduction] = { params.m_colorNoiseReduction.enabled, params.m_colorNoiseReduction.radius, params.m_colorNoiseReduction.depthAwareThreshold, params.m_colorNoiseReduction.strength, params.m_colorNoiseReduction.resolutionScale };
     json[Key_Depth_Lining] = { params.m_depthLining.enabled, params.m_depthLining.strength, params.m_depthLining.threshold, params.m_depthLining.sensitivity, params.m_depthLining.strongMode };
 
     json[Key_Display_Guizmo] = params.m_displayGizmo;
@@ -502,9 +502,9 @@ void ExportViewPointData(nlohmann::json& json, const ViewPointData& data)
         ExportRenderingParameters(json, data);
 
         const DisplayParameters& displayParams = data.getDisplayParameters();
-        json[Key_Edge_Aware_Blur] = { displayParams.m_edgeAwareBlur.enabled, displayParams.m_edgeAwareBlur.radius,
-                displayParams.m_edgeAwareBlur.depthThreshold, displayParams.m_edgeAwareBlur.blendStrength,
-                displayParams.m_edgeAwareBlur.resolutionScale };
+        json[Key_Color_Noise_Reduction] = { displayParams.m_colorNoiseReduction.enabled, displayParams.m_colorNoiseReduction.radius,
+                displayParams.m_colorNoiseReduction.depthAwareThreshold, displayParams.m_colorNoiseReduction.strength,
+                displayParams.m_colorNoiseReduction.resolutionScale };
         json[Key_Post_Rendering_Ambient_Occlusion] = { displayParams.m_postRenderingAmbientOcclusion.enabled, displayParams.m_postRenderingAmbientOcclusion.radius, displayParams.m_postRenderingAmbientOcclusion.intensity };
         json[Key_Depth_Lining] = { displayParams.m_depthLining.enabled, displayParams.m_depthLining.strength,
                 displayParams.m_depthLining.threshold, displayParams.m_depthLining.sensitivity,

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -938,13 +938,22 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
             IOLOG << "ViewPoint PostRenderingAmbientOcclusion malformed" << LOGENDL;
     }
 
-    if (json.find(Key_Edge_Aware_Blur) != json.end())
+    if (json.find(Key_Color_Noise_Reduction) != json.end())
     {
-        nlohmann::json options = json.at(Key_Edge_Aware_Blur);
+        nlohmann::json options = json.at(Key_Color_Noise_Reduction);
         if (options.size() == 5)
-            data.m_edgeAwareBlur = { options[0], options[1], options[2], options[3], options[4] };
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
         else
-            IOLOG << "ViewPoint EdgeAwareBlur malformed" << LOGENDL;
+            IOLOG << "ViewPoint ColorNoiseReduction malformed" << LOGENDL;
+    }
+    else if (json.find(Key_Edge_Aware_Blur_Legacy) != json.end())
+    {
+        // Backward compatibility: old projects used "EdgeAwareBlur".
+        nlohmann::json options = json.at(Key_Edge_Aware_Blur_Legacy);
+        if (options.size() == 5)
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
+        else
+            IOLOG << "ViewPoint EdgeAwareBlur (legacy) malformed" << LOGENDL;
     }
 
     if (json.find(Key_Depth_Lining) != json.end())
@@ -1997,13 +2006,22 @@ bool ImportColumnTiltMeasureData(const nlohmann::json& json, ColumnTiltMeasureDa
 bool ImportViewPointData(const nlohmann::json& json, ViewPointData& data, const std::unordered_map<xg::Guid, SafePtr<AGraphNode>>& nodeById)
 {
     bool retVal(true);
-    if (json.find(Key_Edge_Aware_Blur) != json.end())
+    if (json.find(Key_Color_Noise_Reduction) != json.end())
     {
-        nlohmann::json options = json.at(Key_Edge_Aware_Blur);
+        nlohmann::json options = json.at(Key_Color_Noise_Reduction);
         if (options.size() == 5)
-            data.m_edgeAwareBlur = { options[0], options[1], options[2], options[3], options[4] };
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
         else
-            IOLOG << "ViewPoint EdgeAwareBlur malformed" << LOGENDL;
+            IOLOG << "ViewPoint ColorNoiseReduction malformed" << LOGENDL;
+    }
+    else if (json.find(Key_Edge_Aware_Blur_Legacy) != json.end())
+    {
+        // Backward compatibility: old projects used "EdgeAwareBlur".
+        nlohmann::json options = json.at(Key_Edge_Aware_Blur_Legacy);
+        if (options.size() == 5)
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
+        else
+            IOLOG << "ViewPoint EdgeAwareBlur (legacy) malformed" << LOGENDL;
     }
 
     if (json.find(Key_Depth_Lining) != json.end())

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -179,7 +179,7 @@ CameraNode::CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher
     registerGuiDataFunction(guiDType::renderAlphaObjectsRendering, &CameraNode::onRenderAlphaObjects);
     registerGuiDataFunction(guiDType::renderPostRenderingNormals, &CameraNode::onRenderNormals);
     registerGuiDataFunction(guiDType::renderAmbientOcclusion, &CameraNode::onRenderAmbientOcclusion);
-    registerGuiDataFunction(guiDType::renderEdgeAwareBlur, &CameraNode::onRenderEdgeAwareBlur);
+    registerGuiDataFunction(guiDType::renderColorNoiseReduction, &CameraNode::onRenderColorNoiseReduction);
     registerGuiDataFunction(guiDType::renderDepthLining, &CameraNode::onRenderDepthLining);
     registerGuiDataFunction(guiDType::renderRampScale, &CameraNode::onRenderRampScale);
     registerGuiDataFunction(guiDType::renderColorimetricFilter, &CameraNode::onRenderColorimetricFilter);
@@ -2596,10 +2596,10 @@ void CameraNode::onRenderAmbientOcclusion(IGuiData* data)
     sendNewUIViewPoint();
 }
 
-void CameraNode::onRenderEdgeAwareBlur(IGuiData* data)
+void CameraNode::onRenderColorNoiseReduction(IGuiData* data)
 {
-    auto blurData = static_cast<GuiDataEdgeAwareBlur*>(data);
-    m_edgeAwareBlur = blurData->m_blur;
+    auto blurData = static_cast<GuiDataColorNoiseReduction*>(data);
+    m_colorNoiseReduction = blurData->m_blur;
 
     sendNewUIViewPoint();
 }

--- a/src/pointCloudEngine/RenderingEcoSystem.cpp
+++ b/src/pointCloudEngine/RenderingEcoSystem.cpp
@@ -140,11 +140,11 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
     hash += hash_fn_b(display.m_postRenderingAmbientOcclusion.enabled);
     hash += hash_fn_f(display.m_postRenderingAmbientOcclusion.radius);
     hash += hash_fn_f(display.m_postRenderingAmbientOcclusion.intensity);
-    hash += hash_fn_b(display.m_edgeAwareBlur.enabled);
-    hash += hash_fn_f(display.m_edgeAwareBlur.radius);
-    hash += hash_fn_f(display.m_edgeAwareBlur.depthThreshold);
-    hash += hash_fn_f(display.m_edgeAwareBlur.blendStrength);
-    hash += hash_fn_f(display.m_edgeAwareBlur.resolutionScale);
+    hash += hash_fn_b(display.m_colorNoiseReduction.enabled);
+    hash += hash_fn_f(display.m_colorNoiseReduction.radius);
+    hash += hash_fn_f(display.m_colorNoiseReduction.depthAwareThreshold);
+    hash += hash_fn_f(display.m_colorNoiseReduction.strength);
+    hash += hash_fn_f(display.m_colorNoiseReduction.resolutionScale);
     hash += hash_fn_b(display.m_depthLining.enabled);
     hash += hash_fn_f(display.m_depthLining.strength);
     hash += hash_fn_f(display.m_depthLining.threshold);

--- a/src/pointCloudEngine/RenderingEngine.cpp
+++ b/src/pointCloudEngine/RenderingEngine.cpp
@@ -362,16 +362,16 @@ void RenderingEngine::updateHD()
     // Should be input parameters
     // NOTE: Gap filling relies on a 3x3 kernel. A base 2px border keeps a one-pixel safety zone
     // after the image transfer cropping and avoids visible seams between tiles when the texel
-    // threshold is low (e.g., 2). Post-processing passes like edge-aware blur and depth lining can
+    // threshold is low (e.g., 2). Post-processing passes like color-noise reduction and depth lining can
     // require a larger footprint, so the border is expanded accordingly.
     auto computeTileBorder = [](const DisplayParameters& display) {
         constexpr uint32_t baseBorder = 2;
         uint32_t border = baseBorder;
 
-        if (display.m_edgeAwareBlur.enabled)
+        if (display.m_colorNoiseReduction.enabled)
         {
-            const float resolutionScale = std::max(display.m_edgeAwareBlur.resolutionScale, 0.1f);
-            const uint32_t blurFootprint = static_cast<uint32_t>(std::ceil(display.m_edgeAwareBlur.radius / resolutionScale));
+            const float resolutionScale = std::max(display.m_colorNoiseReduction.resolutionScale, 0.1f);
+            const uint32_t blurFootprint = static_cast<uint32_t>(std::ceil(display.m_colorNoiseReduction.radius / resolutionScale));
             border = std::max(border, blurFootprint + 1u); // +1 to keep a safety band after cropping
         }
 
@@ -882,10 +882,10 @@ bool RenderingEngine::updateFramebuffer(VulkanViewport& viewport)
             m_postRenderer.processDepthLining(cmdBuffer, display.m_depthLining, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
         }
 
-        if (display.m_edgeAwareBlur.enabled)
+        if (display.m_colorNoiseReduction.enabled)
         {
-            vkm.beginPostTreatmentEdgeAwareBlur(framebuffer);
-            m_postRenderer.processEdgeAwareBlur(cmdBuffer, display.m_edgeAwareBlur, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
+            vkm.beginPostTreatmentColorNoiseReduction(framebuffer);
+            m_postRenderer.processColorNoiseReduction(cmdBuffer, display.m_colorNoiseReduction, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
         }
 
         if (display.m_blendMode != BlendMode::Opaque && display.m_transparency > 0.f)
@@ -1059,10 +1059,10 @@ bool RenderingEngine::renderVirtualViewport(TlFramebuffer framebuffer, const Cam
         m_postRenderer.processDepthLining(cmdBuffer, displayParam.m_depthLining, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
     }
 
-    if (displayParam.m_edgeAwareBlur.enabled)
+    if (displayParam.m_colorNoiseReduction.enabled)
     {
-        vkm.beginPostTreatmentEdgeAwareBlur(framebuffer);
-        m_postRenderer.processEdgeAwareBlur(cmdBuffer, displayParam.m_edgeAwareBlur, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
+        vkm.beginPostTreatmentColorNoiseReduction(framebuffer);
+        m_postRenderer.processColorNoiseReduction(cmdBuffer, displayParam.m_colorNoiseReduction, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
     }
 
     if (displayParam.m_blendMode != BlendMode::Opaque && displayParam.m_transparency > 0.f)

--- a/src/shaders/v2/edge_aware_blur.comp
+++ b/src/shaders/v2/edge_aware_blur.comp
@@ -11,8 +11,8 @@ layout(set = 1, binding = 2) buffer correctedDepth
 layout(push_constant) uniform PC {
    layout(offset = 0) ivec2 screenSize;
    layout(offset = 8) float radius;
-   layout(offset = 12) float depthThreshold;
-   layout(offset = 16) float blendStrength;
+   layout(offset = 12) float depthAwareThreshold;
+   layout(offset = 16) float strength;
    layout(offset = 20) float resolutionScale;
 } pc;
 
@@ -29,7 +29,7 @@ void main()
 
    // Parameters
    int r = int(max(pc.radius, 1.0));
-   float depthSigma = max(pc.depthThreshold, 1e-4);
+   float depthSigma = max(pc.depthAwareThreshold, 1e-4);
    float radiusNorm = float(r);
    int stride = int(round(max(1.0, 1.0 / max(pc.resolutionScale, 0.001))));
 
@@ -47,16 +47,27 @@ void main()
 
          float dist2 = float(x * x + y * y);
          float spatialWeight = exp(-dist2 / (2.0 * radiusNorm * radiusNorm));
-         float depthDelta = sampleDepth - centerDepth;
+
+         // Geometric edge preservation:
+         // normalized depth difference prevents excessive smoothing across depth jumps.
+         float depthNorm = max(max(centerDepth, sampleDepth), 1e-6);
+         float depthDelta = abs(sampleDepth - centerDepth) / depthNorm;
          float depthWeight = exp(-(depthDelta * depthDelta) / (2.0 * depthSigma * depthSigma));
 
-         float w = spatialWeight * depthWeight;
+         // Spray reduction:
+         // robust color gating rejects chromatic outliers inside the local neighborhood.
+         vec3 colorDelta = sampleColor - centerColor.rgb;
+         float colorDist2 = dot(colorDelta, colorDelta);
+         float colorSigma = mix(0.02, 0.22, clamp(pc.strength, 0.0, 1.0));
+         float colorWeight = 1.0 / (1.0 + colorDist2 / (colorSigma * colorSigma));
+
+         float w = spatialWeight * depthWeight * colorWeight;
          accumColor += sampleColor * w;
          accumWeight += w;
       }
    }
 
-   vec3 blurred = (accumWeight > 0.0) ? (accumColor / accumWeight) : centerColor.rgb;
-   vec3 mixed = mix(centerColor.rgb, blurred, clamp(pc.blendStrength, 0.0, 1.0));
-   imageStore(inOutColorImage, gid, vec4(mixed, centerColor.a));
+   vec3 stabilizedColor = (accumWeight > 0.0) ? (accumColor / accumWeight) : centerColor.rgb;
+   vec3 outputColor = mix(centerColor.rgb, stabilizedColor, clamp(pc.strength, 0.0, 1.0));
+   imageStore(inOutColorImage, gid, vec4(outputColor, centerColor.a));
 }

--- a/src/vulkan/Renderers/PostRenderer.cpp
+++ b/src/vulkan/Renderers/PostRenderer.cpp
@@ -30,7 +30,7 @@ static std::vector<uint32_t> transparency_hdr_comp_spv =
 #include "transparency_hdr.comp.spv"
 };
 
-static std::vector<uint32_t> edge_aware_blur_comp_spv =
+static std::vector<uint32_t> color_noise_reduction_comp_spv =
 {
 #include "edge_aware_blur.comp.spv"
 };
@@ -79,7 +79,7 @@ void PostRenderer::createShaders()
     loadShaderSPV(m_normalShadingCompShader, normal_shading_comp_spv);
     loadShaderSPV(m_normalColoredCompShader, normal_colored_comp_spv);
     loadShaderSPV(m_transparencyHDRCompShader, transparency_hdr_comp_spv);
-    loadShaderSPV(m_edgeAwareBlurCompShader, edge_aware_blur_comp_spv);
+    loadShaderSPV(m_colorNoiseReductionCompShader, color_noise_reduction_comp_spv);
     loadShaderSPV(m_depthLiningCompShader, depth_lining_comp_spv);
     loadShaderSPV(m_ambientOcclusionCompShader, ambient_occlusion_comp_spv);
 }
@@ -162,7 +162,7 @@ void PostRenderer::createPipelines()
     createFillingPipeline();
     createNormalPipeline();
     createAmbientOcclusionPipeline();
-    createEdgeAwarePipeline();
+    createColorNoiseReductionPipeline();
     createDepthLiningPipeline();
     createTransparencyHDRPipeline();
 }
@@ -219,7 +219,7 @@ void PostRenderer::createPipelineLayouts()
     VkDescriptorSetLayout DSLayout_edgeAware[] = { VulkanManager::getDSLayout_fillingSamplers(), VulkanManager::getDSLayout_finalOutput() };
     pipelineLayoutInfo.setLayoutCount = sizeof(DSLayout_edgeAware) / sizeof(VkDescriptorSetLayout);
     pipelineLayoutInfo.pSetLayouts = DSLayout_edgeAware;
-    err = h_pfn->vkCreatePipelineLayout(h_device, &pipelineLayoutInfo, nullptr, &m_edgeAwarePipelineLayout);
+    err = h_pfn->vkCreatePipelineLayout(h_device, &pipelineLayoutInfo, nullptr, &m_colorNoiseReductionPipelineLayout);
     check_vk_result(err, "Create Pipeline Layout");
 
     VkDescriptorSetLayout DSLayout_depthLining[] = { VulkanManager::getDSLayout_fillingSamplers(), VulkanManager::getDSLayout_finalOutput() };
@@ -321,14 +321,14 @@ void PostRenderer::createAmbientOcclusionPipeline()
     check_vk_result(err, "Create Compute Pipeline");
 }
 
-void PostRenderer::createEdgeAwarePipeline()
+void PostRenderer::createColorNoiseReductionPipeline()
 {
     VkPipelineShaderStageCreateInfo compStageInfo = {
         VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
         nullptr,
         0,
         VK_SHADER_STAGE_COMPUTE_BIT,
-        m_edgeAwareBlurCompShader.module(),
+        m_colorNoiseReductionCompShader.module(),
         "main",
         nullptr
     };
@@ -338,12 +338,12 @@ void PostRenderer::createEdgeAwarePipeline()
         nullptr,                  // pNext
         0,                        // flags
         compStageInfo,            // stage
-        m_edgeAwarePipelineLayout,// layout
+        m_colorNoiseReductionPipelineLayout,// layout
         VK_NULL_HANDLE,           // basePipelineHandle
         0,                        // basePipelineIndex
     };
 
-    VkResult err = h_pfn->vkCreateComputePipelines(h_device, m_pipelineCache, 1, &info, nullptr, &m_edgeAwarePipeline);
+    VkResult err = h_pfn->vkCreateComputePipelines(h_device, m_pipelineCache, 1, &info, nullptr, &m_colorNoiseReductionPipeline);
     check_vk_result(err, "Create Compute Pipeline");
 }
 
@@ -492,23 +492,23 @@ void PostRenderer::processTransparencyHDR(VkCommandBuffer _cmdBuffer, VkDescript
     h_pfn->vkCmdDispatch(_cmdBuffer, (_extent.width + 15) / 16, (_extent.height + 15) / 16, 1);
 }
 
-void PostRenderer::processEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D _extent)
+void PostRenderer::processColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D _extent)
 {
-    h_pfn->vkCmdBindPipeline(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_edgeAwarePipeline);
+    h_pfn->vkCmdBindPipeline(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_colorNoiseReductionPipeline);
 
     VkDescriptorSet descSets[] = { descSetColor, descSetDepth };
-    h_pfn->vkCmdBindDescriptorSets(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_edgeAwarePipelineLayout, 0, 2, descSets, 0, nullptr);
+    h_pfn->vkCmdBindDescriptorSets(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_colorNoiseReductionPipelineLayout, 0, 2, descSets, 0, nullptr);
 
     struct
     {
         glm::ivec2 screenSize;
         float radius;
-        float depthThreshold;
-        float blendStrength;
+        float depthAwareThreshold;
+        float strength;
         float resolutionScale;
-    } pc = { glm::ivec2(_extent.width, _extent.height), blurSettings.radius, blurSettings.depthThreshold, blurSettings.blendStrength, blurSettings.resolutionScale };
+    } pc = { glm::ivec2(_extent.width, _extent.height), blurSettings.radius, blurSettings.depthAwareThreshold, blurSettings.strength, blurSettings.resolutionScale };
 
-    h_pfn->vkCmdPushConstants(_cmdBuffer, m_edgeAwarePipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    h_pfn->vkCmdPushConstants(_cmdBuffer, m_colorNoiseReductionPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
 
     h_pfn->vkCmdDispatch(_cmdBuffer, (_extent.width + 15) / 16, (_extent.height + 15) / 16, 1);
 }
@@ -534,17 +534,17 @@ void PostRenderer::processDepthLining(VkCommandBuffer _cmdBuffer, const DepthLin
     h_pfn->vkCmdDispatch(_cmdBuffer, (_extent.width + 15) / 16, (_extent.height + 15) / 16, 1);
 }
 
-bool PostRenderer::initEdgeAwareBlur(VulkanManager& vkm, uint32_t /*swapChainImageCount*/)
+bool PostRenderer::initColorNoiseReduction(VulkanManager& vkm, uint32_t /*swapChainImageCount*/)
 {
     (void)vkm;
-    // The edge-aware blur pipeline is fully initialized in the constructor via createPipelines().
+    // The color-noise-reduction pipeline is fully initialized in the constructor via createPipelines().
     // This helper simply mirrors the pattern used by other platforms expecting an explicit init call.
-    return m_edgeAwarePipeline != VK_NULL_HANDLE && m_edgeAwareBlurCompShader.isValid();
+    return m_colorNoiseReductionPipeline != VK_NULL_HANDLE && m_colorNoiseReductionCompShader.isValid();
 }
 
-void PostRenderer::transitionAndDispatchEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent)
+void PostRenderer::transitionAndDispatchColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent)
 {
-    processEdgeAwareBlur(_cmdBuffer, blurSettings, descSetColor, descSetDepth, extent);
+    processColorNoiseReduction(_cmdBuffer, blurSettings, descSetColor, descSetDepth, extent);
 }
 
 void PostRenderer::setConstantZRange(float nearZ, float farZ, VkCommandBuffer _cmdBuffer)
@@ -638,9 +638,9 @@ void PostRenderer::cleanup()
         m_ambientOcclusionPipelineLayout = VK_NULL_HANDLE;
     }
 
-    if (m_edgeAwarePipelineLayout) {
-        h_pfn->vkDestroyPipelineLayout(h_device, m_edgeAwarePipelineLayout, nullptr);
-        m_edgeAwarePipelineLayout = VK_NULL_HANDLE;
+    if (m_colorNoiseReductionPipelineLayout) {
+        h_pfn->vkDestroyPipelineLayout(h_device, m_colorNoiseReductionPipelineLayout, nullptr);
+        m_colorNoiseReductionPipelineLayout = VK_NULL_HANDLE;
     }
 
     if (m_depthLiningPipelineLayout) {
@@ -678,10 +678,10 @@ void PostRenderer::cleanup()
         m_ambientOcclusionPipeline = VK_NULL_HANDLE;
     }
 
-    if (m_edgeAwarePipeline)
+    if (m_colorNoiseReductionPipeline)
     {
-        h_pfn->vkDestroyPipeline(h_device, m_edgeAwarePipeline, nullptr);
-        m_edgeAwarePipeline = VK_NULL_HANDLE;
+        h_pfn->vkDestroyPipeline(h_device, m_colorNoiseReductionPipeline, nullptr);
+        m_colorNoiseReductionPipeline = VK_NULL_HANDLE;
     }
 
     if (m_depthLiningPipeline)

--- a/src/vulkan/Renderers/PostRenderer.h
+++ b/src/vulkan/Renderers/PostRenderer.h
@@ -28,12 +28,12 @@ public:
     void processNormalColored(VkCommandBuffer _cmdBuffer, VkUniformOffset matrixUniOffset, VkDescriptorSet descSetColor, VkDescriptorSet descSetOutput, VkExtent2D extent);
     void processTransparencyHDR(VkCommandBuffer _cmdBuffer, VkDescriptorSet descSetColor, VkExtent2D extent);
     void processAmbientOcclusion(VkCommandBuffer _cmdBuffer, const PostRenderingAmbientOcclusion& aoSettings, float nearZ, float farZ, bool isPerspective, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
-    void processEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
+    void processColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
     void processDepthLining(VkCommandBuffer _cmdBuffer, const DepthLining& liningSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
 
     // Compatibility helpers used by some build targets
-    bool initEdgeAwareBlur(VulkanManager& vkm, uint32_t swapChainImageCount);
-    void transitionAndDispatchEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
+    bool initColorNoiseReduction(VulkanManager& vkm, uint32_t swapChainImageCount);
+    void transitionAndDispatchColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
     void setConstantZRange(float nearZ, float farZ, VkCommandBuffer _cmdBuffer);
     void setConstantScreenSize(VkExtent2D screenSize, glm::vec2 pixelSize, VkCommandBuffer _cmdBuffer);
     void setConstantScreenOffset(glm::vec2 offset, VkCommandBuffer cmdBuffer);
@@ -54,7 +54,7 @@ private:
     void createFillingPipeline();
     void createNormalPipeline();
     void createAmbientOcclusionPipeline();
-    void createEdgeAwarePipeline();
+    void createColorNoiseReductionPipeline();
     void createDepthLiningPipeline();
     void createTransparencyHDRPipeline();
 
@@ -82,7 +82,7 @@ private:
     Shader m_normalColoredCompShader;
     Shader m_transparencyHDRCompShader;
     Shader m_ambientOcclusionCompShader;
-    Shader m_edgeAwareBlurCompShader;
+    Shader m_colorNoiseReductionCompShader;
     Shader m_depthLiningCompShader;
 
     VkPipeline m_fillingPipeline;
@@ -91,10 +91,10 @@ private:
     VkPipeline m_ambientOcclusionPipeline = VK_NULL_HANDLE;
     VkPipeline m_transparencyHDRPipeline;
     VkPipeline m_hdrSubsPipeline;
-    VkPipeline m_edgeAwarePipeline;
+    VkPipeline m_colorNoiseReductionPipeline;
     VkPipeline m_depthLiningPipeline;
 
-    VkPipelineLayout m_edgeAwarePipelineLayout = VK_NULL_HANDLE;
+    VkPipelineLayout m_colorNoiseReductionPipelineLayout = VK_NULL_HANDLE;
     VkPipelineLayout m_depthLiningPipelineLayout = VK_NULL_HANDLE;
 };
 

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -966,7 +966,7 @@ void VulkanManager::beginPostTreatmentAmbientOcclusion(TlFramebuffer _fb)
     beginPostTreatmentNormal(_fb);
 }
 
-void VulkanManager::beginPostTreatmentEdgeAwareBlur(TlFramebuffer _fb)
+void VulkanManager::beginPostTreatmentColorNoiseReduction(TlFramebuffer _fb)
 {
     beginPostTreatmentNormal(_fb);
 }


### PR DESCRIPTION
### Motivation

- Replace the legacy "edge-aware blur" post-process with a redesigned "color noise reduction" pass focusing on spray/noise reduction while preserving geometry edges.
- Update APIs, UI and serialization keys to reflect the new feature name and parameters, and keep backward compatibility with existing projects.
- Integrate the updated algorithm into the rendering pipeline and shader stack to drive the new behavior and controls.

### Description

- Renamed types, members and gui enum entries from `EdgeAwareBlur`/`edgeAwareBlur` to `ColorNoiseReduction`/`colorNoiseReduction` across headers and sources, including `RenderingTypes.h`, model classes, GUI data and toolbar code.
- Updated UI labels and widget names (toolbar .ui files and tooltip text) to show "Color noise reduction" and renamed related slots/handlers accordingly.
- Reworked shader and post-processing: replaced `edge_aware_blur.comp` logic with color-noise-aware computations, changed push-constant fields (`depthThreshold`/`blendStrength` -> `depthAwareThreshold`/`strength`), and adapted SPV loading and pipeline creation to `color_noise_reduction` variants in `PostRenderer` and rendering code.
- Updated Vulkan manager interfaces and PostRenderer calls (`beginPostTreatmentEdgeAwareBlur` -> `beginPostTreatmentColorNoiseReduction`, pipeline names, init/dispatch helpers) and adjusted all call sites in the renderer to use the new APIs.
- Updated import/export/serialization keys: replaced `Key_Edge_Aware_Blur` with `Key_Color_Noise_Reduction` and added `Key_Edge_Aware_Blur_Legacy` to preserve backward compatibility when reading old presets/viewpoints.
- Preserved behavior where appropriate (resolution scales, fixed internal depth gate for pass 1) and mapped old stored values to the new struct for seamless migration.

### Testing

- Performed a full project build (Debug and Release) after changes and the build completed successfully.
- Ensured shader SPV is loaded by the `PostRenderer` and pipelines are created for the new compute pass without compile/runtime linker errors during the build.
- Serialization compatibility added: legacy key `EdgeAwareBlur` is supported when deserializing presets/viewpoints to the new `ColorNoiseReduction` fields; no automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7648a5e0832f9a4e4464201f334c)