### PR TITLE
Make import/export more robust and include pipe standards in project bootstrap

### DIFF
--- a/src/controller/controls/ControlProject.cpp
+++ b/src/controller/controls/ControlProject.cpp
@@ -115,8 +115,10 @@ namespace control::project
             if (lang == LanguageType::Nothing)
                 lang = Config::getLanguage();
 
+            // Keep project bootstrap files consistent with what the loader expects.
             SaveLoadSystem::ExportTemplates(sma::GenerateDefaultTemplates(lang), slsError, context.cgetProjectInternalInfo().getTemplatesFolderPath() / File_Templates);
             SaveLoadSystem::ExportLists(generateDefaultLists(lang), context.cgetProjectInternalInfo().getTemplatesFolderPath() / File_Lists);
+            SaveLoadSystem::ExportLists(generateDefaultPipeStandardList(), context.cgetProjectInternalInfo().getTemplatesFolderPath() / File_Pipes);
         }
         else
         {

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -127,6 +127,10 @@ std::unordered_map<StandardType, std::vector<StandardList>> ImportStandards(cons
         return (standards);
     }
 
+    // Standards are optional in object files. Absence of the key is not an import error.
+    if (jsonTemplates.find(Key_Standards) == jsonTemplates.end())
+        return (standards);
+
     if (!DataDeserializer::DeserializeStandards(jsonTemplates, standards))
         IOLOG << "Error import standards" << LOGENDL;
 
@@ -1120,16 +1124,28 @@ void SaveLoadSystem::importJsonProject(const std::filesystem::path& importPath, 
 
     for (const std::filesystem::path& p : objectPathsList)
     {
+        // Ignore folders and unrelated files to avoid noisy "Cannot find" import logs.
+        if (!std::filesystem::is_regular_file(p))
+            continue;
+
+        const std::filesystem::path extension = p.extension();
+        const bool isObjectPayload = extension == File_Extension_Tags
+                                  || extension == File_Extension_Objects
+                                  || extension == File_Extension_ViewPoints;
+
+        if (!isObjectPayload)
+            continue;
+
         controller.getContext().setUserLists(ImportLists<UserList>(p));
         controller.getContext().setTemplates(ImportTemplates(controller, p));
         for (const auto& standardType : ImportStandards(p))
             controller.getContext().setStandards(standardType.second, standardType.first);
 
-        if (p.extension() == File_Extension_Tags)
+        if (extension == File_Extension_Tags)
             LoadTagFile(controller, loadObjs, p);
-        else if (p.extension() == File_Extension_Objects)
+        else if (extension == File_Extension_Objects)
             LoadObjFile(controller, loadObjs, p);
-        else if (p.extension() == File_Extension_ViewPoints)
+        else if (extension == File_Extension_ViewPoints)
             LoadViewPointsFile(controller, loadObjs, p);
     }
 
@@ -2097,16 +2113,28 @@ void SaveLoadSystem::importAuthorObjects(const std::vector<std::filesystem::path
     std::unordered_map<SafePtr<AGraphNode>, std::pair<xg::Guid, nlohmann::json>> loadObjs;
     for (const std::filesystem::path& p : importFiles)
     {
+        // Keep import resilient to folder selections and unsupported files.
+        if (!std::filesystem::is_regular_file(p))
+            continue;
+
+        const std::filesystem::path extension = p.extension();
+        const bool isObjectPayload = extension == File_Extension_Tags
+                                  || extension == File_Extension_Objects
+                                  || extension == File_Extension_ViewPoints;
+
+        if (!isObjectPayload)
+            continue;
+
         controller.getContext().setUserLists(ImportLists<UserList>(p));
         controller.getContext().setTemplates(ImportTemplates(controller, p));
         for (const auto& standardType : ImportStandards(p))
             controller.getContext().setStandards(standardType.second, standardType.first);
 
-        if (p.extension() == File_Extension_Tags)
+        if (extension == File_Extension_Tags)
             LoadTagFile(controller, loadObjs, p);
-        else if (p.extension() == File_Extension_Objects)
+        else if (extension == File_Extension_Objects)
             LoadObjFile(controller, loadObjs, p);
-        else if (p.extension() == File_Extension_ViewPoints)
+        else if (extension == File_Extension_ViewPoints)
             LoadViewPointsFile(controller, loadObjs, p);
     }
 


### PR DESCRIPTION
### Motivation
- Ensure newly created projects include the default pipe standards so loader and consumers see consistent bootstrap templates. 
- Prevent noisy logs and import failures when importing project object folders that contain directories or unrelated files. 
- Treat standards as optional in imported JSON to avoid spurious errors when the `Key_Standards` key is absent. 

### Description
- Add exporting of the default pipe standard list during project creation via `SaveLoadSystem::ExportLists(generateDefaultPipeStandardList(), ..., File_Pipes)` in `Create::doFunction`. 
- Make `ImportStandards` tolerant of missing standards by returning an empty map when `Key_Standards` is not present in the JSON. 
- In project import (`importJsonProject`) skip non-regular files and only process files whose extension matches `File_Extension_Tags`, `File_Extension_Objects`, or `File_Extension_ViewPoints`, and use a cached `extension` variable for comparisons to reduce repeated calls. 
- Apply the same regular-file and supported-extension filtering in `importAuthorObjects` to keep imports resilient to folder selections and unsupported files. 

### Testing
- Ran the project's automated import/export unit tests that exercise object/tag/viewpoint import and project bootstrap creation, and they completed successfully. 
- Executed the broader automated test suite and observed no regressions in import/export behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3147de80832f8f1740e4b691d22b)