### PR TITLE
Preserve image export settings when applying ViewPoint to Camera

### DIFF
--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -194,7 +194,7 @@ public:
     void setOrthoHeight(double height);
 
     void moveToData(const SafePtr<AGraphNode>& data);
-    void snapToViewPoint(const SafePtr<ViewPointNode>& viewpoint);
+    void snapToViewPoint(const SafePtr<ViewPointNode>& viewpoint, bool preserveImageSettings = false);
 
     // Draw camera
     glm::vec3 getExamineTargetPosition() const;

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -740,7 +740,8 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
             // Snap directly to the first viewpoint (same expectation as animation Start):
             // no initial transition trajectory before frame 1 capture.
-            wCam->snapToViewPoint(m_viewpoints.front());
+            // Video export in viewpoints mode must keep current toolbar image settings.
+            wCam->snapToViewPoint(m_viewpoints.front(), true);
             m_lastAppliedVisibilityViewpointIndex = 0;
             controller.getControlListener()->notifyUIControl(new control::viewpoint::UpdateStatesFromViewpoint(m_viewpoints.front()));
         }

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -141,6 +141,46 @@ Color32 interpolateColorHsvShortestPath(const Color32& start, const Color32& end
         static_cast<float>(start.a) + (static_cast<float>(end.a) - static_cast<float>(start.a)) * alpha));
     return normalizedRgbToColor32(utils::color::hsv2rgb(hsv), interpolatedAlpha);
 }
+
+// Copy full display parameters from a viewpoint to the camera while optionally
+// preserving the current image toolbar state (frame, ratios, W/H, alpha, format, AA...).
+// This is used by animation/video contexts where image export settings must remain
+// user-controlled and should not be overridden by viewpoint persisted values.
+void copyDisplayParametersFromViewpoint(DisplayParameters& cameraDisplay, const DisplayParameters& viewpointDisplay, bool preserveImageSettings)
+{
+    const bool previousImageUseFrame = cameraDisplay.m_imageUseFrame;
+    const bool previousImageShowGrid = cameraDisplay.m_imageShowGrid;
+    const bool previousImageRatioImageMode = cameraDisplay.m_imageRatioImageMode;
+    const int previousImageRatioImageIndex = cameraDisplay.m_imageRatioImageIndex;
+    const int previousImageRatioPrintIndex = cameraDisplay.m_imageRatioPrintIndex;
+    const bool previousImagePortrait = cameraDisplay.m_imagePortrait;
+    const uint32_t previousImageWidth = cameraDisplay.m_imageWidth;
+    const uint32_t previousImageHeight = cameraDisplay.m_imageHeight;
+    const bool previousImageAlpha = cameraDisplay.m_imageAlpha;
+    const int previousImageFormat = cameraDisplay.m_imageFormat;
+    const int previousImageAntialiasing = cameraDisplay.m_imageAntialiasing;
+    const int previousImageScaleIndex = cameraDisplay.m_imageScaleIndex;
+    const int previousImageDpiIndex = cameraDisplay.m_imageDpiIndex;
+
+    cameraDisplay = viewpointDisplay;
+
+    if (!preserveImageSettings)
+        return;
+
+    cameraDisplay.m_imageUseFrame = previousImageUseFrame;
+    cameraDisplay.m_imageShowGrid = previousImageShowGrid;
+    cameraDisplay.m_imageRatioImageMode = previousImageRatioImageMode;
+    cameraDisplay.m_imageRatioImageIndex = previousImageRatioImageIndex;
+    cameraDisplay.m_imageRatioPrintIndex = previousImageRatioPrintIndex;
+    cameraDisplay.m_imagePortrait = previousImagePortrait;
+    cameraDisplay.m_imageWidth = previousImageWidth;
+    cameraDisplay.m_imageHeight = previousImageHeight;
+    cameraDisplay.m_imageAlpha = previousImageAlpha;
+    cameraDisplay.m_imageFormat = previousImageFormat;
+    cameraDisplay.m_imageAntialiasing = previousImageAntialiasing;
+    cameraDisplay.m_imageScaleIndex = previousImageScaleIndex;
+    cameraDisplay.m_imageDpiIndex = previousImageDpiIndex;
+}
 }
 
 CameraNode::CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher)
@@ -757,7 +797,8 @@ bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
         return false;
     }
 
-    static_cast<DisplayParameters&>(*this) = *&rFirstViewpoint;
+    // During viewpoints animation playback, keep current image export toolbar values.
+    copyDisplayParametersFromViewpoint(static_cast<DisplayParameters&>(*this), static_cast<const DisplayParameters&>(*&rFirstViewpoint), true);
     applyProjection(*&rFirstViewpoint);
 
     setPosition(m_trajectory.front().point);
@@ -2851,13 +2892,13 @@ void CameraNode::moveToData(const SafePtr<AGraphNode>& data)
     sendNewUIViewPoint();
 }
 
-void CameraNode::snapToViewPoint(const SafePtr<ViewPointNode>& viewpoint)
+void CameraNode::snapToViewPoint(const SafePtr<ViewPointNode>& viewpoint, bool preserveImageSettings)
 {
     ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
     if (!rViewpoint)
         return;
 
-    static_cast<DisplayParameters&>(*this) = *&rViewpoint;
+    copyDisplayParametersFromViewpoint(static_cast<DisplayParameters&>(*this), static_cast<const DisplayParameters&>(*&rViewpoint), preserveImageSettings);
     applyProjection(*&rViewpoint);
     setPosition(rViewpoint->getCenter());
     m_quaternion = glm::normalize(rViewpoint->getOrientation());


### PR DESCRIPTION
### Motivation

- Ensure that image toolbar/export settings are not overridden when snapping the camera to a `ViewPoint` during video export or viewpoint animation playback.

### Description

- Add a boolean `preserveImageSettings` parameter to `CameraNode::snapToViewPoint` with a default of `false` to allow callers to opt into preserving image/export toolbar values when applying a viewpoint.
- Implement `copyDisplayParametersFromViewpoint(DisplayParameters&, const DisplayParameters&, bool)` to copy display parameters from a viewpoint to the camera while optionally restoring the camera's image/export-related fields when `preserveImageSettings` is `true`.
- Replace direct assignment of `DisplayParameters` with calls to `copyDisplayParametersFromViewpoint` in `CameraNode::snapToViewPoint` and during viewpoint animation startup to preserve export settings for video contexts.
- Update the video export path in `ContextExportVideoHD` to call `snapToViewPoint(..., true)` so export settings remain under user control when starting capture.

### Testing

- Project was rebuilt successfully after the changes, indicating the code compiles cleanly.
- The automated unit test suite was executed and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de87689f38832f930ea75c3adb642b)