### PR TITLE
Remove noisy debug logging across export, dialogs, viewport and animation code

### DIFF
--- a/src/controller/functionSystem/ContextExportStep.cpp
+++ b/src/controller/functionSystem/ContextExportStep.cpp
@@ -62,7 +62,8 @@ ContextState ContextExportStep::feedMessage(IMessage* message, Controller& contr
 
 ContextState ContextExportStep::launch(Controller& controller)
 {
-    IOLOG << "ContextExportStep launch " << LOGENDL;
+    // Intentionally keep this context quiet in production logs:
+    // previous step-by-step "launch X" traces were diagnostic noise.
 
     m_state = ContextState::running;
     ErrorType err(ErrorType::Success);
@@ -73,11 +74,9 @@ ContextState ContextExportStep::launch(Controller& controller)
     if (m_output.filename().wstring().find_first_of(L".") == std::wstring::npos)
         m_output += ".step";
 
-    IOLOG << "ContextExportStep launch 1" << LOGENDL;
 
     setRootName(m_output.filename().stem().string());
 
-    IOLOG << "ContextExportStep launch 2" << LOGENDL;
 
     std::vector<SafePtr<AGraphNode>> listToExport;
     for (const SafePtr<AGraphNode>& exportObj : m_listToExport)
@@ -98,13 +97,11 @@ ContextState ContextExportStep::launch(Controller& controller)
             return ((readA->getUserIndex() < readB->getUserIndex()));
         });
 
-    IOLOG << "ContextExportStep launch 3 -- exportSize" << listToExport.size() << LOGENDL;
 
     std::map<xg::Guid, primitiveId> objToPrim;
 
     for (const SafePtr<AGraphNode>& exportObj : listToExport)
     {
-        IOLOG << "ContextExportStep launch 3.5 " << LOGENDL;
         primitiveId primId;
 
         ElementType type;
@@ -244,7 +241,6 @@ ContextState ContextExportStep::launch(Controller& controller)
         }
     }
 
-    //IOLOG << "ContextExportStep launch 3 -- pipingSize : " << m_pipingDirectory.size() << LOGENDL;
 
     /*
     for (auto pipingDirectory : m_pipingDirectory) {
@@ -267,7 +263,6 @@ ContextState ContextExportStep::launch(Controller& controller)
     }
     */
 
-    IOLOG << "ContextExportStep launch 4" << LOGENDL;
 
     std::wstring authName = L"NO_AUTHOR";
     ReadPtr<Author> rAuth = controller.getContext().getActiveAuthor().cget();
@@ -280,7 +275,6 @@ ContextState ContextExportStep::launch(Controller& controller)
     if (m_parameters.openFolderWindowsAfterExport)
         controller.updateInfo(new GuiDataOpenInExplorer(m_output));
 
-    IOLOG << "ContextExportStep launch 5" << LOGENDL;
 
     return (m_state = ContextState::done);
 }

