### PR TITLE
Add runtime diagnostics and enhanced logging for TLS scan import and file operations

### DIFF
--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -193,6 +193,11 @@ public:
     bool getScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath);
 
     bool isScanLeftTofree();
+    // Diagnostic helpers for large import investigations.
+    // They expose runtime queue sizes without changing functional behavior.
+    size_t getActiveScanCount();
+    size_t getScansPendingFreeCount();
+    size_t getPendingCopyCount();
     void copyScanFile_async(const tls::ScanGuid& scanGuid, const std::filesystem::path& destPath, bool savePath, bool overrideDestination, bool removeSource);
     void freeScan_async(tls::ScanGuid scanGuid, bool deletePhysicalFile);
     void resourceManagement_sync();

--- a/projects/lib_tls/tls_impl.cpp
+++ b/projects/lib_tls/tls_impl.cpp
@@ -8,6 +8,8 @@
 #include "tls_transform.h"
 #include "utils.h"
 
+#include <cerrno>
+#include <cstring>
 #include <map>
 
 using namespace tls;
@@ -447,7 +449,9 @@ void ImageFile_p::open_file()
     fstr_.open(filepath_, std::ios::in | std::ios::out | std::ios::binary | std::ios::ate);
     if (fstr_.fail())
     {
-        std::string msg = "An unexpected error occured while opening the file '" + filepath_.string();
+        std::string msg = "An unexpected error occured while opening the file '" + filepath_.string()
+            + "' (errno=" + std::to_string(errno)
+            + ", strerror=" + std::string(std::strerror(errno)) + ")";
         results_.push_back({ result::ERROR, msg });
         return;
     }

--- a/src/controller/functionSystem/ContextImportScan.cpp
+++ b/src/controller/functionSystem/ContextImportScan.cpp
@@ -4,6 +4,7 @@
 #include "controller/Controller.h"
 #include "controller/IControlListener.h"
 #include "io/SaveLoadSystem.h"
+#include "pointCloudEngine/TlScanOverseer.h"
 
 #include "models/graph/PointCloudNode.h"
 #include "models/graph/GraphManager.h"
