### PR TITLE
Handle equivalent TLS paths and consistent scan renaming during conversion/import

### DIFF
--- a/src/controller/functionSystem/ContextConvertionScan.cpp
+++ b/src/controller/functionSystem/ContextConvertionScan.cpp
@@ -27,6 +27,7 @@
 #include "utils/Logger.h"
 
 #include <chrono>
+#include <unordered_set>
 
 
 constexpr double BIG_COORDINATES_THRESHOLD = 10000.0;
@@ -34,6 +35,38 @@ constexpr double BIG_COORDINATES_THRESHOLD = 10000.0;
 #define Ok 0x00000400
 
 constexpr uint64_t POINTS_PER_READ = 2 * 1048576;
+
+namespace
+{
+    bool hasDuplicateScanNames(const IScanFileReader& fileReader)
+    {
+        std::unordered_set<std::wstring> names;
+        for (uint32_t s = 0; s < fileReader.getScanCount(); ++s)
+        {
+            const std::wstring& name = fileReader.getTlsScanHeader(s).name;
+            if (!names.insert(name).second)
+                return true;
+        }
+        return false;
+    }
+
+    std::wstring buildConvertedOutputName(const IScanFileReader& fileReader, const std::filesystem::path& inputFile, uint32_t scanIndex, bool useAutoRenaming)
+    {
+        if (fileReader.getScanCount() <= 1)
+            return inputFile.stem().wstring();
+
+        if (useAutoRenaming)
+        {
+            std::filesystem::path converter(Utils::completeWithZeros(scanIndex + 1));
+            std::wstring outputName = inputFile.stem().wstring();
+            outputName += L"_" + converter.wstring();
+            return outputName;
+        }
+
+        std::filesystem::path converter(fileReader.getTlsScanHeader(scanIndex).name);
+        return converter.wstring();
+    }
+}
 
 BoundingBoxD getScansBoundingBox(const std::vector<glm::dvec3>& scansPositions)
 {
@@ -257,6 +290,9 @@ ContextType ContextConvertionScan::getType() const
 
 void ContextConvertionScan::registerConvertedScan(Controller& controller, const std::filesystem::path& filename, bool overwritedFile, bool asObject, float time)
 {
+    (void)overwritedFile;
+    (void)asObject;
+
     SaveLoadSystem::ErrorCode error;
 
     SafePtr<PointCloudNode> pcObj = SaveLoadSystem::ImportNewTlsFile(filename, m_scanInfo.asObject, controller, error);
@@ -264,13 +300,11 @@ void ContextConvertionScan::registerConvertedScan(Controller& controller, const 
     if (error != SaveLoadSystem::ErrorCode::Success)
     {
         QString log;
-        if (overwritedFile == false)
-        {
-            FUNCLOG << "Error during ContextConversionScan" << LOGENDL;
-            log = QString(TEXT_SCAN_IMPORT_FAILED).arg(QString::fromStdWString(filename.stem().wstring()));
-        }
-        else
-            log = QString(TEXT_SCAN_IMPORT_DONE_TEXT).arg(QString::fromStdWString(filename.stem().wstring()));
+        // Keep failure reporting explicit regardless of overwrite mode.
+        // Overwrite may be enabled for conversion output, but a registration/import
+        // failure must still be surfaced as an error.
+        FUNCLOG << "Error during ContextConversionScan" << LOGENDL;
+        log = QString(TEXT_SCAN_IMPORT_FAILED).arg(QString::fromStdWString(filename.stem().wstring()));
 
         controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(log));
         controller.updateInfo(new GuiDataTmpMessage(log));
@@ -320,6 +354,10 @@ void ContextConvertionScan::convertFile(Controller& controller, const std::files
         return;
     }
 
+    // Use the same naming strategy as pre-check (checkScansExist) to avoid
+    // mismatches between collision detection and actual conversion output names.
+    const bool useAutoRenaming = hasDuplicateScanNames(*fileReader);
+
     for (uint32_t s = 0; s < fileReader->getScanCount(); ++s) 
     {
         if (m_state != ContextState::running)
@@ -334,23 +372,7 @@ void ContextConvertionScan::convertFile(Controller& controller, const std::files
 
         outputDir = controller.getContext().cgetProjectInternalInfo().getPointCloudFolderPath(m_scanInfo.asObject);
 
-        std::wstring outputName;
-        if (fileReader->getScanCount() > 1)
-        {
-            if (fileReader->getScanCount() > 1 && fileReader->getTlsScanHeader(1).name == fileReader->getTlsScanHeader(0).name)
-            {
-                std::filesystem::path converter(Utils::completeWithZeros(s + 1));
-                outputName = inputFile.stem();
-                outputName += L"_" + converter.wstring();
-            }
-            else
-            {
-                std::filesystem::path converter(fileReader->getTlsScanHeader(s).name);
-                outputName = converter.wstring();
-            }
-        }
-        else
-            outputName = inputFile.stem();
+        std::wstring outputName = buildConvertedOutputName(*fileReader, inputFile, s, useAutoRenaming);
 
         if (!m_properties.overwriteExisting && std::filesystem::exists(outputDir / (outputName + std::wstring(L".tls"))))
         {
@@ -463,11 +485,13 @@ int ContextConvertionScan::checkScansExist(const std::filesystem::path& inputFil
         return -1;
     }
 
+    const bool useAutoRenaming = hasDuplicateScanNames(*fileReader);
+    renaming = useAutoRenaming;
+
     for (uint32_t s = 0; s < fileReader->getScanCount(); ++s)
     {
         std::filesystem::path outputFile = destDir;
-        std::filesystem::path converter(fileReader->getTlsScanHeader(s).name);
-        outputFile /= fileReader->getScanCount() == 1 ? inputFile.stem() : std::filesystem::path(converter.wstring());
+        outputFile /= std::filesystem::path(buildConvertedOutputName(*fileReader, inputFile, s, useAutoRenaming));
         outputFile += ".tls";
         headers.push_back(fileReader->getTlsScanHeader(s));
         if (std::filesystem::exists(outputFile))
@@ -476,8 +500,6 @@ int ContextConvertionScan::checkScansExist(const std::filesystem::path& inputFil
             retCode++;
         }
     }
-    //Note (Aurélien) only a quick check of scan name on the first ones, not sure there is a case where we need to check every scans...
-    renaming = (fileReader->getScanCount() > 1 && fileReader->getTlsScanHeader(1).name == fileReader->getTlsScanHeader(0).name);
     delete fileReader;
     return retCode;
 }

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -64,6 +64,7 @@
 #include <algorithm>
 #include <chrono>
 #include <thread>
+#include <cwctype>
 
 #define SAVELOADSYSTEMVERSION 2.0f
 
@@ -75,6 +76,33 @@ static const std::unordered_map<SaveLoadSystem::ObjectsFileType, std::pair<std::
 , {SaveLoadSystem::ObjectsFileType::Tld_Backup, {std::string(File_Extension_Tags) + File_Extension_Backup, Key_Tags}}
 , {SaveLoadSystem::ObjectsFileType::Tlv_Backup, {std::string(File_Extension_ViewPoints) + File_Extension_Backup, Key_ViewPoints}}
 };
+
+namespace
+{
+    std::wstring normalizePathKey(std::filesystem::path path)
+    {
+        path = path.lexically_normal();
+        std::wstring key = path.generic_wstring();
+#ifdef _WIN32
+        std::transform(key.begin(), key.end(), key.begin(), towlower);
+#endif
+        return key;
+    }
+
+    bool arePathsEquivalent(const std::filesystem::path& lhs, const std::filesystem::path& rhs)
+    {
+        if (lhs.empty() || rhs.empty())
+            return false;
+
+        std::error_code ec;
+        if (std::filesystem::equivalent(lhs, rhs, ec))
+            return true;
+
+        // Fallback for cases where equivalent() cannot resolve one path but both refer
+        // to the same location with different textual forms.
+        return normalizePathKey(lhs) == normalizePathKey(rhs);
+    }
+}
 
 
 std::filesystem::path getExplicitPath(const ProjectInternalInfo& project, const std::filesystem::path& file)
@@ -1292,9 +1320,17 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
 
     std::filesystem::path filename(filePath.filename());
     std::filesystem::path dst_path = context.cgetProjectInternalInfo().getPointCloudFolderPath(is_object) / filename;
-    // Copy to project folder and force destination update to avoid keeping a source path
-    // when a file with the same name already exists in destination.
-    tlCopyScanFile(scanGuid, dst_path, true, true, false);
+    const bool fileAlreadyInProjectStorage = arePathsEquivalent(filePath, dst_path);
+    if (!fileAlreadyInProjectStorage)
+    {
+        // Copy to project folder and force destination update to avoid keeping a source path
+        // when a file with the same name already exists in destination.
+        tlCopyScanFile(scanGuid, dst_path, true, true, false);
+    }
+    else
+    {
+        IOLOG << "INFO - TLS file already in project storage, skip physical copy: " << dst_path << LOGENDL;
+    }
 
     // Ensure copy queue is processed and the active scan path points to project storage
     // before exposing the node to delete workflows.
@@ -1304,7 +1340,7 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
     for (int i = 0; i < maxRetry; ++i)
     {
         TlScanOverseer::getInstance().resourceManagement_sync();
-        if (tlGetCurrentScanPath(scanGuid, currentPath) && currentPath == dst_path)
+        if (tlGetCurrentScanPath(scanGuid, currentPath) && arePathsEquivalent(currentPath, dst_path))
         {
             copiedToProjectPath = true;
             break;

--- a/src/models/graph/GraphManager.cpp
+++ b/src/models/graph/GraphManager.cpp
@@ -20,6 +20,34 @@
 
 #include "pointCloudEngine/PCE_core.h"
 
+#include <algorithm>
+#include <cwctype>
+
+namespace
+{
+    std::wstring normalizePathKey(std::filesystem::path path)
+    {
+        path = path.lexically_normal();
+        std::wstring key = path.generic_wstring();
+#ifdef _WIN32
+        std::transform(key.begin(), key.end(), key.begin(), towlower);
+#endif
+        return key;
+    }
+
+    bool arePathsEquivalent(const std::filesystem::path& lhs, const std::filesystem::path& rhs)
+    {
+        if (lhs.empty() || rhs.empty())
+            return false;
+
+        std::error_code ec;
+        if (std::filesystem::equivalent(lhs, rhs, ec))
+            return true;
+
+        return normalizePathKey(lhs) == normalizePathKey(rhs);
+    }
+}
+
 GraphManager::GraphManager(IDataDispatcher& dataDispatcher)
     : m_root(make_safe<AGraphNode>())
     , m_meshManager(&MeshManager::getInstance())
@@ -638,7 +666,7 @@ bool GraphManager::isFilePathOrScanExists(const std::wstring& name, const std::f
         if (type == ElementType::Scan)
         {
             ReadPtr<PointCloudNode> readScan = static_pointer_cast<PointCloudNode>(objectPtr).cget();
-            if (readScan && (readScan->getName() == name || readScan->getTlsFilePath() == filePath))
+            if (readScan && (readScan->getName() == name || arePathsEquivalent(readScan->getTlsFilePath(), filePath)))
                 return (true);
         }
     }

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -208,6 +208,18 @@ bool TlScanOverseer::doFileCopy(scanCopyInfo& copyInfo)
     }
 
     try {
+        std::filesystem::path old_path = oldScan->getPath();
+
+        // Robust guard: even with "overwrite existing", trying to copy a file onto itself
+        // can throw on some platforms when path separators differ ('/' vs '\').
+        // Treat equivalent source/destination as a successful no-op.
+        std::error_code sameFileEc;
+        if (std::filesystem::equivalent(old_path, copyInfo.path, sameFileEc))
+        {
+            Logger::log(IOLog) << "INFO - source and destination are equivalent. Skip copy for {" << copyInfo.guid << "}." << Logger::endl;
+            return true;
+        }
+
         // Check that the destination path is free
         if (!copyInfo.overrideDestination && std::filesystem::exists(copyInfo.path))
         {
@@ -243,7 +255,6 @@ bool TlScanOverseer::doFileCopy(scanCopyInfo& copyInfo)
         {
             std::filesystem::copy_options options = std::filesystem::copy_options::none;
             options |= copyInfo.overrideDestination ? std::filesystem::copy_options::overwrite_existing : std::filesystem::copy_options::skip_existing;
-            std::filesystem::path old_path = oldScan->getPath();
 
             std::filesystem::copy(old_path, copyInfo.path, options);
 


### PR DESCRIPTION
### Motivation
- Avoid duplicate-name collisions and path comparison issues when converting or importing TLS files across platforms and textual path variants.
- Prevent unnecessary file copies and copy failures when source and destination paths are equivalent but differ in textual form or separators.

### Description
- Add `hasDuplicateScanNames` and `buildConvertedOutputName` helpers to `ContextConvertionScan.cpp` and use a consistent naming strategy for converted scans to ensure collision detection and output names match.
- Simplify error logging in `registerConvertedScan` so import failures are always reported regardless of overwrite mode and remove unused parameters there.
- Introduce `arePathsEquivalent` (with `normalizePathKey`) in `SaveLoadSystem.cpp` and `GraphManager.cpp` to reliably compare filesystem paths (using `std::filesystem::equivalent` with a fallback normalization and case-insensitive comparison on Windows).`
- Use `arePathsEquivalent` in `SaveLoadSystem::ImportNewTlsFile` to skip copying when the TLS file is already in project storage and to verify the active scan path, and in `GraphManager::isFilePathOrScanExists` to detect existing scans by path robustly.
- In `TlScanOverseer::doFileCopy` add a guard to treat equivalent source/destination as a no-op (skip copy) to avoid platform-specific copy errors, and refactor copy logic accordingly.

### Testing
- Performed a full project build using the standard build pipeline (`cmake --build .`) and executed the test suite with `ctest`; the build and automated tests passed.
- Ran automated import/conversion integration tests covering multi-scan TLS files and overwrite/no-overwrite scenarios; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9692e404832fb2f40c9df00909ed)