### PR TITLE
Preserve image/export toolbar settings when applying viewpoints and playback

### DIFF
--- a/include/models/graph/CameraNode.h
+++ b/include/models/graph/CameraNode.h
@@ -194,7 +194,12 @@ public:
     void setOrthoHeight(double height);
 
     void moveToData(const SafePtr<AGraphNode>& data);
+    // Legacy/default behavior: applying a viewpoint restores its full persisted state.
+    // Keep this for explicit viewpoint activation flows (e.g. double-click viewpoint).
     void snapToViewPoint(const SafePtr<ViewPointNode>& viewpoint);
+    // Playback/export behavior: keep current image toolbar settings while applying
+    // viewpoint camera/render state.
+    void snapToViewPointForPlayback(const SafePtr<ViewPointNode>& viewpoint);
 
     // Draw camera
     glm::vec3 getExamineTargetPosition() const;

--- a/src/controller/functionSystem/ContextExportVideoHD.cpp
+++ b/src/controller/functionSystem/ContextExportVideoHD.cpp
@@ -740,7 +740,8 @@ ContextState ContextExportVideoHD::launch(Controller& controller)
 
             // Snap directly to the first viewpoint (same expectation as animation Start):
             // no initial transition trajectory before frame 1 capture.
-            wCam->snapToViewPoint(m_viewpoints.front());
+            // Video export in viewpoints mode must keep current toolbar image settings.
+            wCam->snapToViewPointForPlayback(m_viewpoints.front());
             m_lastAppliedVisibilityViewpointIndex = 0;
             controller.getControlListener()->notifyUIControl(new control::viewpoint::UpdateStatesFromViewpoint(m_viewpoints.front()));
         }

--- a/src/gui/toolBars/ToolBarImageGroup.cpp
+++ b/src/gui/toolBars/ToolBarImageGroup.cpp
@@ -255,6 +255,9 @@ ToolBarImageGroup::ToolBarImageGroup(IDataDispatcher& dataDispatcher, QWidget* p
 
 	QObject::connect(m_ui.formatComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ToolBarImageGroup::imageFormat);
 	QObject::connect(m_ui.checkBox_alphaImage, &QCheckBox::toggled, this, &ToolBarImageGroup::imageFormat);
+	// Keep antialiasing persistence aligned with the other HD image toolbar fields.
+	// Without this, viewpoints (which copy camera persisted settings) may miss the latest UI choice.
+	QObject::connect(m_ui.comboBox_antialiasHD, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int) { savePersistentSettingsToCamera(); });
 	QObject::connect(m_ui.comboBox_print, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ToolBarImageGroup::slotRatioChanged);
 	QObject::connect(m_ui.comboBox_ratioImage, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ToolBarImageGroup::slotRatioChanged);
 	QObject::connect(m_ui.comboBox_scale, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ToolBarImageGroup::slotScaleChanged);

--- a/src/models/graph/CameraNode.cpp
+++ b/src/models/graph/CameraNode.cpp
@@ -141,6 +141,46 @@ Color32 interpolateColorHsvShortestPath(const Color32& start, const Color32& end
         static_cast<float>(start.a) + (static_cast<float>(end.a) - static_cast<float>(start.a)) * alpha));
     return normalizedRgbToColor32(utils::color::hsv2rgb(hsv), interpolatedAlpha);
 }
+
+// Copy full display parameters from a viewpoint to the camera while optionally
+// preserving the current image toolbar state (frame, ratios, W/H, alpha, format, AA...).
+// This is used by animation/video contexts where image export settings must remain
+// user-controlled and should not be overridden by viewpoint persisted values.
+void copyDisplayParametersFromViewpoint(DisplayParameters& cameraDisplay, const DisplayParameters& viewpointDisplay, bool preserveImageSettings)
+{
+    const bool previousImageUseFrame = cameraDisplay.m_imageUseFrame;
+    const bool previousImageShowGrid = cameraDisplay.m_imageShowGrid;
+    const bool previousImageRatioImageMode = cameraDisplay.m_imageRatioImageMode;
+    const int previousImageRatioImageIndex = cameraDisplay.m_imageRatioImageIndex;
+    const int previousImageRatioPrintIndex = cameraDisplay.m_imageRatioPrintIndex;
+    const bool previousImagePortrait = cameraDisplay.m_imagePortrait;
+    const uint32_t previousImageWidth = cameraDisplay.m_imageWidth;
+    const uint32_t previousImageHeight = cameraDisplay.m_imageHeight;
+    const bool previousImageAlpha = cameraDisplay.m_imageAlpha;
+    const int previousImageFormat = cameraDisplay.m_imageFormat;
+    const int previousImageAntialiasing = cameraDisplay.m_imageAntialiasing;
+    const int previousImageScaleIndex = cameraDisplay.m_imageScaleIndex;
+    const int previousImageDpiIndex = cameraDisplay.m_imageDpiIndex;
+
+    cameraDisplay = viewpointDisplay;
+
+    if (!preserveImageSettings)
+        return;
+
+    cameraDisplay.m_imageUseFrame = previousImageUseFrame;
+    cameraDisplay.m_imageShowGrid = previousImageShowGrid;
+    cameraDisplay.m_imageRatioImageMode = previousImageRatioImageMode;
+    cameraDisplay.m_imageRatioImageIndex = previousImageRatioImageIndex;
+    cameraDisplay.m_imageRatioPrintIndex = previousImageRatioPrintIndex;
+    cameraDisplay.m_imagePortrait = previousImagePortrait;
+    cameraDisplay.m_imageWidth = previousImageWidth;
+    cameraDisplay.m_imageHeight = previousImageHeight;
+    cameraDisplay.m_imageAlpha = previousImageAlpha;
+    cameraDisplay.m_imageFormat = previousImageFormat;
+    cameraDisplay.m_imageAntialiasing = previousImageAntialiasing;
+    cameraDisplay.m_imageScaleIndex = previousImageScaleIndex;
+    cameraDisplay.m_imageDpiIndex = previousImageDpiIndex;
+}
 }
 
 CameraNode::CameraNode(const std::wstring& name, IDataDispatcher& dataDispatcher)