@@ -78,6 +79,12 @@ ContextState ContextImportScan::launch(Controller& controller)
 		if (error != SaveLoadSystem::ErrorCode::Success)
 		{
 			CONTROLLOG << "Error during ContextImportScan" << LOGENDL;
+			CONTROLLOG << "Import failure details: path=[" << inputFile
+				<< "], errorCode=" << static_cast<int>(error)
+				<< ", activeScans=" << TlScanOverseer::getInstance().getActiveScanCount()
+				<< ", pendingFree=" << TlScanOverseer::getInstance().getScansPendingFreeCount()
+				<< ", pendingCopy=" << TlScanOverseer::getInstance().getPendingCopyCount()
+				<< LOGENDL;
 			// Show a dedicated user-facing message for duplicate scans already present
 			// in project instead of reporting a generic failure.
 			QString log = (error == SaveLoadSystem::ErrorCode::Already_Exists)

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -65,6 +65,7 @@
 #include <chrono>
 #include <thread>
 #include <cwctype>
+#include <cstdio>
 
 #define SAVELOADSYSTEMVERSION 2.0f
 
@@ -1303,7 +1304,19 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
     tls::ScanGuid scanGuid;
     if (tlGetScanGuid(filePath, scanGuid) == false)
     {
-        IOLOG << "Error: " << filePath << " is not a valid tls file." << LOGENDL;
+        // Diagnostic detail for large-batch imports: this path currently fails before
+        // any node is created, often due to lower-level open/read failures.
+        const size_t activeScans = TlScanOverseer::getInstance().getActiveScanCount();
+        const size_t pendingFree = TlScanOverseer::getInstance().getScansPendingFreeCount();
+        const size_t pendingCopy = TlScanOverseer::getInstance().getPendingCopyCount();
+        IOLOG << "Error: " << filePath << " is not a valid tls file."
+            << " Diagnostics{activeScans=" << activeScans
+            << ", pendingFree=" << pendingFree
+            << ", pendingCopy=" << pendingCopy;
+#if defined(_WIN32)
+        IOLOG << ", maxStdio=" << _getmaxstdio();
+#endif
+        IOLOG << "}" << LOGENDL;
         errorCode = ErrorCode::Failed_To_Open;
         return SafePtr<PointCloudNode>();
     }

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -13,7 +13,9 @@
 #include <atomic>
 #include <cmath>
 #include <chrono>
+#include <cerrno>
 #include <condition_variable>
+#include <cstring>
 #include <future>
 #include <mutex>
 #include <set>
@@ -259,7 +261,15 @@ EmbeddedScan::EmbeddedScan(std::filesystem::path const& filepath)
     // open tls file
     if (!tls_img_file_.open(filepath, tls::usage::read))
     {
-        Logger::log(IOLog) << "An error occured while opening the TLS file '" << filepath << "'" << Logger::endl;
+        std::error_code ecExists;
+        const bool exists = std::filesystem::exists(filepath, ecExists);
+        std::error_code ecSize;
+        const uintmax_t fileSize = exists ? std::filesystem::file_size(filepath, ecSize) : 0;
+        Logger::log(IOLog) << "An error occured while opening the TLS file '" << filepath << "'"
+            << " (exists=" << exists
+            << ", size=" << (ecSize ? 0 : fileSize)
+            << ", errno=" << errno
+            << ", strerror=" << std::strerror(errno) << ")" << Logger::endl;
         return;
     }
 

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -68,11 +68,19 @@ void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudIns
 
 bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid& _scanGuid)
 {
+    const size_t activeBefore = getActiveScanCount();
+    const size_t pendingFreeBefore = getScansPendingFreeCount();
+    const size_t pendingCopyBefore = getPendingCopyCount();
+
     EmbeddedScan* newScan = new EmbeddedScan(_filePath);
     xg::Guid nullGuid;
 
     if (newScan->getGuid() == nullGuid)
     {
+        Logger::log(IOLog) << "ERROR - getScanGuid failed for path [" << _filePath
+            << "], returned null GUID. ActiveScans=" << activeBefore
+            << ", PendingFree=" << pendingFreeBefore
+            << ", PendingCopy=" << pendingCopyBefore << Logger::endl;
         _scanGuid = nullGuid;
         // No memory leak
         delete newScan; 
@@ -84,6 +92,10 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     if (it_scan != m_activeScans.end())
     {
         _scanGuid = it_scan->second->getGuid();
+        Logger::log(IOLog) << "INFO - getScanGuid reuse existing GUID {" << _scanGuid
+            << "} for path [" << _filePath << "]. ActiveScans=" << m_activeScans.size()
+            << ", PendingFree=" << m_scansToFree.size()
+            << ", PendingCopy=" << pendingCopyBefore << Logger::endl;
         // No memory leak
         delete newScan;
         return true;
@@ -91,6 +103,10 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
 
     m_activeScans.insert({ newScan->getGuid(), newScan });
     _scanGuid = newScan->getGuid();
+    Logger::log(IOLog) << "INFO - getScanGuid registered GUID {" << _scanGuid
+        << "} for path [" << _filePath << "]. ActiveScans=" << m_activeScans.size()
+        << ", PendingFree=" << m_scansToFree.size()
+        << ", PendingCopy=" << pendingCopyBefore << Logger::endl;
 
     return true;
 }
@@ -133,6 +149,24 @@ bool  TlScanOverseer::isScanLeftTofree()
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
     return !m_scansToFree.empty();
+}
+
+size_t TlScanOverseer::getActiveScanCount()
+{
+    std::lock_guard<std::mutex> lock(m_activeMutex);
+    return m_activeScans.size();
+}
+
+size_t TlScanOverseer::getScansPendingFreeCount()
+{
+    std::lock_guard<std::mutex> lock(m_activeMutex);
+    return m_scansToFree.size();
+}
+
+size_t TlScanOverseer::getPendingCopyCount()
+{
+    std::lock_guard<std::mutex> lock(m_copyMutex);
+    return m_waitingCopies.size();
 }
 
 void TlScanOverseer::copyScanFile_async(const tls::ScanGuid& scanGuid, const std::filesystem::path& destPath, bool savePath, bool overrideDestination, bool removeSource)


### PR DESCRIPTION
### Motivation

- Provide additional runtime diagnostics to investigate large-batch TLS import failures by exposing current overseer queue sizes and richer error information. 
- Improve observability of low-level file open/copy errors by including `errno` and `strerror()` details and reporting file existence/size. 
- Surface overseer/internal state at import failure points so failures can be correlated with resource contention or pending operations.

### Description

- Added diagnostic accessors to `TlScanOverseer`: `getActiveScanCount()`, `getScansPendingFreeCount()`, and `getPendingCopyCount()` and implemented them with proper locking. 
- Enhanced `TlScanOverseer::getScanGuid()` with informational logging including active/pending counts and reuse/new registration messages. 
- Extended import and error logging in `SaveLoadSystem::ImportNewTlsFile()` and `ContextImportScan::launch()` to include overseer queue counts and (on Windows) `_getmaxstdio()` for debugging large imports. 
- Improved file operation error messages in `ImageFile_p::open_file()` (added `errno` and `strerror()`), and in `EmbeddedScan` when opening TLS files (reports existence, file size, `errno`, and `strerror()`). 
- Added required includes (`<cerrno>`, `<cstring>`, `<cstdio>`) and included `pointCloudEngine/TlScanOverseer.h` where needed to enable diagnostics. 

### Testing

- Built the project successfully after changes. 
- Ran the automated unit test suite and CI-style build tests locally and they completed successfully. 
- Executed automated import-related tests that exercise `ImportNewTlsFile` logging paths and they passed (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed37cdf378832fbc8f6f28bb2c84d6)