### PR TITLE
Prevent duplicate save launches during scan import, improve TLS file handling and logging

### DIFF
--- a/src/controller/functionSystem/ContextImportScan.cpp
+++ b/src/controller/functionSystem/ContextImportScan.cpp
@@ -64,12 +64,23 @@ ContextState ContextImportScan::launch(Controller& controller)
 
 	controller.updateInfo(new GuiDataProcessingSplashScreenStart(m_scanInfo.paths.size(), TEXT_IMPORTING_SCAN, QString()));
 	GraphManager& graphManager = controller.getGraphManager();
+	(void)graphManager;
 
+	uint64_t importSuccessCount = 0;
+	uint64_t importFailureCount = 0;
+	uint64_t importDuplicateCount = 0;
+	bool shouldRequestSave = false;
 
 	for (const std::filesystem::path& inputFile : m_scanInfo.paths)
 	{
 		if (m_state != ContextState::running)
+		{
+			FUNCLOG << "ContextImportScan interrupted before completion. "
+				<< "Imported=" << importSuccessCount
+				<< " Failed=" << importFailureCount
+				<< " Duplicates=" << importDuplicateCount << LOGENDL;
 			return ContextState::abort;
+		}
 		controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString::fromStdWString(inputFile.wstring())));
 		SaveLoadSystem::ErrorCode error;
 
@@ -77,6 +88,9 @@ ContextState ContextImportScan::launch(Controller& controller)
 
 		if (error != SaveLoadSystem::ErrorCode::Success)
 		{
+			++importFailureCount;
+			if (error == SaveLoadSystem::ErrorCode::Already_Exists)
+				++importDuplicateCount;
 			CONTROLLOG << "Error during ContextImportScan" << LOGENDL;
 			// Show a dedicated user-facing message for duplicate scans already present
 			// in project instead of reporting a generic failure.
@@ -84,8 +98,10 @@ ContextState ContextImportScan::launch(Controller& controller)
 				? QString(TEXT_SCAN_IMPORT_ALREADY_EXISTS_IGNORED)
 				: QString(TEXT_SCAN_IMPORT_FAILED).arg(QString::fromStdWString(inputFile.wstring()));
 			controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(log));
-			controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
-			controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+
+			// Important: never launch save from this error branch.
+			// Saving is performed once at the end of the batch to avoid
+			// launch/abort cascades between import and save contexts.
 			continue;
 		}
 
@@ -105,10 +121,26 @@ ContextState ContextImportScan::launch(Controller& controller)
 			}
 		}
 
+		++importSuccessCount;
+		shouldRequestSave = true;
 		updateStep(controller, QString(TEXT_SCAN_IMPORT_DONE_TEXT).arg(QString::fromStdWString(inputFile.stem().wstring())), 1);
 	}
 
-	controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+	if (shouldRequestSave)
+	{
+		// Trigger exactly one save request per import batch.
+		// This prevents duplicate save context launches.
+		controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+	}
+	else
+	{
+		CONTROLLOG << "ContextImportScan finished with no imported scan. Save request skipped." << LOGENDL;
+	}
+	CONTROLLOG << "ContextImportScan summary: Total=" << m_scanInfo.paths.size()
+		<< " Imported=" << importSuccessCount
+		<< " Failed=" << importFailureCount
+		<< " Duplicates=" << importDuplicateCount
+		<< " SaveRequested=" << (shouldRequestSave ? "true" : "false") << LOGENDL;
 		
 	controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 

