### PR TITLE
Default to HD image and hide screenshot option in Export Video dialog

### DIFF
--- a/src/gui/Dialog/DialogExportVideo.cpp
+++ b/src/gui/Dialog/DialogExportVideo.cpp
@@ -57,6 +57,12 @@ DialogExportVideo::DialogExportVideo(IDataDispatcher& dataDispatcher, QWidget *p
 
     connect(m_ui.mp4RadioButton, &QRadioButton::toggled, this, &DialogExportVideo::onOutputTypeChanged);
     connect(m_ui.imageRadioButton, &QRadioButton::toggled, this, &DialogExportVideo::onOutputTypeChanged);
+
+    // The option to choose between an HD image and a screenshot has been hidden and set to HD image by default, so as not to add an extra layer of complexity for the user. However, both options are still available in case they are needed in the future.
+    m_ui.imageHDRadioButton->setChecked(true);
+    m_ui.label_4->setVisible(false);
+    m_ui.widget->setVisible(false);
+
     onOutputTypeChanged();
 }
 


### PR DESCRIPTION
### Motivation
- Reduce UI complexity by hiding the option between an HD image and a screenshot and defaulting to HD image to prevent user confusion while keeping both options available for future use.

### Description
- In `DialogExportVideo.cpp` the constructor now sets `m_ui.imageHDRadioButton->setChecked(true)`, hides `m_ui.label_4` and `m_ui.widget`, and adds a comment explaining the change so the screenshot option remains present in code but removed from the visible UI.

### Testing
- No automated tests were added or run for this minor UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4f8ca270832fb620c2482d89f15d)