--- a/src/gui/Dialog/AListListDialog.cpp
+++ b/src/gui/Dialog/AListListDialog.cpp
@@ -12,7 +12,6 @@ AListListDialog::AListListDialog(IDataDispatcher& dataDispatcher, QWidget *paren
 	, m_openPath(QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory))
 {
 	m_ui.setupUi(this);
-	GUI_LOG << "create AListListDialog" << LOGENDL;
 
 	m_ui.RemoveBtn->setEnabled(false);
 	m_ui.EditBtn->setEnabled(false);
@@ -50,7 +49,6 @@ AListListDialog::AListListDialog(IDataDispatcher& dataDispatcher, QWidget *paren
 
 AListListDialog::~AListListDialog()
 {
-	GUI_LOG << "destroy AListListDialog" << LOGENDL;
 	m_dataDispatcher.unregisterObserver(this);
 }
 
@@ -71,7 +69,6 @@ void AListListDialog::onProjectPath(IGuiData* data)
 
 void AListListDialog::showTreeMenu(QPoint p)
 {
-	//GUI_LOG << "show Tree Menu" << LOGENDL;
 	m_idSaved = m_ui.listListView->indexAt(p);
 	if (m_idSaved.isValid() == false)
 		return;

--- a/src/gui/Dialog/AListModifierDialog.cpp
+++ b/src/gui/Dialog/AListModifierDialog.cpp
@@ -19,12 +19,10 @@ AListModifierDialog::AListModifierDialog(IDataDispatcher& dataDispatcher, QDialo
 	//connect(m_ui.lineEditIndex, SIGNAL(editingFinished()), this, SLOT(changeUserIndex()));
 	QObject::connect(m_ui.NameLineEdit, SIGNAL(editingFinished()), this, SLOT(renameElem()));
 	QObject::connect(m_ui.RemoveBtn, SIGNAL(clicked()), this, SLOT(deleteElem()));
-	GUI_LOG << "create AListModifierDialog" << LOGENDL;
 }
 
 AListModifierDialog::~AListModifierDialog()
 {
-	GUI_LOG << "destroy AListModifierDialog" << LOGENDL;
 	m_dataDispatcher.unregisterObserver(this);
 }
 

--- a/src/gui/Dialog/AListNameDialog.cpp
+++ b/src/gui/Dialog/AListNameDialog.cpp
@@ -10,12 +10,10 @@ AListNameDialog::AListNameDialog(IDataDispatcher& dataDispatcher, QWidget *paren
 
 	QObject::connect(m_ui.CancelBtn, SIGNAL(clicked()), this, SLOT(cancelCreation()));
 	QObject::connect(m_ui.okBtn, SIGNAL(clicked()), this, SLOT(acceptCreation()));
-	GUI_LOG << "create AListNameDialog" << LOGENDL;
 }
 
 AListNameDialog::~AListNameDialog()
 {
-	GUI_LOG << "destroy AListNameDialog" << LOGENDL;
 	m_dataDispatcher.unregisterObserver(this);
 }
 

--- a/src/gui/Dialog/AuthorCreateDialog.cpp
+++ b/src/gui/Dialog/AuthorCreateDialog.cpp
@@ -12,12 +12,10 @@ AuthorCreateDialog::AuthorCreateDialog(IDataDispatcher& dataDispatcher, QWidget 
 
 	QObject::connect(ui->CancelBtn, SIGNAL(clicked()), this, SLOT(cancelCreation()));
 	QObject::connect(ui->OkBtn, SIGNAL(clicked()), this, SLOT(acceptCreation()));
-	GUI_LOG << "create AuthorCreateDialog" << LOGENDL;
 }
 
 AuthorCreateDialog::~AuthorCreateDialog()
 {
-	GUI_LOG << "destroy AuthorCreateDialog" << LOGENDL;
 	m_dataDispatcher.unregisterObserver(this);
 }
 

--- a/src/gui/Dialog/AuthorListDialog.cpp
+++ b/src/gui/Dialog/AuthorListDialog.cpp
@@ -16,7 +16,6 @@ AuthorListDialog::AuthorListDialog(IDataDispatcher& dataDispatcher, QWidget *par
 	m_ui.setupUi(this);
 	this->show();
 	
-	GUI_LOG << "create AuthorListDialog" << LOGENDL;
 
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::sendAuthorsList);
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::closeAuthorList);
@@ -39,7 +38,6 @@ AuthorListDialog::AuthorListDialog(IDataDispatcher& dataDispatcher, QWidget *par
 
 AuthorListDialog::~AuthorListDialog()
 {
-	GUI_LOG << "destroy AuthorListDialog" << LOGENDL;
 	m_dataDispatcher.sendControl(new control::author::SaveAuthors());
 	m_dataDispatcher.unregisterObserver(this);
 }
@@ -114,19 +112,13 @@ void AuthorListDialog::deleteAuthor()
 
 	if (reply == QMessageBox::Yes)
 	{
-		std::wstringstream ss;
 		QModelIndexList list = m_ui.AuthorListView->selectionModel()->selectedIndexes();
-
-		int i = 0;
 
 		foreach (const QModelIndex &index, list)
 		{
-			ss << ((i == 0) ? L"" : L", ");
 			AuthorListNode *list = static_cast<AuthorListNode*>(model->itemFromIndex(index));
-			ss << list->text().toStdWString();
 			m_dataDispatcher.sendControl(new control::author::DeleteAuthor(list->getAuthor()));
 		}
-		GUI_LOG << "delete " << ss.str() << LOGENDL;
 	}
 	else
 		GUI_LOG << "list not deleted" << LOGENDL;

--- a/src/gui/Dialog/DialogRecentProjects.cpp
+++ b/src/gui/Dialog/DialogRecentProjects.cpp
@@ -15,7 +15,6 @@ DialogRecentProjects::DialogRecentProjects(IDataDispatcher& dataDispatcher, QWid
 	this->show();
 	setModal(true);
 	
-	GUI_LOG << "create DialogRecentProjects" << LOGENDL;
 
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::sendRecentProjects);
 
@@ -27,7 +26,6 @@ DialogRecentProjects::DialogRecentProjects(IDataDispatcher& dataDispatcher, QWid
 
 DialogRecentProjects::~DialogRecentProjects()
 {
-	GUI_LOG << "destroy DialogRecentProjects " << LOGENDL;
 	m_dataDispatcher.unregisterObserver(this);
 }
 

--- a/src/gui/Dialog/ListListDialog.cpp
+++ b/src/gui/Dialog/ListListDialog.cpp
@@ -87,7 +87,6 @@ void ListListDialog::clickOnItem(const QModelIndex &idx)
 		m_ui.DuplicateBtn->setEnabled(true);
 		m_ui.ExportBtn->setEnabled(true);
 	}
-	GUI_LOG << "click on item" << LOGENDL;
 }
 
 void ListListDialog::addNewList()

--- a/src/gui/Dialog/ListModifierDialog.cpp
+++ b/src/gui/Dialog/ListModifierDialog.cpp
@@ -17,7 +17,6 @@ ListModifierDialog::ListModifierDialog(IDataDispatcher& dataDispatcher, QDialog 
 
 ListModifierDialog::~ListModifierDialog()
 {
-	GUI_LOG << "destroy ListModifierDialog" << LOGENDL;
 }
 
 void ListModifierDialog::getList(IGuiData *data)
@@ -118,19 +117,13 @@ void ListModifierDialog::renameElem()
 
 void ListModifierDialog::deleteElem()
 {
-	std::wstringstream ss;
 	QModelIndexList list = m_ui.listView->selectionModel()->selectedIndexes();
-
-	int i = 0;
 
 	foreach(const QModelIndex &index, list)
 	{
-		ss << ((i == 0) ? "" : ", ");
 		ItemNode *element = static_cast<ItemNode*>(model->itemFromIndex(index));
-		ss << element->getWStrData();
 		m_dataDispatcher.sendControl(new control::userlist::RemoveItemFromList(m_list, element->getWStrData()));
 	}
-	GUI_LOG << "delete " << ss.str() << LOGENDL;
 }
 
 void ListModifierDialog::clearList()

--- a/src/gui/Dialog/ProjectTemplateListDialog.cpp
+++ b/src/gui/Dialog/ProjectTemplateListDialog.cpp
@@ -111,7 +111,6 @@ void ProjectTemplateListDialog::clickOnItem(const QModelIndex &idx)
 		m_ui.updateBtn->setEnabled(false);
 		m_ui.RenameBtn->setEnabled(false);
 	}
-	GUI_LOG << "click on item" << LOGENDL;
 }
 
 
@@ -156,7 +155,6 @@ void ProjectTemplateListDialog::deleteTemplate()
 			ItemNode* item = static_cast<ItemNode*>(m_model->itemFromIndex(index));
 			m_dataDispatcher.sendControl(new control::projectTemplate::DeleteTemplate(item->getWStrData()));
 		}
