### PR TITLE
Batch scan import: single-save behavior, error handling, and logging improvements

### DIFF
--- a/src/controller/functionSystem/ContextImportScan.cpp
+++ b/src/controller/functionSystem/ContextImportScan.cpp
@@ -64,12 +64,23 @@ ContextState ContextImportScan::launch(Controller& controller)
 
 	controller.updateInfo(new GuiDataProcessingSplashScreenStart(m_scanInfo.paths.size(), TEXT_IMPORTING_SCAN, QString()));
 	GraphManager& graphManager = controller.getGraphManager();
+	(void)graphManager;
 
+	uint64_t importSuccessCount = 0;
+	uint64_t importFailureCount = 0;
+	uint64_t importDuplicateCount = 0;
+	bool shouldRequestSave = false;
 
 	for (const std::filesystem::path& inputFile : m_scanInfo.paths)
 	{
 		if (m_state != ContextState::running)
+		{
+			FUNCLOG << "ContextImportScan interrupted before completion. "
+				<< "Imported=" << importSuccessCount
+				<< " Failed=" << importFailureCount
+				<< " Duplicates=" << importDuplicateCount << LOGENDL;
 			return ContextState::abort;
+		}
 		controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString::fromStdWString(inputFile.wstring())));
 		SaveLoadSystem::ErrorCode error;
 
@@ -77,6 +88,9 @@ ContextState ContextImportScan::launch(Controller& controller)
 
 		if (error != SaveLoadSystem::ErrorCode::Success)
 		{
+			++importFailureCount;
+			if (error == SaveLoadSystem::ErrorCode::Already_Exists)
+				++importDuplicateCount;
 			CONTROLLOG << "Error during ContextImportScan" << LOGENDL;
 			// Show a dedicated user-facing message for duplicate scans already present
 			// in project instead of reporting a generic failure.
@@ -84,8 +98,10 @@ ContextState ContextImportScan::launch(Controller& controller)
 				? QString(TEXT_SCAN_IMPORT_ALREADY_EXISTS_IGNORED)
 				: QString(TEXT_SCAN_IMPORT_FAILED).arg(QString::fromStdWString(inputFile.wstring()));
 			controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(log));
-			controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
-			controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+
+			// Important: never launch save from this error branch.
+			// Saving is performed once at the end of the batch to avoid
+			// launch/abort cascades between import and save contexts.
 			continue;
 		}
 
@@ -105,10 +121,26 @@ ContextState ContextImportScan::launch(Controller& controller)
 			}
 		}
 
+		++importSuccessCount;
+		shouldRequestSave = true;
 		updateStep(controller, QString(TEXT_SCAN_IMPORT_DONE_TEXT).arg(QString::fromStdWString(inputFile.stem().wstring())), 1);
 	}
 
-	controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+	if (shouldRequestSave)
+	{
+		// Trigger exactly one save request per import batch.
+		// This prevents duplicate save context launches.
+		controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+	}
+	else
+	{
+		CONTROLLOG << "ContextImportScan finished with no imported scan. Save request skipped." << LOGENDL;
+	}
+	CONTROLLOG << "ContextImportScan summary: Total=" << m_scanInfo.paths.size()
+		<< " Imported=" << importSuccessCount
+		<< " Failed=" << importFailureCount
+		<< " Duplicates=" << importDuplicateCount
+		<< " SaveRequested=" << (shouldRequestSave ? "true" : "false") << LOGENDL;
 		
 	controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 

--- a/src/controller/functionSystem/FunctionManager.cpp
+++ b/src/controller/functionSystem/FunctionManager.cpp
@@ -38,9 +38,32 @@ FunctionManager::~FunctionManager()
 ContextId FunctionManager::launchFunction(Controller& controller, const ContextType& type)
 {
     FUNCLOG << "launch context " << magic_enum::enum_name(type) << LOGENDL;
+
+    AContext* currentContext = getContext(m_actualCId);
+    if (currentContext != nullptr)
+    {
+        const ContextType currentType = currentContext->getType();
+        const ContextState currentState = currentContext->getState();
+        FUNCLOG << "current active context id=" << m_actualCId
+            << " type=" << magic_enum::enum_name(currentType)
+            << " state=" << magic_enum::enum_name(currentState) << LOGENDL;
+
+        // Save context can be requested several times by UI controls.
+        // Keep this launch idempotent while a save context is already active
+        // to avoid unnecessary abort/relaunch sequences.
+        if (type == ContextType::saveProject &&
+            currentType == ContextType::saveProject &&
+            currentState != ContextState::done &&
+            currentState != ContextState::abort)
+        {
+            FUNCLOG << "saveProject launch ignored: a save context is already active (id=" << m_actualCId << ")" << LOGENDL;
+            return m_actualCId;
+        }
+    }
     //NOTE (Aurélien) POC Undo/Redo context
     //controller->updateInfo(new GuiDataUndoRedoAble(true, true));
-    abort(controller, m_actualCId);
+    if (m_actualCId != INVALID_CONTEXT_ID)
+        abort(controller, m_actualCId);
 
     m_actualCId = s_contextIdGiver.giveAutoId();
 
@@ -189,7 +212,9 @@ void FunctionManager::abort(Controller& controller, const ContextId& id)
     AContext* context = getContext(id);
     if (context != nullptr)
     {
-        FUNCLOG << "Abort context " << magic_enum::enum_name(context->getType()) << LOGENDL;
+        FUNCLOG << "Abort context id=" << id
+            << " type=" << magic_enum::enum_name(context->getType())
+            << " state=" << magic_enum::enum_name(context->getState()) << LOGENDL;
         context->abort(controller);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent repeated save context launches during multi-file scan imports and avoid cascading abort/relaunch behavior. 
- Make import processing more robust and observable by counting successes/failures/duplicates and logging a concise summary. 
- Avoid idempotency issues when the UI requests multiple `saveProject` launches while one is already running. 

### Description
- In `ContextImportScan::launch` added counters (`importSuccessCount`, `importFailureCount`, `importDuplicateCount`) and a `shouldRequestSave` flag to track batch results and decide whether to request a single save at the end of the batch. 
- Stop launching a save from the per-file error branch and instead trigger exactly one `control::project::StartSave()` after the loop when at least one import succeeded, and log a summary of the run. 
- Early-return with a clear log when the import context is interrupted mid-batch. 
- Minor unused-variable suppression for `graphManager` to avoid warnings. 
- In `FunctionManager::launchFunction` check the currently active context and make `saveProject` launches idempotent by ignoring new save launches while a save context is already active and not finished. 
- Improve logging in `FunctionManager::launchFunction` and `FunctionManager::abort` to include context id, type, and state for better traceability. 
- Only call `abort` when `m_actualCId` is valid. 

### Testing
- Ran the project's automated test suite and the import/save integration scenario; no test regressions were observed. 
- Executed manual batch import scenarios to confirm that duplicate/failed imports are reported, only one save request is triggered when imports succeed, and interruptions are handled cleanly. 
- Verified enhanced logs are emitted for both launch and abort paths to aid debugging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc04aee0c832f855d1d1fa07c8363)