### PR TITLE
Introduce ColorNoiseReduction (replace EdgeAwareBlur), add experimental cartoon palette and related refactor

### DIFF
--- a/include/controller/controls/AnimationHelper.h
+++ b/include/controller/controls/AnimationHelper.h
@@ -53,7 +53,7 @@ namespace control::animation::helper
             reference.m_postRenderingNormals.show == candidate.m_postRenderingNormals.show &&
             reference.m_postRenderingAmbientOcclusion.enabled == candidate.m_postRenderingAmbientOcclusion.enabled &&
             reference.m_postRenderingNormals.blendColor == candidate.m_postRenderingNormals.blendColor &&
-            reference.m_edgeAwareBlur.enabled == candidate.m_edgeAwareBlur.enabled &&
+            reference.m_colorNoiseReduction.enabled == candidate.m_colorNoiseReduction.enabled &&
             reference.m_depthLining.enabled == candidate.m_depthLining.enabled &&
             reference.m_depthLining.strongMode == candidate.m_depthLining.strongMode;
     }

--- a/include/gui/GuiData/GuiDataRendering.h
+++ b/include/gui/GuiData/GuiDataRendering.h
@@ -344,15 +344,15 @@ public:
 	PostRenderingAmbientOcclusion m_ao;
 };
 
-class GuiDataEdgeAwareBlur : public GuiDataActiveCamera
+class GuiDataColorNoiseReduction : public GuiDataActiveCamera
 {
 public:
-        GuiDataEdgeAwareBlur(const EdgeAwareBlur& blurSettings, SafePtr<CameraNode> camera);
-        ~GuiDataEdgeAwareBlur() {};
+        GuiDataColorNoiseReduction(const ColorNoiseReduction& blurSettings, SafePtr<CameraNode> camera);
+        ~GuiDataColorNoiseReduction() {};
         virtual guiDType getType() override;
 
 public:
-        EdgeAwareBlur m_blur;
+        ColorNoiseReduction m_blur;
 };
 
 class GuiDataDepthLining : public GuiDataActiveCamera

--- a/include/gui/GuiData/IGuiData.h
+++ b/include/gui/GuiData/IGuiData.h
@@ -76,7 +76,7 @@ enum class guiDType
         renderAlphaObjectsRendering,
         renderPostRenderingNormals,
         renderAmbientOcclusion,
-        renderEdgeAwareBlur,
+        renderColorNoiseReduction,
         renderDepthLining,
         renderRampScale,
         renderColorimetricFilter,

--- a/include/gui/toolBars/ToolBarRenderEnhance.h
+++ b/include/gui/toolBars/ToolBarRenderEnhance.h
@@ -25,8 +25,8 @@ private:
 	void onActiveCamera(IGuiData* data);
 	void onFocusViewport(IGuiData* data);
 	void blockAllSignals(bool block);
-	void updateEdgeAwareBlurUi(bool enabled);
-	EdgeAwareBlur getEdgeAwareBlurFromUi() const;
+	void updateColorNoiseReductionUi(bool enabled);
+	ColorNoiseReduction getColorNoiseReductionFromUi() const;
 	void updateDepthLiningUi(bool enabled);
 	DepthLining getDepthLiningFromUi() const;
 
@@ -43,8 +43,8 @@ private:
 	SafePtr<CameraNode> m_focusCamera;
 
 private slots:
-	void slotEdgeAwareBlurToggled(int state);
-	void slotEdgeAwareBlurValueChanged(int value);
+	void slotColorNoiseReductionToggled(int state);
+	void slotColorNoiseReductionValueChanged(int value);
 	void slotDepthLiningToggled(int state);
 	void slotDepthLiningValueChanged(int value);
 	void slotDepthLiningSensitivityChanged(int value);

--- a/include/io/SerializerKeys.h
+++ b/include/io/SerializerKeys.h
@@ -226,6 +226,7 @@
 #define Key_Cartoon_Value_Levels			"CartoonValueLevels"
 #define Key_Cartoon_Saturation_Min_Percent		"CartoonSaturationMinPercent"
 #define Key_Cartoon_Saturation_Levels			"CartoonSaturationLevels"
+#define Key_Cartoon_Experimental_Palette_Size		"CartoonExperimentalPaletteSize"
 
 #define Key_DistRamp					"DistanceRamp"
 #define Key_DistRampSteps				"DistanceRampSteps"
@@ -241,7 +242,9 @@
 
 #define Key_Post_Rendering_Normals		"PostRenderingNormals"
 #define Key_Post_Rendering_Ambient_Occlusion "PostRenderingAmbientOcclusion"
-#define Key_Edge_Aware_Blur			"EdgeAwareBlur"
+#define Key_Color_Noise_Reduction			"ColorNoiseReduction"
+// Legacy key kept for backward compatibility with old projects/viewpoints.
+#define Key_Edge_Aware_Blur_Legacy            "EdgeAwareBlur"
 #define Key_Depth_Lining			"DepthLining"
 #define Key_Display_Guizmo				"DisplayGuizmo"
 #define Key_Ramp_Scale_Options			"RampScaleOptions"

--- a/include/models/3d/DisplayParameters.h
+++ b/include/models/3d/DisplayParameters.h
@@ -81,9 +81,12 @@ public:
     float          m_hue = 0.f;
     glm::vec3      m_flatColor = glm::vec3(0.5f);
     // Cartoon RGB (display-only) parameters.
-    int            m_cartoonValueLevels = 8;
+    int            m_cartoonValueLevels = 6;
     int            m_cartoonSaturationMinPercent = 12; // [0..100]
     int            m_cartoonSaturationLevels = 4;
+    // Internal/dev toggle for pass 3A evaluation:
+    // 0 => legacy cartoon quantization, >0 => experimental palette path (palette size).
+    int            m_cartoonExperimentalPaletteSize = 0;
 
     // Ramp Distance
     float          m_distRampMin = 0.f;
@@ -103,7 +106,7 @@ public:
     // Post processing
     PostRenderingNormals    m_postRenderingNormals = { true, false, true, 0.4f, 1.f };
     PostRenderingAmbientOcclusion m_postRenderingAmbientOcclusion = {};
-    EdgeAwareBlur           m_edgeAwareBlur = {};
+    ColorNoiseReduction           m_colorNoiseReduction = {};
     DepthLining             m_depthLining = {};
 
     // GUI

--- a/include/models/application/ViewPointAnimation.h
+++ b/include/models/application/ViewPointAnimation.h
@@ -62,7 +62,7 @@ struct AnimationViewpointInfo
     BlendMode blendMode = BlendMode::Opaque;
     bool normals = false;
     bool blendColor = false;
-    bool edgeAwareBlur = false;
+    bool colorNoiseReduction = false;
     bool depthLining = false;
     bool depthLiningStrongMode = false;
 };

--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -56,6 +56,7 @@ struct ViewpointRenderState
     float cartoonValueLevels = 0.0f;
     float cartoonSaturationMinPercent = 0.0f;
     float cartoonSaturationLevels = 0.0f;
+    float cartoonExperimentalPaletteSize = 0.0f;
     float alphaObject = 0.0f;
     float fovy = 0.0f;
     std::unordered_set<SafePtr<AGraphNode>> visibleObjects;
@@ -300,7 +301,7 @@ private:
     void onRenderAlphaObjects(IGuiData* data);
     void onRenderNormals(IGuiData* data);
     void onRenderAmbientOcclusion(IGuiData* data);
-    void onRenderEdgeAwareBlur(IGuiData* data);
+    void onRenderColorNoiseReduction(IGuiData* data);
     void onRenderDepthLining(IGuiData* data);
     void onRenderRampScale(IGuiData* data);
     void onRenderColorimetricFilter(IGuiData* data);

--- a/include/pointCloudEngine/RenderingTypes.h
+++ b/include/pointCloudEngine/RenderingTypes.h
@@ -93,12 +93,15 @@ struct PostRenderingAmbientOcclusion
     float intensity = 0.4f;
 };
 
-struct EdgeAwareBlur
+struct ColorNoiseReduction
 {
     bool enabled = true;
-    float radius = 2.0f;
-    float depthThreshold = 0.35f;
-    float blendStrength = 0.25f;
+    float radius = 5.0f;
+    // Internal depth gate used to preserve geometric edges.
+    // Intentionally not exposed in the UI for pass 1.
+    float depthAwareThreshold = 0.05f;
+    // User-facing intensity of the spray/noise reduction.
+    float strength = 0.45f;
     float resolutionScale = 1.0f; // 1.0 = full res, 0.5 = half res
 };
 

--- a/include/vulkan/VulkanManager.h
+++ b/include/vulkan/VulkanManager.h
@@ -144,7 +144,7 @@ public:
     void beginPostTreatmentFilling(TlFramebuffer framebuffer);
     void beginPostTreatmentNormal(TlFramebuffer framebuffer);
     void beginPostTreatmentAmbientOcclusion(TlFramebuffer framebuffer);
-    void beginPostTreatmentEdgeAwareBlur(TlFramebuffer framebuffer);
+    void beginPostTreatmentColorNoiseReduction(TlFramebuffer framebuffer);
     void beginPostTreatmentDepthLining(TlFramebuffer framebuffer);
     void beginPostTreatmentTransparency(TlFramebuffer framebuffer);
 

--- a/src/controller/controls/ControlAnimation.cpp
+++ b/src/controller/controls/ControlAnimation.cpp
@@ -42,7 +42,7 @@ namespace control::animation
                 info.blendMode = rViewpoint->m_blendMode;
                 info.normals = rViewpoint->m_postRenderingNormals.show;
                 info.blendColor = rViewpoint->m_postRenderingNormals.blendColor;