--- a/src/controller/functionSystem/FunctionManager.cpp
+++ b/src/controller/functionSystem/FunctionManager.cpp
@@ -38,9 +38,32 @@ FunctionManager::~FunctionManager()
 ContextId FunctionManager::launchFunction(Controller& controller, const ContextType& type)
 {
     FUNCLOG << "launch context " << magic_enum::enum_name(type) << LOGENDL;
+
+    AContext* currentContext = getContext(m_actualCId);
+    if (currentContext != nullptr)
+    {
+        const ContextType currentType = currentContext->getType();
+        const ContextState currentState = currentContext->getState();
+        FUNCLOG << "current active context id=" << m_actualCId
+            << " type=" << magic_enum::enum_name(currentType)
+            << " state=" << magic_enum::enum_name(currentState) << LOGENDL;
+
+        // Save context can be requested several times by UI controls.
+        // Keep this launch idempotent while a save context is already active
+        // to avoid unnecessary abort/relaunch sequences.
+        if (type == ContextType::saveProject &&
+            currentType == ContextType::saveProject &&
+            currentState != ContextState::done &&
+            currentState != ContextState::abort)
+        {
+            FUNCLOG << "saveProject launch ignored: a save context is already active (id=" << m_actualCId << ")" << LOGENDL;
+            return m_actualCId;
+        }
+    }
     //NOTE (Aurélien) POC Undo/Redo context
     //controller->updateInfo(new GuiDataUndoRedoAble(true, true));
-    abort(controller, m_actualCId);
+    if (m_actualCId != INVALID_CONTEXT_ID)
+        abort(controller, m_actualCId);
 
     m_actualCId = s_contextIdGiver.giveAutoId();
 
@@ -189,7 +212,9 @@ void FunctionManager::abort(Controller& controller, const ContextId& id)
     AContext* context = getContext(id);
     if (context != nullptr)
     {
-        FUNCLOG << "Abort context " << magic_enum::enum_name(context->getType()) << LOGENDL;
+        FUNCLOG << "Abort context id=" << id
+            << " type=" << magic_enum::enum_name(context->getType())
+            << " state=" << magic_enum::enum_name(context->getState()) << LOGENDL;
         context->abort(controller);
     }
 }

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -11,9 +11,11 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cerrno>
 #include <cmath>
 #include <chrono>
 #include <condition_variable>
+#include <cstring>
 #include <future>
 #include <mutex>
 #include <set>
@@ -259,7 +261,9 @@ EmbeddedScan::EmbeddedScan(std::filesystem::path const& filepath)
     // open tls file
     if (!tls_img_file_.open(filepath, tls::usage::read))
     {
-        Logger::log(IOLog) << "An error occured while opening the TLS file '" << filepath << "'" << Logger::endl;
+        const int err = errno;
+        Logger::log(IOLog) << "An error occured while opening the TLS file '" << filepath
+            << "' (errno=" << err << ", strerror='" << std::strerror(err) << "')" << Logger::endl;
         return;
     }
 
@@ -312,11 +316,15 @@ EmbeddedScan::~EmbeddedScan()
     }
     delete[] m_pCellBuffers;
 
+    // Always close the underlying TLS file handle when the scan object is destroyed.
+    // This is critical during large import batches where many temporary EmbeddedScan
+    // objects are created to resolve GUID/header information.
+    const std::filesystem::path filepath = tls_img_file_.getPath();
+    tls_point_cloud_.reset();
+    tls_img_file_.close();
+
     if (m_deleteFileWhenDestroyed)
     {
-        std::filesystem::path filepath = tls_img_file_.getPath();
-        tls_img_file_.close();
-
         if (std::filesystem::remove(filepath) == true)
         {
             Logger::log(IOLog) << "INFO - the file " << filepath << " has been successfully removed." << Logger::endl;


### PR DESCRIPTION
### Motivation
- Prevent cascading save-context launches and cluttered logs when importing many scan files in a batch. 
- Make context lifecycle logging clearer and avoid relaunching a `saveProject` context while one is already active. 
- Improve TLS file error diagnostics and ensure TLS file handles are closed promptly so temporary files can be removed.

### Description
- Add import counters (`importSuccessCount`, `importFailureCount`, `importDuplicateCount`) and a `shouldRequestSave` flag to `ContextImportScan` and only trigger a single save request at the end of a successful import batch, skipping save when nothing was imported, plus a summary `CONTROLLOG` at the end. 
- Stop launching save from the per-file error branch and avoid early save/abort cascades by deferring the single save trigger to the end of the loop, and handle early interruption by logging counts before aborting. 
- Silence unused variable warning for `graphManager` with `(void)graphManager`. 
- In `FunctionManager`, log the current active context id/type/state when launching and ignore redundant `saveProject` launches if a save context is already active to make save launches idempotent; improve abort logging to include context id/type/state and only call `abort` when there is a valid active context. 
- In `EmbeddedScan`, add `errno`/`strerror` diagnostics to TLS open errors and include required headers, and always reset/close the underlying TLS file handle in the destructor (before optionally deleting the file) so file handles are released during large import batches.

### Testing
- Project build was performed and completed successfully after the changes. 
- Verified batch import behavior manually with a simulated import batch containing success, duplicate and failure cases and confirmed a single save request is issued only when at least one file was imported. 
- Ran the existing automated test suite and integration checks; all tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc04aee0c832f855d1d1fa07c8363)