-		GUI_LOG << "delete " << list.size() << " templates." << LOGENDL;
 	}
 	else
 		GUI_LOG << "templates not deleted" << LOGENDL;

--- a/src/gui/Dialog/StandardListDialog.cpp
+++ b/src/gui/Dialog/StandardListDialog.cpp
@@ -99,7 +99,6 @@ void StandardListDialog::clickOnItem(const QModelIndex &idx)
 		m_ui.DuplicateBtn->setEnabled(true);
 		m_ui.ExportBtn->setEnabled(true);
 	}
-	GUI_LOG << "click on item" << LOGENDL;
 }
 
 void StandardListDialog::addNewList()

--- a/src/gui/Dialog/StandardModifierDialog.cpp
+++ b/src/gui/Dialog/StandardModifierDialog.cpp
@@ -35,7 +35,6 @@ StandardModifierDialog::StandardModifierDialog(IDataDispatcher& dataDispatcher, 
 
 StandardModifierDialog::~StandardModifierDialog()
 {
-	GUI_LOG << "destroy StandardModifierDialog" << LOGENDL;
 }
 
 void StandardModifierDialog::getList(IGuiData *data)
@@ -143,19 +142,13 @@ void StandardModifierDialog::renameElem()
 
 void StandardModifierDialog::deleteElem()
 {
-	std::wstringstream ss;
 	QModelIndexList list = m_ui.listView->selectionModel()->selectedIndexes();
-
-	int i = 0;
 
 	foreach(const QModelIndex &index, list)
 	{
-		ss << ((i == 0) ? "" : ", ");
 		ItemNode *element = static_cast<ItemNode*>(model->itemFromIndex(index));
-		ss << element->getWStrData();
 		m_dataDispatcher.sendControl(new control::standards::RemoveItemFromList(m_list, std::stod(element->getWStrData()), m_type));
 	}
-	GUI_LOG << "delete " << ss.str() << LOGENDL;
 }
 
 void StandardModifierDialog::clearList()

--- a/src/gui/Dialog/TagTemplateNameDialog.cpp
+++ b/src/gui/Dialog/TagTemplateNameDialog.cpp
@@ -11,12 +11,10 @@ TagTemplateNameDialog::TagTemplateNameDialog(IDataDispatcher& dataDispatcher, QW
 
 	QObject::connect(ui->CancelBtn, SIGNAL(clicked()), this, SLOT(cancelCreation()));
 	QObject::connect(ui->okBtn, SIGNAL(clicked()), this, SLOT(acceptCreation()));
-	GUI_LOG << "create TagTemplateNameDialog" << LOGENDL;
 }
 
 TagTemplateNameDialog::~TagTemplateNameDialog()
 {
-	GUI_LOG << "destroy TagTemplateNameDialog" << LOGENDL;
 	m_dataDispatcher.unregisterObserver(this);
 }
 

--- a/src/gui/Dialog/TemplateEditorDialog.cpp
+++ b/src/gui/Dialog/TemplateEditorDialog.cpp
@@ -25,7 +25,6 @@ TemplateEditorDialog::TemplateEditorDialog(IDataDispatcher &dataDispacher, QWidg
 							{sma::tFieldType::string, TEXT_TEMPLATEEDITOR_STRING }, })
 {
 	ui->setupUi(this);
-	GUI_LOG << "create TemplateEditorDialog" << LOGENDL;
 
 	m_defaultValueManagers.insert(std::pair<sma::tFieldType, std::pair<defaultValueWidgetGenerator, defaultValueGatherer>>(sma::tFieldType::string,
 		std::pair<defaultValueWidgetGenerator, defaultValueGatherer>(&TemplateEditorDialog::generateStringWidget, &TemplateEditorDialog::gatherStringWidget)));

--- a/src/gui/Dialog/TemplateManagerDialog.cpp
+++ b/src/gui/Dialog/TemplateManagerDialog.cpp
@@ -23,7 +23,6 @@ TemplateManagerDialog::TemplateManagerDialog(IDataDispatcher &dataDispacher, QWi
 	m_ui->setupUi(this);
 	m_templateEditorDialog.hide();
 	m_templateNameDialog.hide();
-	GUI_LOG << "create TemplateManagerDialog" << LOGENDL;
 
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::sendTemplateList);
 	m_ui->templateList->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
@@ -45,7 +44,6 @@ TemplateManagerDialog::TemplateManagerDialog(IDataDispatcher &dataDispacher, QWi
 
 TemplateManagerDialog::~TemplateManagerDialog()
 {
-	GUI_LOG << "delete TemplateManagerDialog" << LOGENDL;
 	m_dataDispatcher.sendControl(new control::tagTemplate::SaveTemplates);
 	m_dataDispatcher.unregisterObserver(this);
 }
@@ -76,7 +74,6 @@ void TemplateManagerDialog::clickOnItem(const QModelIndex &idx)
 		m_ui->ExportBtn->setEnabled(false);
 	}
 
-	GUI_LOG << "click on item " << tempNode->text().toStdWString() << LOGENDL;
 }
 
 void TemplateManagerDialog::receiveTemplateList(IGuiData * data)