@@ -632,6 +672,8 @@ bool CameraNode::animateSimpleTrajectory()
         {
             //Note(Aurélien) #363 do stuff
             ReadPtr<ViewPointNode> rVp = m_animation.begin()->cget();
+            // Keep legacy behavior here: explicit viewpoint activation restores
+            // the full viewpoint state, including persisted image toolbar settings.
             static_cast<DisplayParameters&>(*this) = *&rVp;
             applyProjection(*&rVp);
             m_quaternion = rVp->getOrientation();
@@ -757,7 +799,8 @@ bool CameraNode::startAnimation(const bool& isOffline, const uint64_t& step)
         return false;
     }
 
-    static_cast<DisplayParameters&>(*this) = *&rFirstViewpoint;
+    // During viewpoints animation playback, keep current image export toolbar values.
+    copyDisplayParametersFromViewpoint(static_cast<DisplayParameters&>(*this), static_cast<const DisplayParameters&>(*&rFirstViewpoint), true);
     applyProjection(*&rFirstViewpoint);
 
     setPosition(m_trajectory.front().point);
@@ -2857,7 +2900,19 @@ void CameraNode::snapToViewPoint(const SafePtr<ViewPointNode>& viewpoint)
     if (!rViewpoint)
         return;
 
-    static_cast<DisplayParameters&>(*this) = *&rViewpoint;
+    copyDisplayParametersFromViewpoint(static_cast<DisplayParameters&>(*this), static_cast<const DisplayParameters&>(*&rViewpoint), false);
+    applyProjection(*&rViewpoint);
+    setPosition(rViewpoint->getCenter());
+    m_quaternion = glm::normalize(rViewpoint->getOrientation());
+}
+
+void CameraNode::snapToViewPointForPlayback(const SafePtr<ViewPointNode>& viewpoint)
+{
+    ReadPtr<ViewPointNode> rViewpoint = viewpoint.cget();
+    if (!rViewpoint)
+        return;
+
+    copyDisplayParametersFromViewpoint(static_cast<DisplayParameters&>(*this), static_cast<const DisplayParameters&>(*&rViewpoint), true);
     applyProjection(*&rViewpoint);
     setPosition(rViewpoint->getCenter());
     m_quaternion = glm::normalize(rViewpoint->getOrientation());


### PR DESCRIPTION
### Motivation
- Prevent viewpoint activation and animation playback from unintentionally overriding user-selected image export and toolbar settings (format, alpha, AA, size, ratios, etc.).
- Keep legacy behavior when explicitly snapping to a viewpoint (e.g. double-click) while using a different behavior for playback/export flows.

### Description
- Add `copyDisplayParametersFromViewpoint` helper to selectively copy display parameters from a `ViewPointNode` while optionally preserving image/export toolbar fields.
- Add `CameraNode::snapToViewPointForPlayback` to apply viewpoint camera/render state while preserving current image toolbar/export settings, and keep `snapToViewPoint` for legacy full-restore behavior.
- Replace direct `DisplayParameters` assignment in animation and export code with calls that preserve image settings during viewpoint animation/playback and change `ContextExportVideoHD` to call `snapToViewPointForPlayback` for initial frame snap.
- Ensure antialiasing toolbar changes are persisted by connecting `comboBox_antialiasHD` change to `savePersistentSettingsToCamera()` in `ToolBarImageGroup`.

### Testing
- Project build completed successfully with the changes using the normal build pipeline (`cmake`/`make` or IDE builds). 
- Ran automated unit tests (`ctest`) and the test suite passed. 
- Ran automated UI/export-related tests covering viewpoint playback and HD export flows and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de87689f38832f930ea75c3adb642b)