-                info.edgeAwareBlur = rViewpoint->m_edgeAwareBlur.enabled;
+                info.colorNoiseReduction = rViewpoint->m_colorNoiseReduction.enabled;
                 info.depthLining = rViewpoint->m_depthLining.enabled;
                 info.depthLiningStrongMode = rViewpoint->m_depthLining.strongMode;
                 viewpoints.push_back(info);

--- a/src/gui/Dialog/DialogAnimationConfig.cpp
+++ b/src/gui/Dialog/DialogAnimationConfig.cpp
@@ -455,7 +455,7 @@ void DialogAnimationConfig::checkRenderingConsistency(const xg::Guid& newViewpoi
         current.blendMode == ref.blendMode &&
         current.normals == ref.normals &&
         current.blendColor == ref.blendColor &&
-        current.edgeAwareBlur == ref.edgeAwareBlur &&
+        current.colorNoiseReduction == ref.colorNoiseReduction &&
         current.depthLining == ref.depthLining &&
         current.depthLiningStrongMode == ref.depthLiningStrongMode;
 

--- a/src/gui/DisplayPresetManager.cpp
+++ b/src/gui/DisplayPresetManager.cpp
@@ -67,6 +67,7 @@ namespace
 		json[Key_Cartoon_Value_Levels] = params.m_cartoonValueLevels;
 		json[Key_Cartoon_Saturation_Min_Percent] = params.m_cartoonSaturationMinPercent;
 		json[Key_Cartoon_Saturation_Levels] = params.m_cartoonSaturationLevels;
+		json[Key_Cartoon_Experimental_Palette_Size] = params.m_cartoonExperimentalPaletteSize;
 		json[Key_Flat_Color] = { params.m_flatColor.x, params.m_flatColor.y, params.m_flatColor.z };
 
 			json[Key_DistRamp] = { params.m_distRampMin, params.m_distRampMax };
@@ -83,7 +84,7 @@ namespace
 
 		json[Key_Post_Rendering_Normals] = { params.m_postRenderingNormals.show, params.m_postRenderingNormals.inverseTone, params.m_postRenderingNormals.blendColor, params.m_postRenderingNormals.normalStrength, params.m_postRenderingNormals.gloss };
 		json[Key_Post_Rendering_Ambient_Occlusion] = { params.m_postRenderingAmbientOcclusion.enabled, params.m_postRenderingAmbientOcclusion.radius, params.m_postRenderingAmbientOcclusion.intensity };
-		json[Key_Edge_Aware_Blur] = { params.m_edgeAwareBlur.enabled, params.m_edgeAwareBlur.radius, params.m_edgeAwareBlur.depthThreshold, params.m_edgeAwareBlur.blendStrength, params.m_edgeAwareBlur.resolutionScale };
+		json[Key_Color_Noise_Reduction] = { params.m_colorNoiseReduction.enabled, params.m_colorNoiseReduction.radius, params.m_colorNoiseReduction.depthAwareThreshold, params.m_colorNoiseReduction.strength, params.m_colorNoiseReduction.resolutionScale };
 		json[Key_Depth_Lining] = { params.m_depthLining.enabled, params.m_depthLining.strength, params.m_depthLining.threshold, params.m_depthLining.sensitivity, params.m_depthLining.strongMode };
 
 		json[Key_Display_Guizmo] = params.m_displayGizmo;
@@ -258,7 +259,7 @@ namespace
 		if (json.find(Key_Cartoon_Value_Levels) != json.end())
 			data.m_cartoonValueLevels = json.at(Key_Cartoon_Value_Levels).get<int>();
 		else
-			data.m_cartoonValueLevels = 8;
+			data.m_cartoonValueLevels = 6;
 
 		if (json.find(Key_Cartoon_Saturation_Min_Percent) != json.end())
 			data.m_cartoonSaturationMinPercent = json.at(Key_Cartoon_Saturation_Min_Percent).get<int>();
@@ -269,6 +270,12 @@ namespace
 			data.m_cartoonSaturationLevels = json.at(Key_Cartoon_Saturation_Levels).get<int>();
 		else
 			data.m_cartoonSaturationLevels = 4;
+
+		// Pass 3A (internal): optional experimental palette size for cartoon mode.
+		if (json.find(Key_Cartoon_Experimental_Palette_Size) != json.end())
+			data.m_cartoonExperimentalPaletteSize = std::max(0, json.at(Key_Cartoon_Experimental_Palette_Size).get<int>());
+		else
+			data.m_cartoonExperimentalPaletteSize = 0;
 
 		if (json.find(Key_Flat_Color) != json.end())
 		{
@@ -599,11 +606,18 @@ namespace
 				data.m_postRenderingAmbientOcclusion = { options[0], options[1], options[2] };
 		}
 
-		if (json.find(Key_Edge_Aware_Blur) != json.end())
+		if (json.find(Key_Color_Noise_Reduction) != json.end())
 		{
-			nlohmann::json options = json.at(Key_Edge_Aware_Blur);
+			nlohmann::json options = json.at(Key_Color_Noise_Reduction);
 			if (options.size() == 5)
-				data.m_edgeAwareBlur = { options[0], options[1], options[2], options[3], options[4] };
+				data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
+		}
+		else if (json.find(Key_Edge_Aware_Blur_Legacy) != json.end())
+		{
+			// Backward compatibility with legacy display presets.
+			nlohmann::json options = json.at(Key_Edge_Aware_Blur_Legacy);
+			if (options.size() == 5)
+				data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
 		}
 
 		if (json.find(Key_Depth_Lining) != json.end())
@@ -967,7 +981,7 @@ void DisplayPresetManager::applyPreset(const DisplayPreset& preset)
 	m_dataDispatcher.updateInformation(new GuiDataRenderTransparencyOptions(params.m_negativeEffect, params.m_reduceFlash, params.m_flashAdvanced, params.m_highlightKneeStart, params.m_highlightKneeSoftness, params.m_advancedFlashBoost, 0.f, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataPostRenderingNormals(params.m_postRenderingNormals, false, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderAmbientOcclusion(params.m_postRenderingAmbientOcclusion, m_focusCamera), this);
-	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(params.m_edgeAwareBlur, m_focusCamera), this);
+	m_dataDispatcher.updateInformation(new GuiDataColorNoiseReduction(params.m_colorNoiseReduction, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataDepthLining(params.m_depthLining, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderColorimetricFilter(params.m_colorimetricFilter, m_focusCamera), this);
 	m_dataDispatcher.updateInformation(new GuiDataRenderPolygonalSelector(params.m_polygonalSelector, m_focusCamera), this);
@@ -1060,7 +1074,7 @@ DisplayPresetManager::DisplayPreset DisplayPresetManager::getRawPreset() const
 	parameters.m_saturation = 0.f;
 	parameters.m_postRenderingNormals.show = false;
 	parameters.m_postRenderingAmbientOcclusion.enabled = false;
-	parameters.m_edgeAwareBlur.enabled = false;
+	parameters.m_colorNoiseReduction.enabled = false;
 	parameters.m_depthLining.enabled = false;
 	preset.displayParameters = parameters;
 	preset.showHideState = getDefaultShowHideState();

--- a/src/gui/GuiData/GuiDataRendering.cpp
+++ b/src/gui/GuiData/GuiDataRendering.cpp
@@ -348,14 +348,14 @@ guiDType GuiDataRenderAmbientOcclusion::getType()
 	return guiDType::renderAmbientOcclusion;
 }
 
-GuiDataEdgeAwareBlur::GuiDataEdgeAwareBlur(const EdgeAwareBlur& blurSettings, SafePtr<CameraNode> camera)
+GuiDataColorNoiseReduction::GuiDataColorNoiseReduction(const ColorNoiseReduction& blurSettings, SafePtr<CameraNode> camera)
         : GuiDataActiveCamera(camera)
         , m_blur(blurSettings)
 {}
 
-guiDType GuiDataEdgeAwareBlur::getType()
+guiDType GuiDataColorNoiseReduction::getType()
 {
-        return  guiDType::renderEdgeAwareBlur;
+        return  guiDType::renderColorNoiseReduction;
 }
 
 GuiDataDepthLining::GuiDataDepthLining(const DepthLining& liningSettings, SafePtr<CameraNode> camera)

--- a/src/gui/forms/toolbar_renderenhance.ui
+++ b/src/gui/forms/toolbar_renderenhance.ui
@@ -30,9 +30,9 @@
     <number>3</number>
    </property>
    <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="checkBox_edgeAwareBlur">
+   <widget class="QCheckBox" name="checkBox_colorNoiseReduction">
      <property name="text">
-      <string>Smooth render</string>
+      <string>Color noise reduction</string>
      </property>
     </widget>
    </item>
@@ -87,9 +87,9 @@
     <widget class="QSpinBox" name="spinBox_edgeAwareDepth"/>
    </item>
    <item row="2" column="2">
-    <widget class="QLabel" name="label_mix">
+   <widget class="QLabel" name="label_mix">
      <property name="text">
-      <string>Mix</string>
+      <string>Strength</string>
      </property>
     </widget>
    </item>

--- a/src/gui/forms/toolbar_renderenhancegroup.ui
+++ b/src/gui/forms/toolbar_renderenhancegroup.ui
@@ -57,12 +57,12 @@
     </widget>
    </item>
    <item row="0" column="0" colspan="2">
-    <widget class="QCheckBox" name="checkBox_edgeAwareBlur">
+   <widget class="QCheckBox" name="checkBox_colorNoiseReduction">
      <property name="toolTip">
-      <string>This function adds a slight blur that can help soften the rendering. It is best to keep the values fairly low. </string>
+      <string>Reduces color spray/noise on scans while preserving geometric edges.</string>
      </property>
      <property name="text">
-      <string>Smooth render</string>
+      <string>Color noise reduction</string>
      </property>
     </widget>
    </item>
@@ -147,7 +147,7 @@
       <number>20</number>
      </property>
      <property name="value">
-      <number>2</number>
+      <number>5</number>
      </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -179,14 +179,14 @@
       <number>20</number>
      </property>
      <property name="value">
-      <number>2</number>
+      <number>5</number>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_mix">
+   <widget class="QLabel" name="label_mix">
      <property name="text">
-      <string>Mix</string>
+      <string>Strength</string>
      </property>
     </widget>
    </item>
@@ -198,6 +198,9 @@
        <height>0</height>
       </size>
      </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
      <property name="value">
       <number>30</number>
      </property>
@@ -208,6 +211,9 @@
    </item>
    <item row="2" column="2">
     <widget class="QSpinBox" name="spinBox_edgeAwareBlend">
+     <property name="maximum">
+      <number>100</number>
+     </property>
      <property name="value">
       <number>30</number>
      </property>

--- a/src/gui/forms/toolbar_rendersettingsgroup.ui
+++ b/src/gui/forms/toolbar_rendersettingsgroup.ui
@@ -618,7 +618,7 @@
       <number>64</number>
      </property>
      <property name="value">
-      <number>8</number>
+      <number>6</number>
      </property>
     </widget>
    </item>

--- a/src/gui/toolBars/ToolBarRenderEnhance.cpp
+++ b/src/gui/toolBars/ToolBarRenderEnhance.cpp
@@ -12,9 +12,16 @@ namespace
 {
 	constexpr float DEPTH_LINING_STRENGTH_UI_SCALE = 1.5f;
 	constexpr float DEPTH_LINING_SENSITIVITY_UI_SCALE = 3.0f;
-	constexpr int EDGE_AWARE_DEPTH_FIXED = 5;
-	[[maybe_unused]] constexpr std::array<const char*, 3> EDGE_AWARE_RESOLUTION_LABELS = { "Full res", "Half res", "Quarter res" };
-	constexpr std::array<float, 3> EDGE_AWARE_RESOLUTION_SCALES = { 1.0f, 0.5f, 0.25f };
+	// Fixed depth gate for pass 1 (no dedicated UI control requested).
+	constexpr int COLOR_NOISE_REDUCTION_DEPTH_FIXED = 5;
+	[[maybe_unused]] constexpr std::array<const char*, 3> COLOR_NOISE_REDUCTION_RESOLUTION_LABELS = { "Full res", "Half res", "Quarter res" };
+	constexpr std::array<float, 3> COLOR_NOISE_REDUCTION_RESOLUTION_SCALES = { 1.0f, 0.5f, 0.25f };
+	// Pass 2 tuning:
+	// Keep full-res on small kernels, switch to half-res sampling on larger kernels
+	// to stabilize performance while preserving perceived sharpness.
+	constexpr int COLOR_NOISE_REDUCTION_HALF_RES_RADIUS_THRESHOLD = 5;
+	// UI strength is expressed as percentage [0..100], while shader strength is [0..1.5].
+	constexpr float COLOR_NOISE_REDUCTION_STRENGTH_UI_TO_SHADER = 1.5f;
 }
 
 ToolBarRenderEnhance::ToolBarRenderEnhance(IDataDispatcher& dataDispatcher, QWidget* parent, float guiScale)
@@ -26,14 +33,14 @@ ToolBarRenderEnhance::ToolBarRenderEnhance(IDataDispatcher& dataDispatcher, QWid
 	setEnabled(false);
 	(void)guiScale;
 
-	connect(m_ui.checkBox_edgeAwareBlur, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotEdgeAwareBlurToggled);
+	connect(m_ui.checkBox_colorNoiseReduction, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotColorNoiseReductionToggled);
 	connect(m_ui.slider_edgeAwareRadius, &QSlider::valueChanged, m_ui.spinBox_edgeAwareRadius, &QSpinBox::setValue);
 	connect(m_ui.spinBox_edgeAwareRadius, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_edgeAwareRadius, &QSlider::setValue);
-	connect(m_ui.slider_edgeAwareRadius, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotEdgeAwareBlurValueChanged);
+	connect(m_ui.slider_edgeAwareRadius, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotColorNoiseReductionValueChanged);
 
 	connect(m_ui.slider_edgeAwareBlend, &QSlider::valueChanged, m_ui.spinBox_edgeAwareBlend, &QSpinBox::setValue);
 	connect(m_ui.spinBox_edgeAwareBlend, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), m_ui.slider_edgeAwareBlend, &QSlider::setValue);
-	connect(m_ui.slider_edgeAwareBlend, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotEdgeAwareBlurValueChanged);
+	connect(m_ui.slider_edgeAwareBlend, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotColorNoiseReductionValueChanged);
 
 	connect(m_ui.checkBox_depthLining, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotDepthLiningToggled);
 	connect(m_ui.slider_depthLiningStrength, &QSlider::valueChanged, m_ui.spinBox_depthLiningStrength, &QSpinBox::setValue);
@@ -44,7 +51,7 @@ ToolBarRenderEnhance::ToolBarRenderEnhance(IDataDispatcher& dataDispatcher, QWid
 	connect(m_ui.slider_depthLiningSensitivity, &QSlider::valueChanged, this, &ToolBarRenderEnhance::slotDepthLiningSensitivityChanged);
 	connect(m_ui.checkBox_depthLiningStrongMode, &QCheckBox::stateChanged, this, &ToolBarRenderEnhance::slotDepthLiningStrongModeToggled);
 
-	updateEdgeAwareBlurUi(m_ui.checkBox_edgeAwareBlur->isChecked());
+	updateColorNoiseReductionUi(m_ui.checkBox_colorNoiseReduction->isChecked());
 	updateDepthLiningUi(m_ui.checkBox_depthLining->isChecked());
 
 	registerGuiDataFunction(guiDType::projectLoaded, &ToolBarRenderEnhance::onProjectLoad);
@@ -81,21 +88,24 @@ void ToolBarRenderEnhance::onActiveCamera(IGuiData* data)
 
 	blockAllSignals(true);
 
-	const EdgeAwareBlur& blurSettings = displayParameters.m_edgeAwareBlur;
-	int radiusValue = std::clamp(static_cast<int>(std::round(blurSettings.radius)), m_ui.slider_edgeAwareRadius->minimum(), m_ui.slider_edgeAwareRadius->maximum());
-	int blendValue = std::clamp(static_cast<int>(std::round(blurSettings.blendStrength * 100.f)), m_ui.slider_edgeAwareBlend->minimum(), m_ui.slider_edgeAwareBlend->maximum());
+	const ColorNoiseReduction& noiseReductionSettings = displayParameters.m_colorNoiseReduction;
+	int radiusValue = std::clamp(static_cast<int>(std::round(noiseReductionSettings.radius)), m_ui.slider_edgeAwareRadius->minimum(), m_ui.slider_edgeAwareRadius->maximum());
+	int strengthValue = std::clamp(
+		static_cast<int>(std::round((noiseReductionSettings.strength / COLOR_NOISE_REDUCTION_STRENGTH_UI_TO_SHADER) * 100.f)),
+		m_ui.slider_edgeAwareBlend->minimum(),
+		m_ui.slider_edgeAwareBlend->maximum());
 
 	const DepthLining& liningSettings = displayParameters.m_depthLining;
 	int liningStrength = std::clamp(static_cast<int>(std::round((liningSettings.strength / DEPTH_LINING_STRENGTH_UI_SCALE) * 100.f)), m_ui.slider_depthLiningStrength->minimum(), m_ui.slider_depthLiningStrength->maximum());
 	int liningSensitivity = std::clamp(static_cast<int>(std::round((liningSettings.sensitivity / DEPTH_LINING_SENSITIVITY_UI_SCALE) * 100.f)), m_ui.slider_depthLiningSensitivity->minimum(), m_ui.slider_depthLiningSensitivity->maximum());
 
-	m_ui.checkBox_edgeAwareBlur->setChecked(blurSettings.enabled);
+	m_ui.checkBox_colorNoiseReduction->setChecked(noiseReductionSettings.enabled);
 	m_ui.slider_edgeAwareRadius->setValue(radiusValue);
 	m_ui.spinBox_edgeAwareRadius->setValue(radiusValue);
-	m_ui.slider_edgeAwareBlend->setValue(blendValue);
-	m_ui.spinBox_edgeAwareBlend->setValue(blendValue);
+	m_ui.slider_edgeAwareBlend->setValue(strengthValue);
+	m_ui.spinBox_edgeAwareBlend->setValue(strengthValue);
 
-	updateEdgeAwareBlurUi(blurSettings.enabled);
+	updateColorNoiseReductionUi(noiseReductionSettings.enabled);
 
 	m_ui.checkBox_depthLining->setChecked(liningSettings.enabled);
 	m_ui.slider_depthLiningStrength->setValue(liningStrength);
@@ -117,7 +127,7 @@ void ToolBarRenderEnhance::onFocusViewport(IGuiData* data)
 
 void ToolBarRenderEnhance::blockAllSignals(bool block)
 {
-	m_ui.checkBox_edgeAwareBlur->blockSignals(block);
+	m_ui.checkBox_colorNoiseReduction->blockSignals(block);
 	m_ui.slider_edgeAwareRadius->blockSignals(block);
 	m_ui.spinBox_edgeAwareRadius->blockSignals(block);
 	m_ui.slider_edgeAwareBlend->blockSignals(block);
@@ -130,7 +140,7 @@ void ToolBarRenderEnhance::blockAllSignals(bool block)
 	m_ui.checkBox_depthLiningStrongMode->blockSignals(block);
 }
 
-void ToolBarRenderEnhance::updateEdgeAwareBlurUi(bool enabled)
+void ToolBarRenderEnhance::updateColorNoiseReductionUi(bool enabled)
 {
 	m_ui.slider_edgeAwareRadius->setEnabled(enabled);
 	m_ui.spinBox_edgeAwareRadius->setEnabled(enabled);
@@ -138,14 +148,19 @@ void ToolBarRenderEnhance::updateEdgeAwareBlurUi(bool enabled)
 	m_ui.spinBox_edgeAwareBlend->setEnabled(enabled);
 }
 
-EdgeAwareBlur ToolBarRenderEnhance::getEdgeAwareBlurFromUi() const
+ColorNoiseReduction ToolBarRenderEnhance::getColorNoiseReductionFromUi() const
 {
-	EdgeAwareBlur settings = {};
-	settings.enabled = m_ui.checkBox_edgeAwareBlur->isChecked();
-	settings.radius = static_cast<float>(m_ui.spinBox_edgeAwareRadius->value());
-	settings.depthThreshold = static_cast<float>(EDGE_AWARE_DEPTH_FIXED) / 100.f;
-	settings.blendStrength = m_ui.spinBox_edgeAwareBlend->value() / 100.f;
-	settings.resolutionScale = EDGE_AWARE_RESOLUTION_SCALES.front();
+	ColorNoiseReduction settings = {};
+	settings.enabled = m_ui.checkBox_colorNoiseReduction->isChecked();
+	const int radiusUi = std::clamp(m_ui.spinBox_edgeAwareRadius->value(), m_ui.slider_edgeAwareRadius->minimum(), m_ui.slider_edgeAwareRadius->maximum());
+	const int strengthUi = std::clamp(m_ui.spinBox_edgeAwareBlend->value(), m_ui.slider_edgeAwareBlend->minimum(), m_ui.slider_edgeAwareBlend->maximum());
+
+	settings.radius = static_cast<float>(radiusUi);
+	settings.depthAwareThreshold = static_cast<float>(COLOR_NOISE_REDUCTION_DEPTH_FIXED) / 100.f;
+	settings.strength = (strengthUi / 100.f) * COLOR_NOISE_REDUCTION_STRENGTH_UI_TO_SHADER;
+	settings.resolutionScale = (radiusUi >= COLOR_NOISE_REDUCTION_HALF_RES_RADIUS_THRESHOLD)
+		? COLOR_NOISE_REDUCTION_RESOLUTION_SCALES[1]
+		: COLOR_NOISE_REDUCTION_RESOLUTION_SCALES[0];
 
 	return settings;
 }
@@ -172,19 +187,19 @@ DepthLining ToolBarRenderEnhance::getDepthLiningFromUi() const
 	return settings;
 }
 
-void ToolBarRenderEnhance::slotEdgeAwareBlurToggled(int state)
+void ToolBarRenderEnhance::slotColorNoiseReductionToggled(int state)
 {
-	updateEdgeAwareBlurUi(state == Qt::Checked);
-	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(getEdgeAwareBlurFromUi(), m_focusCamera), this);
+	updateColorNoiseReductionUi(state == Qt::Checked);
+	m_dataDispatcher.updateInformation(new GuiDataColorNoiseReduction(getColorNoiseReductionFromUi(), m_focusCamera), this);
 }
 
-void ToolBarRenderEnhance::slotEdgeAwareBlurValueChanged(int value)
+void ToolBarRenderEnhance::slotColorNoiseReductionValueChanged(int value)
 {
 	(void)value;
-	if (!m_ui.checkBox_edgeAwareBlur->isChecked())
+	if (!m_ui.checkBox_colorNoiseReduction->isChecked())
 		return;
 
-	m_dataDispatcher.updateInformation(new GuiDataEdgeAwareBlur(getEdgeAwareBlurFromUi(), m_focusCamera), this);
+	m_dataDispatcher.updateInformation(new GuiDataColorNoiseReduction(getColorNoiseReductionFromUi(), m_focusCamera), this);
 }
 
 void ToolBarRenderEnhance::slotDepthLiningToggled(int state)

--- a/src/io/exports/DataSerializer.cpp
+++ b/src/io/exports/DataSerializer.cpp
@@ -360,6 +360,7 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 	json[Key_Cartoon_Value_Levels] = params.m_cartoonValueLevels;
 	json[Key_Cartoon_Saturation_Min_Percent] = params.m_cartoonSaturationMinPercent;
 	json[Key_Cartoon_Saturation_Levels] = params.m_cartoonSaturationLevels;
+	json[Key_Cartoon_Experimental_Palette_Size] = params.m_cartoonExperimentalPaletteSize;
 	json[Key_Flat_Color] = { params.m_flatColor.x, params.m_flatColor.y, params.m_flatColor.z };
 
 	json[Key_DistRamp] = { params.m_distRampMin, params.m_distRampMax };
@@ -376,7 +377,7 @@ void ExportRenderingParameters(nlohmann::json& json, const RenderingParameters& 
 
     json[Key_Post_Rendering_Normals] = { params.m_postRenderingNormals.show, params.m_postRenderingNormals.inverseTone, params.m_postRenderingNormals.blendColor, params.m_postRenderingNormals.normalStrength, params.m_postRenderingNormals.gloss };
     json[Key_Post_Rendering_Ambient_Occlusion] = { params.m_postRenderingAmbientOcclusion.enabled, params.m_postRenderingAmbientOcclusion.radius, params.m_postRenderingAmbientOcclusion.intensity };
-    json[Key_Edge_Aware_Blur] = { params.m_edgeAwareBlur.enabled, params.m_edgeAwareBlur.radius, params.m_edgeAwareBlur.depthThreshold, params.m_edgeAwareBlur.blendStrength, params.m_edgeAwareBlur.resolutionScale };
+    json[Key_Color_Noise_Reduction] = { params.m_colorNoiseReduction.enabled, params.m_colorNoiseReduction.radius, params.m_colorNoiseReduction.depthAwareThreshold, params.m_colorNoiseReduction.strength, params.m_colorNoiseReduction.resolutionScale };
     json[Key_Depth_Lining] = { params.m_depthLining.enabled, params.m_depthLining.strength, params.m_depthLining.threshold, params.m_depthLining.sensitivity, params.m_depthLining.strongMode };
 
     json[Key_Display_Guizmo] = params.m_displayGizmo;
@@ -502,9 +503,9 @@ void ExportViewPointData(nlohmann::json& json, const ViewPointData& data)
         ExportRenderingParameters(json, data);
 
         const DisplayParameters& displayParams = data.getDisplayParameters();
-        json[Key_Edge_Aware_Blur] = { displayParams.m_edgeAwareBlur.enabled, displayParams.m_edgeAwareBlur.radius,
-                displayParams.m_edgeAwareBlur.depthThreshold, displayParams.m_edgeAwareBlur.blendStrength,
-                displayParams.m_edgeAwareBlur.resolutionScale };
+        json[Key_Color_Noise_Reduction] = { displayParams.m_colorNoiseReduction.enabled, displayParams.m_colorNoiseReduction.radius,
+                displayParams.m_colorNoiseReduction.depthAwareThreshold, displayParams.m_colorNoiseReduction.strength,
+                displayParams.m_colorNoiseReduction.resolutionScale };
         json[Key_Post_Rendering_Ambient_Occlusion] = { displayParams.m_postRenderingAmbientOcclusion.enabled, displayParams.m_postRenderingAmbientOcclusion.radius, displayParams.m_postRenderingAmbientOcclusion.intensity };
         json[Key_Depth_Lining] = { displayParams.m_depthLining.enabled, displayParams.m_depthLining.strength,
                 displayParams.m_depthLining.threshold, displayParams.m_depthLining.sensitivity,

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -507,7 +507,7 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
     if (json.find(Key_Cartoon_Value_Levels) != json.end())
         data.m_cartoonValueLevels = json.at(Key_Cartoon_Value_Levels).get<int>();
     else
-        data.m_cartoonValueLevels = 8;
+        data.m_cartoonValueLevels = 6;
 
     if (json.find(Key_Cartoon_Saturation_Min_Percent) != json.end())
         data.m_cartoonSaturationMinPercent = json.at(Key_Cartoon_Saturation_Min_Percent).get<int>();
@@ -518,6 +518,12 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
         data.m_cartoonSaturationLevels = json.at(Key_Cartoon_Saturation_Levels).get<int>();
     else
         data.m_cartoonSaturationLevels = 4;
+
+    // Pass 3A (internal): optional experimental palette size for cartoon mode.
+    if (json.find(Key_Cartoon_Experimental_Palette_Size) != json.end())
+        data.m_cartoonExperimentalPaletteSize = std::max(0, json.at(Key_Cartoon_Experimental_Palette_Size).get<int>());
+    else
+        data.m_cartoonExperimentalPaletteSize = 0;
 
     if (json.find(Key_Flat_Color) != json.end())
     {
@@ -938,13 +944,22 @@ bool ImportDisplayParameters(const nlohmann::json& json, DisplayParameters& data
             IOLOG << "ViewPoint PostRenderingAmbientOcclusion malformed" << LOGENDL;
     }
 
-    if (json.find(Key_Edge_Aware_Blur) != json.end())
+    if (json.find(Key_Color_Noise_Reduction) != json.end())
     {
-        nlohmann::json options = json.at(Key_Edge_Aware_Blur);
+        nlohmann::json options = json.at(Key_Color_Noise_Reduction);
         if (options.size() == 5)
-            data.m_edgeAwareBlur = { options[0], options[1], options[2], options[3], options[4] };
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
         else
-            IOLOG << "ViewPoint EdgeAwareBlur malformed" << LOGENDL;
+            IOLOG << "ViewPoint ColorNoiseReduction malformed" << LOGENDL;
+    }
+    else if (json.find(Key_Edge_Aware_Blur_Legacy) != json.end())
+    {
+        // Backward compatibility: old projects used "EdgeAwareBlur".
+        nlohmann::json options = json.at(Key_Edge_Aware_Blur_Legacy);
+        if (options.size() == 5)
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
+        else
+            IOLOG << "ViewPoint EdgeAwareBlur (legacy) malformed" << LOGENDL;
     }
 
     if (json.find(Key_Depth_Lining) != json.end())
@@ -1997,13 +2012,22 @@ bool ImportColumnTiltMeasureData(const nlohmann::json& json, ColumnTiltMeasureDa
 bool ImportViewPointData(const nlohmann::json& json, ViewPointData& data, const std::unordered_map<xg::Guid, SafePtr<AGraphNode>>& nodeById)
 {
     bool retVal(true);
-    if (json.find(Key_Edge_Aware_Blur) != json.end())
+    if (json.find(Key_Color_Noise_Reduction) != json.end())
     {
-        nlohmann::json options = json.at(Key_Edge_Aware_Blur);
+        nlohmann::json options = json.at(Key_Color_Noise_Reduction);
         if (options.size() == 5)
-            data.m_edgeAwareBlur = { options[0], options[1], options[2], options[3], options[4] };
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
         else
-            IOLOG << "ViewPoint EdgeAwareBlur malformed" << LOGENDL;
+            IOLOG << "ViewPoint ColorNoiseReduction malformed" << LOGENDL;
+    }
+    else if (json.find(Key_Edge_Aware_Blur_Legacy) != json.end())
+    {
+        // Backward compatibility: old projects used "EdgeAwareBlur".
+        nlohmann::json options = json.at(Key_Edge_Aware_Blur_Legacy);
+        if (options.size() == 5)
+            data.m_colorNoiseReduction = { options[0], options[1], options[2], options[3], options[4] };
+        else
+            IOLOG << "ViewPoint EdgeAwareBlur (legacy) malformed" << LOGENDL;
     }
 
     if (json.find(Key_Depth_Lining) != json.end())

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -179,7 +179,7 @@ CameraNode::CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher
     registerGuiDataFunction(guiDType::renderAlphaObjectsRendering, &CameraNode::onRenderAlphaObjects);
     registerGuiDataFunction(guiDType::renderPostRenderingNormals, &CameraNode::onRenderNormals);
     registerGuiDataFunction(guiDType::renderAmbientOcclusion, &CameraNode::onRenderAmbientOcclusion);
-    registerGuiDataFunction(guiDType::renderEdgeAwareBlur, &CameraNode::onRenderEdgeAwareBlur);
+    registerGuiDataFunction(guiDType::renderColorNoiseReduction, &CameraNode::onRenderColorNoiseReduction);
     registerGuiDataFunction(guiDType::renderDepthLining, &CameraNode::onRenderDepthLining);
     registerGuiDataFunction(guiDType::renderRampScale, &CameraNode::onRenderRampScale);
     registerGuiDataFunction(guiDType::renderColorimetricFilter, &CameraNode::onRenderColorimetricFilter);
@@ -1615,6 +1615,7 @@ ViewpointRenderState CameraNode::buildViewpointRenderState(const ViewPointNode& 
     state.cartoonValueLevels = static_cast<float>(viewpoint.m_cartoonValueLevels);
     state.cartoonSaturationMinPercent = static_cast<float>(viewpoint.m_cartoonSaturationMinPercent);
     state.cartoonSaturationLevels = static_cast<float>(viewpoint.m_cartoonSaturationLevels);
+    state.cartoonExperimentalPaletteSize = static_cast<float>(viewpoint.m_cartoonExperimentalPaletteSize);
     state.alphaObject = viewpoint.m_alphaObject;
     state.fovy = viewpoint.getFovy();
     state.visibleObjects = viewpoint.getVisibleObjects();
@@ -1649,6 +1650,7 @@ ViewpointRenderState CameraNode::lerpViewpointRenderState(const ViewpointRenderS
     state.cartoonValueLevels = start.cartoonValueLevels + (end.cartoonValueLevels - start.cartoonValueLevels) * alpha;
     state.cartoonSaturationMinPercent = start.cartoonSaturationMinPercent + (end.cartoonSaturationMinPercent - start.cartoonSaturationMinPercent) * alpha;
     state.cartoonSaturationLevels = start.cartoonSaturationLevels + (end.cartoonSaturationLevels - start.cartoonSaturationLevels) * alpha;
+    state.cartoonExperimentalPaletteSize = start.cartoonExperimentalPaletteSize + (end.cartoonExperimentalPaletteSize - start.cartoonExperimentalPaletteSize) * alpha;
     state.alphaObject = start.alphaObject + (end.alphaObject - start.alphaObject) * alpha;
     state.fovy = start.fovy + (end.fovy - start.fovy) * alpha;
     state.renderMode = start.renderMode;
@@ -1758,6 +1760,7 @@ void CameraNode::applyViewpointRenderState(const ViewpointRenderState& state)
     m_cartoonValueLevels = std::max(2, static_cast<int>(std::round(state.cartoonValueLevels)));
     m_cartoonSaturationMinPercent = std::clamp(static_cast<int>(std::round(state.cartoonSaturationMinPercent)), 0, 100);
     m_cartoonSaturationLevels = std::max(1, static_cast<int>(std::round(state.cartoonSaturationLevels)));
+    m_cartoonExperimentalPaletteSize = std::max(0, static_cast<int>(std::round(state.cartoonExperimentalPaletteSize)));
     m_alphaObject = state.alphaObject;
     setFovy(state.fovy, false);
 
@@ -2596,10 +2599,10 @@ void CameraNode::onRenderAmbientOcclusion(IGuiData* data)
     sendNewUIViewPoint();
 }
 
-void CameraNode::onRenderEdgeAwareBlur(IGuiData* data)
+void CameraNode::onRenderColorNoiseReduction(IGuiData* data)
 {
-    auto blurData = static_cast<GuiDataEdgeAwareBlur*>(data);
-    m_edgeAwareBlur = blurData->m_blur;
+    auto blurData = static_cast<GuiDataColorNoiseReduction*>(data);
+    m_colorNoiseReduction = blurData->m_blur;
 
     sendNewUIViewPoint();
 }

--- a/src/models/graph/ObjectNodeVisitor.cpp
+++ b/src/models/graph/ObjectNodeVisitor.cpp
@@ -1549,6 +1549,7 @@ void ObjectNodeVisitor::draw_baked_pointClouds(VkCommandBuffer cmdBuffer, Render
         static_cast<float>(m_displayParameters.m_cartoonValueLevels),
         static_cast<float>(m_displayParameters.m_cartoonSaturationMinPercent),
         static_cast<float>(m_displayParameters.m_cartoonSaturationLevels),
+        static_cast<float>(m_displayParameters.m_cartoonExperimentalPaletteSize),
         cmdBuffer);
     renderer.setConstantBlending((float)m_displayParameters.m_hue, cmdBuffer);
 

--- a/src/pointCloudEngine/RenderingEcoSystem.cpp
+++ b/src/pointCloudEngine/RenderingEcoSystem.cpp
@@ -118,6 +118,7 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
     hash += hash_fn_i(display.m_cartoonValueLevels);
     hash += hash_fn_i(display.m_cartoonSaturationMinPercent);
     hash += hash_fn_i(display.m_cartoonSaturationLevels);
+    hash += hash_fn_i(display.m_cartoonExperimentalPaletteSize);
     hash += hash_vec3(display.m_flatColor);
     hash += hash_fn_f(display.m_distRampMin);
     hash += hash_fn_f(display.m_distRampMax);
@@ -140,11 +141,11 @@ uint64_t HashFrame::hashRenderingData(VkExtent2D viewportExtent, const glm::dmat
     hash += hash_fn_b(display.m_postRenderingAmbientOcclusion.enabled);
     hash += hash_fn_f(display.m_postRenderingAmbientOcclusion.radius);
     hash += hash_fn_f(display.m_postRenderingAmbientOcclusion.intensity);
-    hash += hash_fn_b(display.m_edgeAwareBlur.enabled);
-    hash += hash_fn_f(display.m_edgeAwareBlur.radius);
-    hash += hash_fn_f(display.m_edgeAwareBlur.depthThreshold);
-    hash += hash_fn_f(display.m_edgeAwareBlur.blendStrength);
-    hash += hash_fn_f(display.m_edgeAwareBlur.resolutionScale);
+    hash += hash_fn_b(display.m_colorNoiseReduction.enabled);
+    hash += hash_fn_f(display.m_colorNoiseReduction.radius);
+    hash += hash_fn_f(display.m_colorNoiseReduction.depthAwareThreshold);
+    hash += hash_fn_f(display.m_colorNoiseReduction.strength);
+    hash += hash_fn_f(display.m_colorNoiseReduction.resolutionScale);
     hash += hash_fn_b(display.m_depthLining.enabled);
     hash += hash_fn_f(display.m_depthLining.strength);
     hash += hash_fn_f(display.m_depthLining.threshold);

--- a/src/pointCloudEngine/RenderingEngine.cpp
+++ b/src/pointCloudEngine/RenderingEngine.cpp
@@ -362,16 +362,16 @@ void RenderingEngine::updateHD()
     // Should be input parameters
     // NOTE: Gap filling relies on a 3x3 kernel. A base 2px border keeps a one-pixel safety zone
     // after the image transfer cropping and avoids visible seams between tiles when the texel
-    // threshold is low (e.g., 2). Post-processing passes like edge-aware blur and depth lining can
+    // threshold is low (e.g., 2). Post-processing passes like color-noise reduction and depth lining can
     // require a larger footprint, so the border is expanded accordingly.
     auto computeTileBorder = [](const DisplayParameters& display) {
         constexpr uint32_t baseBorder = 2;
         uint32_t border = baseBorder;
 
-        if (display.m_edgeAwareBlur.enabled)
+        if (display.m_colorNoiseReduction.enabled)
         {
-            const float resolutionScale = std::max(display.m_edgeAwareBlur.resolutionScale, 0.1f);
-            const uint32_t blurFootprint = static_cast<uint32_t>(std::ceil(display.m_edgeAwareBlur.radius / resolutionScale));
+            const float resolutionScale = std::max(display.m_colorNoiseReduction.resolutionScale, 0.1f);
+            const uint32_t blurFootprint = static_cast<uint32_t>(std::ceil(display.m_colorNoiseReduction.radius / resolutionScale));
             border = std::max(border, blurFootprint + 1u); // +1 to keep a safety band after cropping
         }
 
@@ -882,10 +882,10 @@ bool RenderingEngine::updateFramebuffer(VulkanViewport& viewport)
             m_postRenderer.processDepthLining(cmdBuffer, display.m_depthLining, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
         }
 
-        if (display.m_edgeAwareBlur.enabled)
+        if (display.m_colorNoiseReduction.enabled)
         {
-            vkm.beginPostTreatmentEdgeAwareBlur(framebuffer);
-            m_postRenderer.processEdgeAwareBlur(cmdBuffer, display.m_edgeAwareBlur, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
+            vkm.beginPostTreatmentColorNoiseReduction(framebuffer);
+            m_postRenderer.processColorNoiseReduction(cmdBuffer, display.m_colorNoiseReduction, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
         }
 
         if (display.m_blendMode != BlendMode::Opaque && display.m_transparency > 0.f)
@@ -1059,10 +1059,10 @@ bool RenderingEngine::renderVirtualViewport(TlFramebuffer framebuffer, const Cam
         m_postRenderer.processDepthLining(cmdBuffer, displayParam.m_depthLining, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
     }
 
-    if (displayParam.m_edgeAwareBlur.enabled)
+    if (displayParam.m_colorNoiseReduction.enabled)
     {
-        vkm.beginPostTreatmentEdgeAwareBlur(framebuffer);
-        m_postRenderer.processEdgeAwareBlur(cmdBuffer, displayParam.m_edgeAwareBlur, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
+        vkm.beginPostTreatmentColorNoiseReduction(framebuffer);
+        m_postRenderer.processColorNoiseReduction(cmdBuffer, displayParam.m_colorNoiseReduction, framebuffer->descSetSamplers, framebuffer->descSetCorrectedDepth, framebuffer->extent);
     }
 
     if (displayParam.m_blendMode != BlendMode::Opaque && displayParam.m_transparency > 0.f)

--- a/src/shaders/blocks/block_point_input_vert.glsl
+++ b/src/shaders/blocks/block_point_input_vert.glsl
@@ -37,6 +37,7 @@ layout(push_constant) uniform PC {
     layout(offset = 40) float cartoonValueLevels;
     layout(offset = 44) float cartoonSaturationMin;
     layout(offset = 48) vec3 ptColor;
+    layout(offset = 60) float cartoonExperimentalPaletteSize;
 } pc;
 
 layout(set = 0, binding = 0) uniform uniformCamera {

--- a/src/shaders/blocks/block_point_rgb_main_cartoon_vert.glsl
+++ b/src/shaders/blocks/block_point_rgb_main_cartoon_vert.glsl
@@ -1,3 +1,38 @@
+float hueDistance(float a, float b)
+{
+    float d = abs(a - b);
+    return min(d, 1.0 - d);
+}
+
+vec3 projectToExperimentalPalette(vec3 hsv, float paletteSize)
+{
+    // Internal pass 3A path:
+    // build a compact procedural palette in HSV and project to nearest hue anchor.
+    float k = clamp(floor(paletteSize + 0.5), 3.0, 16.0);
+    vec3 best = hsv;
+    float bestDist = 1e9;
+
+    for (int i = 0; i < 16; ++i)
+    {
+        if (float(i) >= k)
+            break;
+
+        float hueAnchor = (float(i) + 0.5) / k;
+        vec3 candidate = vec3(hueAnchor, max(hsv.y, 0.55), hsv.z);
+        float dh = hueDistance(hsv.x, candidate.x);
+        float ds = hsv.y - candidate.y;
+        float dv = hsv.z - candidate.z;
+        float dist = (dh * dh) * 2.4 + (ds * ds) * 0.6 + (dv * dv) * 0.2;
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = candidate;
+        }
+    }
+
+    return best;
+}
+
 void main() {
     gl_PointSize = pc.ptSize;
     vec4 worldPos4 = uScan.model * vec4(vec3(posXY, posZ) * coordPrec + origin, 1.0);
@@ -18,6 +53,11 @@ void main() {
     float valDen = max(valueLevels - 1.0, 1.0);
     hsv.y = floor(hsv.y * satDen + 0.5) / satDen;
     hsv.z = floor(hsv.z * valDen + 0.5) / valDen;
+
+    // Pass 3A (internal, non-UI): optional experimental palette projection.
+    // 0.0 = disabled (legacy path), >0.0 = palette size.
+    if (pc.cartoonExperimentalPaletteSize > 0.5)
+        hsv = projectToExperimentalPalette(hsv, pc.cartoonExperimentalPaletteSize);
 
     // Keep existing toolbar controls active in cartoon mode.
     hsv.y = clamp(hsv.y * pc.saturation, 0.0, 1.0);

--- a/src/shaders/v2/edge_aware_blur.comp
+++ b/src/shaders/v2/edge_aware_blur.comp
@@ -11,8 +11,8 @@ layout(set = 1, binding = 2) buffer correctedDepth
 layout(push_constant) uniform PC {
    layout(offset = 0) ivec2 screenSize;
    layout(offset = 8) float radius;
-   layout(offset = 12) float depthThreshold;
-   layout(offset = 16) float blendStrength;
+   layout(offset = 12) float depthAwareThreshold;
+   layout(offset = 16) float strength;
    layout(offset = 20) float resolutionScale;
 } pc;
 
@@ -27,9 +27,26 @@ void main()
    vec4 centerColor = imageLoad(inOutColorImage, gid);
    float centerDepth = depth[idx];
 
+   // Fast-path: keep original color when effect strength is effectively disabled
+   // (avoids extra neighborhood work and keeps deterministic output).
+   if (pc.strength <= 1e-4)
+   {
+      imageStore(inOutColorImage, gid, centerColor);
+      return;
+   }
+
+   // Skip empty pixels (background / no reconstructed geometry).
+   if (centerDepth <= 0.0)
+   {
+      imageStore(inOutColorImage, gid, centerColor);
+      return;
+   }
+
    // Parameters
-   int r = int(max(pc.radius, 1.0));
-   float depthSigma = max(pc.depthThreshold, 1e-4);
+   float strengthClamped = clamp(pc.strength, 0.0, 1.5);
+   float strengthNormalized = clamp(strengthClamped / 1.5, 0.0, 1.0);
+   int r = int(clamp(pc.radius, 1.0, 20.0));
+   float depthSigma = max(pc.depthAwareThreshold, 1e-4);
    float radiusNorm = float(r);
    int stride = int(round(max(1.0, 1.0 / max(pc.resolutionScale, 0.001))));
 
@@ -43,20 +60,35 @@ void main()
          ivec2 coord = clamp(gid + ivec2(x, y), ivec2(0), pc.screenSize - ivec2(1));
          uint sampleIdx = uint(coord.x + coord.y * pc.screenSize.x);
          float sampleDepth = depth[sampleIdx];
+         if (sampleDepth <= 0.0)
+            continue;
          vec3 sampleColor = imageLoad(inOutColorImage, coord).rgb;
 
          float dist2 = float(x * x + y * y);
          float spatialWeight = exp(-dist2 / (2.0 * radiusNorm * radiusNorm));
-         float depthDelta = sampleDepth - centerDepth;
+
+         // Geometric edge preservation:
+         // normalized depth difference prevents excessive smoothing across depth jumps.
+         float depthNorm = max(max(centerDepth, sampleDepth), 1e-6);
+         float depthDelta = abs(sampleDepth - centerDepth) / depthNorm;
          float depthWeight = exp(-(depthDelta * depthDelta) / (2.0 * depthSigma * depthSigma));
 
-         float w = spatialWeight * depthWeight;
+         // Spray reduction:
+         // robust color gating rejects chromatic outliers inside the local neighborhood.
+         vec3 colorDelta = sampleColor - centerColor.rgb;
+         float colorDist2 = dot(colorDelta, colorDelta);
+         // Pass 2 request: allow 1.5x stronger maximum effect compared to previous range.
+         // We model this by extending the upper chroma tolerance envelope.
+         float colorSigma = mix(0.025, 0.29, strengthNormalized);
+         float colorWeight = 1.0 / (1.0 + colorDist2 / (colorSigma * colorSigma));
+
+         float w = spatialWeight * depthWeight * colorWeight;
          accumColor += sampleColor * w;
          accumWeight += w;
       }
    }
 
-   vec3 blurred = (accumWeight > 0.0) ? (accumColor / accumWeight) : centerColor.rgb;
-   vec3 mixed = mix(centerColor.rgb, blurred, clamp(pc.blendStrength, 0.0, 1.0));
-   imageStore(inOutColorImage, gid, vec4(mixed, centerColor.a));
+   vec3 stabilizedColor = (accumWeight > 0.0) ? (accumColor / accumWeight) : centerColor.rgb;
+   vec3 outputColor = mix(centerColor.rgb, stabilizedColor, clamp(strengthClamped, 0.0, 1.0));
+   imageStore(inOutColorImage, gid, vec4(outputColor, centerColor.a));
 }

--- a/src/vulkan/Renderers/PostRenderer.cpp
+++ b/src/vulkan/Renderers/PostRenderer.cpp
@@ -30,7 +30,7 @@ static std::vector<uint32_t> transparency_hdr_comp_spv =
 #include "transparency_hdr.comp.spv"
 };
 
-static std::vector<uint32_t> edge_aware_blur_comp_spv =
+static std::vector<uint32_t> color_noise_reduction_comp_spv =
 {
 #include "edge_aware_blur.comp.spv"
 };
@@ -79,7 +79,7 @@ void PostRenderer::createShaders()
     loadShaderSPV(m_normalShadingCompShader, normal_shading_comp_spv);
     loadShaderSPV(m_normalColoredCompShader, normal_colored_comp_spv);
     loadShaderSPV(m_transparencyHDRCompShader, transparency_hdr_comp_spv);
-    loadShaderSPV(m_edgeAwareBlurCompShader, edge_aware_blur_comp_spv);
+    loadShaderSPV(m_colorNoiseReductionCompShader, color_noise_reduction_comp_spv);
     loadShaderSPV(m_depthLiningCompShader, depth_lining_comp_spv);
     loadShaderSPV(m_ambientOcclusionCompShader, ambient_occlusion_comp_spv);
 }
@@ -162,7 +162,7 @@ void PostRenderer::createPipelines()
     createFillingPipeline();
     createNormalPipeline();
     createAmbientOcclusionPipeline();
-    createEdgeAwarePipeline();
+    createColorNoiseReductionPipeline();
     createDepthLiningPipeline();
     createTransparencyHDRPipeline();
 }
@@ -219,7 +219,7 @@ void PostRenderer::createPipelineLayouts()
     VkDescriptorSetLayout DSLayout_edgeAware[] = { VulkanManager::getDSLayout_fillingSamplers(), VulkanManager::getDSLayout_finalOutput() };
     pipelineLayoutInfo.setLayoutCount = sizeof(DSLayout_edgeAware) / sizeof(VkDescriptorSetLayout);
     pipelineLayoutInfo.pSetLayouts = DSLayout_edgeAware;
-    err = h_pfn->vkCreatePipelineLayout(h_device, &pipelineLayoutInfo, nullptr, &m_edgeAwarePipelineLayout);
+    err = h_pfn->vkCreatePipelineLayout(h_device, &pipelineLayoutInfo, nullptr, &m_colorNoiseReductionPipelineLayout);
     check_vk_result(err, "Create Pipeline Layout");
 
     VkDescriptorSetLayout DSLayout_depthLining[] = { VulkanManager::getDSLayout_fillingSamplers(), VulkanManager::getDSLayout_finalOutput() };
@@ -321,14 +321,14 @@ void PostRenderer::createAmbientOcclusionPipeline()
     check_vk_result(err, "Create Compute Pipeline");
 }
 
-void PostRenderer::createEdgeAwarePipeline()
+void PostRenderer::createColorNoiseReductionPipeline()
 {
     VkPipelineShaderStageCreateInfo compStageInfo = {
         VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
         nullptr,
         0,
         VK_SHADER_STAGE_COMPUTE_BIT,
-        m_edgeAwareBlurCompShader.module(),
+        m_colorNoiseReductionCompShader.module(),
         "main",
         nullptr
     };
@@ -338,12 +338,12 @@ void PostRenderer::createEdgeAwarePipeline()
         nullptr,                  // pNext
         0,                        // flags
         compStageInfo,            // stage
-        m_edgeAwarePipelineLayout,// layout
+        m_colorNoiseReductionPipelineLayout,// layout
         VK_NULL_HANDLE,           // basePipelineHandle
         0,                        // basePipelineIndex
     };
 
-    VkResult err = h_pfn->vkCreateComputePipelines(h_device, m_pipelineCache, 1, &info, nullptr, &m_edgeAwarePipeline);
+    VkResult err = h_pfn->vkCreateComputePipelines(h_device, m_pipelineCache, 1, &info, nullptr, &m_colorNoiseReductionPipeline);
     check_vk_result(err, "Create Compute Pipeline");
 }
 
@@ -492,23 +492,30 @@ void PostRenderer::processTransparencyHDR(VkCommandBuffer _cmdBuffer, VkDescript
     h_pfn->vkCmdDispatch(_cmdBuffer, (_extent.width + 15) / 16, (_extent.height + 15) / 16, 1);
 }
 
-void PostRenderer::processEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D _extent)
+void PostRenderer::processColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D _extent)
 {
-    h_pfn->vkCmdBindPipeline(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_edgeAwarePipeline);
+    h_pfn->vkCmdBindPipeline(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_colorNoiseReductionPipeline);
 
     VkDescriptorSet descSets[] = { descSetColor, descSetDepth };
-    h_pfn->vkCmdBindDescriptorSets(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_edgeAwarePipelineLayout, 0, 2, descSets, 0, nullptr);
+    h_pfn->vkCmdBindDescriptorSets(_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_colorNoiseReductionPipelineLayout, 0, 2, descSets, 0, nullptr);
+
+    // Clamp runtime values before sending push constants to keep shader behavior stable
+    // even with legacy/hand-edited project files.
+    const float radius = std::clamp(blurSettings.radius, 0.0f, 20.0f);
+    const float depthAwareThreshold = std::clamp(blurSettings.depthAwareThreshold, 0.0001f, 1.0f);
+    const float strength = std::clamp(blurSettings.strength, 0.0f, 1.5f);
+    const float resolutionScale = std::clamp(blurSettings.resolutionScale, 0.1f, 1.0f);
 
     struct
     {
         glm::ivec2 screenSize;
         float radius;
-        float depthThreshold;
-        float blendStrength;
+        float depthAwareThreshold;
+        float strength;
         float resolutionScale;
-    } pc = { glm::ivec2(_extent.width, _extent.height), blurSettings.radius, blurSettings.depthThreshold, blurSettings.blendStrength, blurSettings.resolutionScale };
+    } pc = { glm::ivec2(_extent.width, _extent.height), radius, depthAwareThreshold, strength, resolutionScale };
 
-    h_pfn->vkCmdPushConstants(_cmdBuffer, m_edgeAwarePipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    h_pfn->vkCmdPushConstants(_cmdBuffer, m_colorNoiseReductionPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
 
     h_pfn->vkCmdDispatch(_cmdBuffer, (_extent.width + 15) / 16, (_extent.height + 15) / 16, 1);
 }
@@ -534,17 +541,17 @@ void PostRenderer::processDepthLining(VkCommandBuffer _cmdBuffer, const DepthLin
     h_pfn->vkCmdDispatch(_cmdBuffer, (_extent.width + 15) / 16, (_extent.height + 15) / 16, 1);
 }
 
-bool PostRenderer::initEdgeAwareBlur(VulkanManager& vkm, uint32_t /*swapChainImageCount*/)
+bool PostRenderer::initColorNoiseReduction(VulkanManager& vkm, uint32_t /*swapChainImageCount*/)
 {
     (void)vkm;
-    // The edge-aware blur pipeline is fully initialized in the constructor via createPipelines().
+    // The color-noise-reduction pipeline is fully initialized in the constructor via createPipelines().
     // This helper simply mirrors the pattern used by other platforms expecting an explicit init call.
-    return m_edgeAwarePipeline != VK_NULL_HANDLE && m_edgeAwareBlurCompShader.isValid();
+    return m_colorNoiseReductionPipeline != VK_NULL_HANDLE && m_colorNoiseReductionCompShader.isValid();
 }
 
-void PostRenderer::transitionAndDispatchEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent)
+void PostRenderer::transitionAndDispatchColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent)
 {
-    processEdgeAwareBlur(_cmdBuffer, blurSettings, descSetColor, descSetDepth, extent);
+    processColorNoiseReduction(_cmdBuffer, blurSettings, descSetColor, descSetDepth, extent);
 }
 
 void PostRenderer::setConstantZRange(float nearZ, float farZ, VkCommandBuffer _cmdBuffer)
@@ -638,9 +645,9 @@ void PostRenderer::cleanup()
         m_ambientOcclusionPipelineLayout = VK_NULL_HANDLE;
     }
 
-    if (m_edgeAwarePipelineLayout) {
-        h_pfn->vkDestroyPipelineLayout(h_device, m_edgeAwarePipelineLayout, nullptr);
-        m_edgeAwarePipelineLayout = VK_NULL_HANDLE;
+    if (m_colorNoiseReductionPipelineLayout) {
+        h_pfn->vkDestroyPipelineLayout(h_device, m_colorNoiseReductionPipelineLayout, nullptr);
+        m_colorNoiseReductionPipelineLayout = VK_NULL_HANDLE;
     }
 
     if (m_depthLiningPipelineLayout) {
@@ -678,10 +685,10 @@ void PostRenderer::cleanup()
         m_ambientOcclusionPipeline = VK_NULL_HANDLE;
     }
 
-    if (m_edgeAwarePipeline)
+    if (m_colorNoiseReductionPipeline)
     {
-        h_pfn->vkDestroyPipeline(h_device, m_edgeAwarePipeline, nullptr);
-        m_edgeAwarePipeline = VK_NULL_HANDLE;
+        h_pfn->vkDestroyPipeline(h_device, m_colorNoiseReductionPipeline, nullptr);
+        m_colorNoiseReductionPipeline = VK_NULL_HANDLE;
     }
 
     if (m_depthLiningPipeline)

--- a/src/vulkan/Renderers/PostRenderer.h
+++ b/src/vulkan/Renderers/PostRenderer.h
@@ -28,12 +28,12 @@ public:
     void processNormalColored(VkCommandBuffer _cmdBuffer, VkUniformOffset matrixUniOffset, VkDescriptorSet descSetColor, VkDescriptorSet descSetOutput, VkExtent2D extent);
     void processTransparencyHDR(VkCommandBuffer _cmdBuffer, VkDescriptorSet descSetColor, VkExtent2D extent);
     void processAmbientOcclusion(VkCommandBuffer _cmdBuffer, const PostRenderingAmbientOcclusion& aoSettings, float nearZ, float farZ, bool isPerspective, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
-    void processEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
+    void processColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
     void processDepthLining(VkCommandBuffer _cmdBuffer, const DepthLining& liningSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
 
     // Compatibility helpers used by some build targets
-    bool initEdgeAwareBlur(VulkanManager& vkm, uint32_t swapChainImageCount);
-    void transitionAndDispatchEdgeAwareBlur(VkCommandBuffer _cmdBuffer, const EdgeAwareBlur& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
+    bool initColorNoiseReduction(VulkanManager& vkm, uint32_t swapChainImageCount);
+    void transitionAndDispatchColorNoiseReduction(VkCommandBuffer _cmdBuffer, const ColorNoiseReduction& blurSettings, VkDescriptorSet descSetColor, VkDescriptorSet descSetDepth, VkExtent2D extent);
     void setConstantZRange(float nearZ, float farZ, VkCommandBuffer _cmdBuffer);
     void setConstantScreenSize(VkExtent2D screenSize, glm::vec2 pixelSize, VkCommandBuffer _cmdBuffer);
     void setConstantScreenOffset(glm::vec2 offset, VkCommandBuffer cmdBuffer);
@@ -54,7 +54,7 @@ private:
     void createFillingPipeline();
     void createNormalPipeline();
     void createAmbientOcclusionPipeline();
-    void createEdgeAwarePipeline();
+    void createColorNoiseReductionPipeline();
     void createDepthLiningPipeline();
     void createTransparencyHDRPipeline();
 
@@ -82,7 +82,7 @@ private:
     Shader m_normalColoredCompShader;
     Shader m_transparencyHDRCompShader;
     Shader m_ambientOcclusionCompShader;
-    Shader m_edgeAwareBlurCompShader;
+    Shader m_colorNoiseReductionCompShader;
     Shader m_depthLiningCompShader;
 
     VkPipeline m_fillingPipeline;
@@ -91,10 +91,10 @@ private:
     VkPipeline m_ambientOcclusionPipeline = VK_NULL_HANDLE;
     VkPipeline m_transparencyHDRPipeline;
     VkPipeline m_hdrSubsPipeline;
-    VkPipeline m_edgeAwarePipeline;
+    VkPipeline m_colorNoiseReductionPipeline;
     VkPipeline m_depthLiningPipeline;
 
-    VkPipelineLayout m_edgeAwarePipelineLayout = VK_NULL_HANDLE;
+    VkPipelineLayout m_colorNoiseReductionPipelineLayout = VK_NULL_HANDLE;
     VkPipelineLayout m_depthLiningPipelineLayout = VK_NULL_HANDLE;
 };
 

--- a/src/vulkan/Renderers/Renderer.cpp
+++ b/src/vulkan/Renderers/Renderer.cpp
@@ -535,6 +535,7 @@ void Renderer::createPointPipelineLayout()
     // cartoonValL | 40     | 4
     // cartoonSatM | 44     | 4
     // ptColor     | 48     | 12
+    // cartoonExpP | 60     | 4
     //-------------+---------------------------------
     VkPushConstantRange pcr[] =
     {
@@ -1001,20 +1002,23 @@ void Renderer::setConstantSaturationLuminance(float saturation, float luminance,
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout_cb, VK_SHADER_STAGE_VERTEX_BIT, 20, 4, &fluminance);
 }
 
-void Renderer::setConstantCartoonOptions(float valueLevels, float saturationMinPercent, float saturationLevels, VkCommandBuffer _cmdBuffer)
+void Renderer::setConstantCartoonOptions(float valueLevels, float saturationMinPercent, float saturationLevels, float experimentalPaletteSize, VkCommandBuffer _cmdBuffer)
 {
     const float fValueLevels = std::max(valueLevels, 2.0f);
     const float fSaturationLevels = std::max(saturationLevels, 1.0f);
     const float fSaturationMin = std::clamp(saturationMinPercent / 100.0f, 0.0f, 1.0f);
+    const float fExperimentalPaletteSize = std::max(0.0f, experimentalPaletteSize);
 
     // Offsets are mirrored in block_point_input_vert.glsl.
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 4, 4, &fSaturationLevels);
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 40, 4, &fValueLevels);
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 44, 4, &fSaturationMin);
+    h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 60, 4, &fExperimentalPaletteSize);
 
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout_cb, VK_SHADER_STAGE_VERTEX_BIT, 4, 4, &fSaturationLevels);
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout_cb, VK_SHADER_STAGE_VERTEX_BIT, 40, 4, &fValueLevels);
     h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout_cb, VK_SHADER_STAGE_VERTEX_BIT, 44, 4, &fSaturationMin);
+    h_pfn->vkCmdPushConstants(_cmdBuffer, m_pipelineLayout_cb, VK_SHADER_STAGE_VERTEX_BIT, 60, 4, &fExperimentalPaletteSize);
 }
 
 void Renderer::setConstantBlending(float blending, VkCommandBuffer _cmdBuffer)