@@ -134,7 +131,6 @@ void TemplateManagerDialog::deleteTemplate()
 
 void TemplateManagerDialog::showTreeMenu(QPoint p)
 {
-	GUI_LOG << "show Tree Menu" << LOGENDL;
 
 	m_idSaved = m_ui->templateList->indexAt(p);
 	if (m_idSaved.isValid() == false)
@@ -159,7 +155,6 @@ void TemplateManagerDialog::showTreeMenu(QPoint p)
 
 void TemplateManagerDialog::newTemplate()
 {
-	GUI_LOG << "add new template" << LOGENDL;
 	m_templateNameDialog.show();
 }
 

--- a/src/gui/toolBars/ToolBarAnimationGroup.cpp
+++ b/src/gui/toolBars/ToolBarAnimationGroup.cpp
@@ -107,10 +107,6 @@ void ToolBarAnimationGroup::onProjectLoad(IGuiData* data)
 void ToolBarAnimationGroup::onAnimationPlaybackStart(IGuiData* data)
 {
     (void)data;
-    GUI_LOG << "[ANIM_DBG] toolbar received playback start"
-        << " waitingFirstViewpoint=" << m_waitingChronometerStartAtFirstViewpoint
-        << " accumulatedMs=" << m_chronometerAccumulatedMs
-        << LOGENDL;
     if (!m_waitingChronometerStartAtFirstViewpoint)
         return;
 
@@ -153,10 +149,6 @@ void ToolBarAnimationGroup::onAnimationToolbarState(IGuiData* data)
 void ToolBarAnimationGroup::onRenderStopAnimation(IGuiData* data)
 {
     (void)data;
-    GUI_LOG << "[ANIM_DBG] toolbar received stop animation"
-        << " isStopRequested=" << m_isStopRequested
-        << " accumulatedMs(before)=" << m_chronometerAccumulatedMs
-        << LOGENDL;
     m_isStarted = false;
 	m_isPaused = false;
 	m_isOrbitalRunning = false;
@@ -207,7 +199,6 @@ void ToolBarAnimationGroup::slotStartAnimation()
 	const bool viewpointsMode = m_ui.betweenViewpointsRadioButton->isChecked();
 	if (m_isPaused)
 	{
-		GUI_LOG << "[ANIM_DBG] toolbar start clicked while paused resume path" << LOGENDL;
 		m_isStopRequested = false;
 		m_pendingViewpointsStart = false;
 		m_waitingChronometerStartAtFirstViewpoint = false;
@@ -221,7 +212,6 @@ void ToolBarAnimationGroup::slotStartAnimation()
 
 	if (viewpointsMode)
 	{
-		GUI_LOG << "[ANIM_DBG] toolbar start clicked viewpoints mode" << LOGENDL;
 		const ViewPointAnimationConfig* selectedConfig = getSelectedAnimationConfig();
 		if (!selectedConfig)
 			return;
@@ -247,11 +237,6 @@ void ToolBarAnimationGroup::slotStartAnimation()
 	}
 
 	resetChronometer();
-	GUI_LOG << "[ANIM_DBG] toolbar start dispatch"
-		<< " viewpointsMode=" << viewpointsMode
-		<< " canStartAnimation=" << m_canStartAnimation
-		<< " waitPlaybackStart=" << viewpointsMode
-		<< LOGENDL;
 	m_isStopRequested = false;
 	m_waitingChronometerStartAtFirstViewpoint = viewpointsMode;
 	m_dataDispatcher.updateInformation(new GuiDataRenderStartAnimation(!viewpointsMode, static_cast<double>(m_ui.lengthSpinBox->value()), false, m_ui.degreesSpinBox->value(), m_ui.interpolateCheckBox->isChecked(), m_ui.verticalOrbitalCheckBox->isChecked()));

--- a/src/gui/viewport/VulkanViewport.cpp
+++ b/src/gui/viewport/VulkanViewport.cpp
@@ -189,10 +189,7 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
 
     if (startData->m_isOrbital)
     {
-        GUI_LOG << "[ANIM_DBG] viewport start request orbital resume=" << startData->m_resume
-            << " duration=" << startData->m_durationSeconds
-            << " degrees=" << startData->m_orbitalDegrees
-            << " vertical=" << startData->m_verticalOrbital << LOGENDL;
+        // Debug-only animation traces removed (pass 1 log cleanup): keep runtime behavior unchanged.
         m_viewpointStartInputLockArmed = false;
         if (startData->m_resume && m_isOrbitalAnimationActive && m_isOrbitalAnimationPaused)
         {
@@ -230,7 +227,6 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
 
     if (startData->m_resume)
     {
-        GUI_LOG << "[ANIM_DBG] viewport resume request viewpoints" << LOGENDL;
         m_viewpointStartInputLockArmed = false;
         wCam->resumeAnimation();
     }
@@ -239,10 +235,6 @@ void VulkanViewport::onRenderStartAnimation(IGuiData* data)
         wCam->setViewpointRenderInterpolationEnabled(startData->m_interpolateViewpointRenderings);
         const bool started = wCam->startAnimation(m_saveImagesAnim);
         m_viewpointStartInputLockArmed = started;
-        GUI_LOG << "[ANIM_DBG] viewport start request viewpoints started=" << started
-            << " inputLockArmed=" << m_viewpointStartInputLockArmed
-            << " mouseDeltas(dx,dy,wheel)= (" << m_MI.deltaX << ", " << m_MI.deltaY << ", " << m_MI.wheel << ")"
-            << LOGENDL;
         if (started)
             m_MI.resetDeltas();
     }
@@ -281,7 +273,6 @@ void VulkanViewport::onRenderStopAnimation(IGuiData* data)
     m_orbitalTotalAngleRad = 0.0;
     m_orbitalVertical = false;
     m_orbitalDirectionSign = 1.0;
-    GUI_LOG << "[ANIM_DBG] viewport received stop animation" << LOGENDL;
     wCam->endAnimation();
 }
 
@@ -451,9 +442,6 @@ void VulkanViewport::updateInputs(WritePtr<CameraNode>& wCam, SafePtr<Manipulato
     {
         skipUserInputThisFrame = true;
         m_viewpointStartInputLockArmed = false;
-        GUI_LOG << "[ANIM_DBG] viewport consumed one-frame viewpoints input lock"
-            << " mouseDeltas(dx,dy,wheel)= (" << m_MI.deltaX << ", " << m_MI.deltaY << ", " << m_MI.wheel << ")"
-            << LOGENDL;
         m_MI.resetDeltas();
     }
 

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -687,13 +687,6 @@ void CameraNode::AddViewPoint1(SafePtr<ViewPointNode> vp, const InterpolationVal
 
 bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
 {
-    GRAPH_LOG << "[ANIM_DBG] camera startAnimation request"
-        << " offline=" << isOffline
-        << " playlistSize=" << m_animationPlaylist.size()
-        << " durationSec=" << m_animationDurationSeconds
-        << " mode=" << static_cast<int>(m_viewPointAnimationMode)
-        << LOGENDL;
-
     m_isOfflineRendering = isOffline;
     if (m_animationPlaylist.size() < 2)
     {


### PR DESCRIPTION
### Motivation
- Reduce excessive and noisy debug output that was polluting logs and making production logging harder to read.
- Remove leftover development/diagnostic `GUI_LOG`/`IOLOG` traces and other debug-only messages from UI dialogs, animation tooling and export paths.
- Keep runtime behavior unchanged while making logs quieter and avoiding unnecessary string/stream allocations used only for logging.

### Description
- Removed many debug log statements (`GUI_LOG`, `IOLOG`, `GRAPH_LOG`) from dialog classes such as `AListListDialog`, `AListModifierDialog`, `AListNameDialog`, `AuthorCreateDialog`, `AuthorListDialog`, `DialogRecentProjects`, `ListListDialog`, `ListModifierDialog`, `ProjectTemplateListDialog`, `StandardListDialog`, `StandardModifierDialog`, `TagTemplateNameDialog`, `TemplateEditorDialog`, `TemplateManagerDialog` and others.
- Muted diagnostic traces in animation/viewport/camera code paths by removing debug logging in `ToolBarAnimationGroup`, `VulkanViewport` and `CameraNode::startAnimation`, replacing some debug lines with short explanatory comments where appropriate to preserve intent (for example in `ContextExportStep::launch`).
- Eliminated a few unused temporary variables and removed commented-out logging blocks to reduce clutter while preserving existing control flow and behavior.
- Ensured file/path handling in `ContextExportStep` remains unchanged (still appends `".step"` when needed) and directory/type bookkeeping is untouched.

### Testing
- Performed a full project build with `cmake`/`make` to validate compilation after removing logging statements and minor cleanups, and the build completed successfully.
- Ran the automated unit/integration test suite with `ctest` and all tests passed without regressions.
- Executed an automated GUI smoke test to start core dialogs and the viewport, which completed successfully and showed no functional differences related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd16522440832f989a8ba6a7ac59b0)