--- a/src/vulkan/Renderers/Renderer.h
+++ b/src/vulkan/Renderers/Renderer.h
@@ -51,7 +51,7 @@ public:
     void setConstantPointSize(float ptSize, VkCommandBuffer _cmdBuffer);
     void setConstantContrastBrightness(float contrast, float brightness, VkCommandBuffer _cmdBuffer);
 	void setConstantSaturationLuminance(float saturation, float luminance, VkCommandBuffer _cmdBuffer);
-    void setConstantCartoonOptions(float valueLevels, float saturationMinPercent, float saturationLevels, VkCommandBuffer _cmdBuffer);
+    void setConstantCartoonOptions(float valueLevels, float saturationMinPercent, float saturationLevels, float experimentalPaletteSize, VkCommandBuffer _cmdBuffer);
     void setConstantBlending(float blending, VkCommandBuffer _cmdBuffer);
     void setConstantRampDistance(float min, float max, int steps, VkCommandBuffer _cmdBuffer);
 	void setConstantPtColor(const glm::vec3& color, VkCommandBuffer _cmdBuffer);

--- a/src/vulkan/VulkanManager.cpp
+++ b/src/vulkan/VulkanManager.cpp
@@ -966,7 +966,7 @@ void VulkanManager::beginPostTreatmentAmbientOcclusion(TlFramebuffer _fb)
     beginPostTreatmentNormal(_fb);
 }
 
-void VulkanManager::beginPostTreatmentEdgeAwareBlur(TlFramebuffer _fb)
+void VulkanManager::beginPostTreatmentColorNoiseReduction(TlFramebuffer _fb)
 {
     beginPostTreatmentNormal(_fb);
 }


### PR DESCRIPTION
### Motivation
- Replace legacy edge-aware blur with a more targeted color-noise reduction pass that preserves geometric edges while reducing chromatic spray produced by scans.
- Expose a user-facing strength/radius/resolution workflow and keep a fixed depth gate for pass-1 while enabling internal depth-aware tuning for future passes.
- Add an internal experimental cartoon palette projection path and reduce the default cartoon quantization level for current UI defaults and projects.

### Description
- Renamed the `EdgeAwareBlur` feature to `ColorNoiseReduction` across the codebase and replaced types, GUI widgets, enum keys and API (e.g. `GuiDataEdgeAwareBlur` -> `GuiDataColorNoiseReduction`, `beginPostTreatmentEdgeAwareBlur` -> `beginPostTreatmentColorNoiseReduction`, pipeline/shader names and push constants updated accordingly). 
- Reworked `ColorNoiseReduction` parameters and defaults (`radius`, `depthAwareThreshold`, `strength`, `resolutionScale`) and added deterministic/clamped handling when dispatching to the compute shader; kept a legacy key `Key_Edge_Aware_Blur_Legacy` for backward compatibility when deserializing old projects. 
- Replaced the compute shader implementation with a new `edge_aware_blur.comp` -> color-noise reduction algorithm that adds depth-aware gating and chroma-aware weighting, supports extended strength (up to 1.5), and includes fast-path exits for disabled/empty pixels. 
- Added an internal/dev cartoon feature: added `m_cartoonExperimentalPaletteSize` to `DisplayParameters` and corresponding push-constant and vertex shader support to optionally project colors to a compact procedural palette; reduced default `m_cartoonValueLevels` from `8` to `6` and threaded serialization/deserialization (`Key_Cartoon_Experimental_Palette_Size`) and export/import updates. 
- Updated UI forms and toolbar code to rename labels, controls and default values (checkboxes, sliders, spinboxes and tooltips) and adjusted the `ToolBarRenderEnhance` logic to compute resolution scale and map UI strength to shader strength. 
- Updated serialization and I/O (`SerializerKeys`, `DisplayPresetManager`, `DataSerializer`, `DataDeserializer`, `ExportRenderingParameters`, `ExportViewPointData`, `ImportDisplayParameters`, `ImportViewPointData`) to use the new key `Key_Color_Noise_Reduction` while preserving compatibility with older `EdgeAwareBlur` presets. 

### Testing
- Performed a full project compilation and linker pass which completed successfully with the updated symbols and shader bundles. 
- Ran the automated unit/integration test suite (project build and renderer smoke-tests) including the post-processing dispatch paths, and all tested cases passed. 
- Executed an automated headless rendering smoke test that exercises the new color-noise reduction and the cartoon experimental palette push-constant path, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7648a5e0832f9a4e4464201f334c)