### PR TITLE
Lazy-load scans and fix TLS file handle leaks; make import/save idempotent

### DIFF
--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -418,6 +418,8 @@ public:
 private:
     TlScanOverseer();
     ~TlScanOverseer();
+    EmbeddedScan* ensureScanLoaded_nolock(const tls::ScanGuid& scanGuid);
+    bool resolveScanPath_nolock(const tls::ScanGuid& scanGuid, std::filesystem::path& scanPath);
 
     struct WorkingScanInfo
     {
@@ -434,6 +436,9 @@ private:
     std::atomic<bool> m_haltStream;
 
     // Accessible files and scans
+    // m_knownScanPaths is the persistent registry (GUID -> path).
+    // m_activeScans contains only scans currently loaded in memory.
+    std::unordered_map<tls::ScanGuid, std::filesystem::path> m_knownScanPaths;
     std::unordered_map<tls::ScanGuid, EmbeddedScan*> m_activeScans;
     static thread_local std::vector<WorkingScanInfo> s_workingScansTransfo;
 

--- a/src/controller/functionSystem/ContextImportScan.cpp
+++ b/src/controller/functionSystem/ContextImportScan.cpp
@@ -64,12 +64,23 @@ ContextState ContextImportScan::launch(Controller& controller)
 
 	controller.updateInfo(new GuiDataProcessingSplashScreenStart(m_scanInfo.paths.size(), TEXT_IMPORTING_SCAN, QString()));
 	GraphManager& graphManager = controller.getGraphManager();
+	(void)graphManager;
 
+	uint64_t importSuccessCount = 0;
+	uint64_t importFailureCount = 0;
+	uint64_t importDuplicateCount = 0;
+	bool shouldRequestSave = false;
 
 	for (const std::filesystem::path& inputFile : m_scanInfo.paths)
 	{
 		if (m_state != ContextState::running)
+		{
+			FUNCLOG << "ContextImportScan interrupted before completion. "
+				<< "Imported=" << importSuccessCount
+				<< " Failed=" << importFailureCount
+				<< " Duplicates=" << importDuplicateCount << LOGENDL;
 			return ContextState::abort;
+		}
 		controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString::fromStdWString(inputFile.wstring())));
 		SaveLoadSystem::ErrorCode error;
 
@@ -77,6 +88,9 @@ ContextState ContextImportScan::launch(Controller& controller)
 
 		if (error != SaveLoadSystem::ErrorCode::Success)
 		{
+			++importFailureCount;
+			if (error == SaveLoadSystem::ErrorCode::Already_Exists)
+				++importDuplicateCount;
 			CONTROLLOG << "Error during ContextImportScan" << LOGENDL;
 			// Show a dedicated user-facing message for duplicate scans already present
 			// in project instead of reporting a generic failure.
@@ -84,8 +98,10 @@ ContextState ContextImportScan::launch(Controller& controller)
 				? QString(TEXT_SCAN_IMPORT_ALREADY_EXISTS_IGNORED)
 				: QString(TEXT_SCAN_IMPORT_FAILED).arg(QString::fromStdWString(inputFile.wstring()));
 			controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(log));
-			controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
-			controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+
+			// Important: never launch save from this error branch.
+			// Saving is performed once at the end of the batch to avoid
+			// launch/abort cascades between import and save contexts.
 			continue;
 		}
 
@@ -105,10 +121,26 @@ ContextState ContextImportScan::launch(Controller& controller)
 			}
 		}
 
+		++importSuccessCount;
+		shouldRequestSave = true;
 		updateStep(controller, QString(TEXT_SCAN_IMPORT_DONE_TEXT).arg(QString::fromStdWString(inputFile.stem().wstring())), 1);
 	}
 
-	controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+	if (shouldRequestSave)
+	{
+		// Trigger exactly one save request per import batch.
+		// This prevents duplicate save context launches.
+		controller.getControlListener()->notifyUIControl(new control::project::StartSave());
+	}
+	else
+	{
+		CONTROLLOG << "ContextImportScan finished with no imported scan. Save request skipped." << LOGENDL;
+	}
+	CONTROLLOG << "ContextImportScan summary: Total=" << m_scanInfo.paths.size()
+		<< " Imported=" << importSuccessCount
+		<< " Failed=" << importFailureCount
+		<< " Duplicates=" << importDuplicateCount
+		<< " SaveRequested=" << (shouldRequestSave ? "true" : "false") << LOGENDL;
 		
 	controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 

--- a/src/controller/functionSystem/FunctionManager.cpp
+++ b/src/controller/functionSystem/FunctionManager.cpp
@@ -38,9 +38,32 @@ FunctionManager::~FunctionManager()
 ContextId FunctionManager::launchFunction(Controller& controller, const ContextType& type)
 {
     FUNCLOG << "launch context " << magic_enum::enum_name(type) << LOGENDL;
+
+    AContext* currentContext = getContext(m_actualCId);
+    if (currentContext != nullptr)
+    {
+        const ContextType currentType = currentContext->getType();
+        const ContextState currentState = currentContext->getState();
+        FUNCLOG << "current active context id=" << m_actualCId
+            << " type=" << magic_enum::enum_name(currentType)
+            << " state=" << magic_enum::enum_name(currentState) << LOGENDL;
+
+        // Save context can be requested several times by UI controls.
+        // Keep this launch idempotent while a save context is already active
+        // to avoid unnecessary abort/relaunch sequences.
+        if (type == ContextType::saveProject &&
+            currentType == ContextType::saveProject &&
+            currentState != ContextState::done &&
+            currentState != ContextState::abort)
+        {
+            FUNCLOG << "saveProject launch ignored: a save context is already active (id=" << m_actualCId << ")" << LOGENDL;
+            return m_actualCId;
+        }
+    }
     //NOTE (Aurélien) POC Undo/Redo context
     //controller->updateInfo(new GuiDataUndoRedoAble(true, true));
-    abort(controller, m_actualCId);
+    if (m_actualCId != INVALID_CONTEXT_ID)
+        abort(controller, m_actualCId);
 
     m_actualCId = s_contextIdGiver.giveAutoId();
 
@@ -189,7 +212,9 @@ void FunctionManager::abort(Controller& controller, const ContextId& id)
     AContext* context = getContext(id);
     if (context != nullptr)
     {
-        FUNCLOG << "Abort context " << magic_enum::enum_name(context->getType()) << LOGENDL;
+        FUNCLOG << "Abort context id=" << id
+            << " type=" << magic_enum::enum_name(context->getType())
+            << " state=" << magic_enum::enum_name(context->getState()) << LOGENDL;
         context->abort(controller);
     }
 }

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -11,9 +11,11 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cerrno>
 #include <cmath>
 #include <chrono>
 #include <condition_variable>
+#include <cstring>
 #include <future>
 #include <mutex>
 #include <set>
@@ -259,7 +261,9 @@ EmbeddedScan::EmbeddedScan(std::filesystem::path const& filepath)
     // open tls file
     if (!tls_img_file_.open(filepath, tls::usage::read))
     {
-        Logger::log(IOLog) << "An error occured while opening the TLS file '" << filepath << "'" << Logger::endl;
+        const int err = errno;
+        Logger::log(IOLog) << "An error occured while opening the TLS file '" << filepath
+            << "' (errno=" << err << ", strerror='" << std::strerror(err) << "')" << Logger::endl;
         return;
     }
 
@@ -312,11 +316,15 @@ EmbeddedScan::~EmbeddedScan()
     }
     delete[] m_pCellBuffers;
 
+    // Always close the underlying TLS file handle when the scan object is destroyed.
+    // This is critical during large import batches where many temporary EmbeddedScan
+    // objects are created to resolve GUID/header information.
+    const std::filesystem::path filepath = tls_img_file_.getPath();
+    tls_point_cloud_.reset();
+    tls_img_file_.close();
+
     if (m_deleteFileWhenDestroyed)
     {
-        std::filesystem::path filepath = tls_img_file_.getPath();
-        tls_img_file_.close();
-
         if (std::filesystem::remove(filepath) == true)
         {
             Logger::log(IOLog) << "INFO - the file " << filepath << " has been successfully removed." << Logger::endl;

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -45,6 +45,7 @@ void TlScanOverseer::shutdown()
         delete (scan.second);
     }
     m_activeScans.clear();
+    m_knownScanPaths.clear();
 }
 
 void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingTransfo)
@@ -55,13 +56,13 @@ void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudIns
     // Else find the working scans instance in the active scans
     for (const tls::PointCloudInstance& guid_transfo : workingTransfo)
     {
-        auto it_scan = instance.m_activeScans.find(guid_transfo.header.guid);
-        if (it_scan == instance.m_activeScans.end())
+        EmbeddedScan* scan = instance.ensureScanLoaded_nolock(guid_transfo.header.guid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << guid_transfo.header.guid << Logger::endl;
         }
         else
-            s_workingScansTransfo.push_back({ *it_scan->second, guid_transfo.transfo, guid_transfo.isClippable });
+            s_workingScansTransfo.push_back({ *scan, guid_transfo.transfo, guid_transfo.isClippable });
             //s_workingScansTransfo.emplace_back(*it_scan->second, guid_transfo.tranfo, guid_transfo.isClippable);
     }
 }
@@ -80,17 +81,17 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     }
 
     std::lock_guard<std::mutex> lock(m_activeMutex);
-    auto it_scan = m_activeScans.find(newScan->getGuid());
-    if (it_scan != m_activeScans.end())
-    {
-        _scanGuid = it_scan->second->getGuid();
-        // No memory leak
-        delete newScan;
-        return true;
-    }
-
-    m_activeScans.insert({ newScan->getGuid(), newScan });
     _scanGuid = newScan->getGuid();
+    m_knownScanPaths.insert_or_assign(_scanGuid, newScan->getPath());
+
+    // Keep already active scans untouched, but do not force every GUID lookup
+    // to remain active in memory. This allows mass import operations to register
+    // scans without accumulating one open file handle per scan.
+    auto it_scan = m_activeScans.find(_scanGuid);
+    if (it_scan != m_activeScans.end())
+        m_knownScanPaths.insert_or_assign(_scanGuid, it_scan->second->getPath());
+
+    delete newScan;
 
     return true;
 }
@@ -99,10 +100,10 @@ bool TlScanOverseer::getScanHeader(tls::ScanGuid scanGuid, tls::ScanHeader& info
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
 
-    auto it_scan = m_activeScans.find(scanGuid);
-    if (it_scan != m_activeScans.end())
+    EmbeddedScan* scan = ensureScanLoaded_nolock(scanGuid);
+    if (scan != nullptr)
     {
-        it_scan->second->getInfo(info);
+        scan->getInfo(info);
         return true;
     }
     else
@@ -116,10 +117,8 @@ bool TlScanOverseer::getScanPath(tls::ScanGuid scanGuid, std::filesystem::path& 
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
 
-    auto it_scan = m_activeScans.find(scanGuid);
-    if (it_scan != m_activeScans.end())
+    if (resolveScanPath_nolock(scanGuid, scanPath))
     {
-        scanPath = it_scan->second->getPath();
         return true;
     }
     else
@@ -158,9 +157,14 @@ void TlScanOverseer::freeScan_async(tls::ScanGuid scanGuid, bool deletePhysicalF
         m_scansToFree.push_back(scanFile);
 
         m_activeScans.erase(it_scan);
+        if (deletePhysicalFile)
+            m_knownScanPaths.erase(scanGuid);
     }
     else
     {
+        // Keep the path registry in sync if the object was already unloaded.
+        if (deletePhysicalFile)
+            m_knownScanPaths.erase(scanGuid);
         Logger::log(IOLog) << "Info: Try to free a Scanfile not present, UUID = " << scanGuid << Logger::endl;
     }
 }
@@ -259,7 +263,11 @@ bool TlScanOverseer::doFileCopy(scanCopyInfo& copyInfo)
             std::filesystem::copy(old_path, copyInfo.path, options);
 
             if (copyInfo.savePath || copyInfo.removeSource)
+            {
                 oldScan->setPath(copyInfo.path);
+                std::lock_guard<std::mutex> lock(m_activeMutex);
+                m_knownScanPaths.insert_or_assign(copyInfo.guid, copyInfo.path);
+            }
 
             if (copyInfo.removeSource)
                 std::filesystem::remove(old_path);
@@ -303,18 +311,15 @@ bool TlScanOverseer::getScanView(tls::ScanGuid _scanGuid, const TlProjectionInfo
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
 
-        auto it_scan = m_activeScans.find(_scanGuid);
-        if (it_scan == m_activeScans.end())
+        scan = ensureScanLoaded_nolock(_scanGuid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a scan not present, UUID = " << _scanGuid << Logger::endl;
             return false;
         }
-        else
-        {
-            scan = it_scan->second;
-            // The current frame index lock the scan resources before the mutex is unlock
-            globalOk = scan->getGlobalDrawInfo(_scanDrawInfo);
-        }
+
+        // The current frame index lock the scan resources before the mutex is unlock
+        globalOk = scan->getGlobalDrawInfo(_scanDrawInfo);
     }
 
     _scanDrawInfo.cellDrawInfo.clear();
@@ -363,15 +368,11 @@ bool TlScanOverseer::testClippingEffect(tls::ScanGuid _scanGuid, const Transform
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
 
-        auto it_scan = m_activeScans.find(_scanGuid);
-        if (it_scan == m_activeScans.end())
+        scan = ensureScanLoaded_nolock(_scanGuid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << _scanGuid << Logger::endl;
             return false;
-        }
-        else
-        {
-            scan = it_scan->second;
         }
     }
 
@@ -384,15 +385,11 @@ bool TlScanOverseer::clipScan(tls::ScanGuid _scanGuid, const TransformationModul
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
 
-        auto it_scan = m_activeScans.find(_scanGuid);
-        if (it_scan == m_activeScans.end())
+        scan = ensureScanLoaded_nolock(_scanGuid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << _scanGuid << Logger::endl;
             return false;
-        }
-        else
-        {
-            scan = it_scan->second;
         }
     }
 
@@ -406,15 +403,11 @@ bool TlScanOverseer::computeOutlierStats(tls::ScanGuid _scanGuid, const Transfor
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
 
-        auto it_scan = m_activeScans.find(_scanGuid);
-        if (it_scan == m_activeScans.end())
+        scan = ensureScanLoaded_nolock(_scanGuid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << _scanGuid << Logger::endl;
             return false;
-        }
-        else
-        {
-            scan = it_scan->second;
         }
     }
 
@@ -427,15 +420,11 @@ bool TlScanOverseer::filterOutliersAndWrite(tls::ScanGuid _scanGuid, const Trans
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
 
-        auto it_scan = m_activeScans.find(_scanGuid);
-        if (it_scan == m_activeScans.end())
+        scan = ensureScanLoaded_nolock(_scanGuid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << _scanGuid << Logger::endl;
             return false;
-        }
-        else
-        {
-            scan = it_scan->second;
         }
     }
 
@@ -448,13 +437,12 @@ bool TlScanOverseer::filterAndWrite(tls::ScanGuid scanGuid, const Transformation
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
 
-        auto it_scan = m_activeScans.find(scanGuid);
-        if (it_scan == m_activeScans.end())
+        scan = ensureScanLoaded_nolock(scanGuid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << scanGuid << Logger::endl;
             return false;
         }
-        scan = it_scan->second;
     }
 
     return scan->filterAndWrite(modelMat, clippingAssembly, colorimetricSettings, polygonalSelectorSettings, mode, outScan, keptPoints, progress);
@@ -466,13 +454,12 @@ bool TlScanOverseer::balanceColorsAndWrite(tls::ScanGuid scanGuid, const Transfo
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
 
-        auto it_scan = m_activeScans.find(scanGuid);
-        if (it_scan == m_activeScans.end())
+        scan = ensureScanLoaded_nolock(scanGuid);
+        if (scan == nullptr)
         {
             Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << scanGuid << Logger::endl;
             return false;
         }
-        scan = it_scan->second;
     }
 
     return scan->balanceColorsAndWrite(modelMat, clippingAssembly, kMin, kMax, trimPercent, sharpnessBlend, applyOnIntensity, applyOnRgb, externalPointsProvider, outScan, modifiedPoints, progress);
@@ -492,6 +479,60 @@ void TlScanOverseer::collectPointsInGeometricBox(const GeometricBox& box, const 
         pair.scan.setComputeTransfo(pair.transfo.getCenter(), pair.transfo.getOrientation());
         pair.scan.collectPointsInGeometricBox(box, pair.transfo, localAssembly, result);
     }
+}
+
+EmbeddedScan* TlScanOverseer::ensureScanLoaded_nolock(const tls::ScanGuid& scanGuid)
+{
+    auto itActive = m_activeScans.find(scanGuid);
+    if (itActive != m_activeScans.end())
+        return itActive->second;
+
+    auto itPath = m_knownScanPaths.find(scanGuid);
+    if (itPath == m_knownScanPaths.end())
+        return nullptr;
+
+    EmbeddedScan* loadedScan = new EmbeddedScan(itPath->second);
+    xg::Guid nullGuid;
+    if (loadedScan->getGuid() == nullGuid)
+    {
+        Logger::log(IOLog) << "Error: failed to reload scan from registry, UUID = " << scanGuid
+            << " path = " << itPath->second << Logger::endl;
+        delete loadedScan;
+        return nullptr;
+    }
+
+    if (loadedScan->getGuid() != scanGuid)
+    {
+        Logger::log(IOLog) << "Error: scan GUID mismatch while reloading. Expected = "
+            << scanGuid << ", actual = " << loadedScan->getGuid()
+            << ", path = " << itPath->second << Logger::endl;
+        delete loadedScan;
+        return nullptr;
+    }
+
+    m_activeScans.insert({ scanGuid, loadedScan });
+    m_knownScanPaths.insert_or_assign(scanGuid, loadedScan->getPath());
+    return loadedScan;
+}
+
+bool TlScanOverseer::resolveScanPath_nolock(const tls::ScanGuid& scanGuid, std::filesystem::path& scanPath)
+{
+    auto itActive = m_activeScans.find(scanGuid);
+    if (itActive != m_activeScans.end())
+    {
+        scanPath = itActive->second->getPath();
+        m_knownScanPaths.insert_or_assign(scanGuid, scanPath);
+        return true;
+    }
+
+    auto itKnown = m_knownScanPaths.find(scanGuid);
+    if (itKnown != m_knownScanPaths.end())
+    {
+        scanPath = itKnown->second;
+        return true;
+    }
+
+    return false;
 }
 
 //tls::ScanGuid TlScanOverseer::clipNewScan(tls::ScanGuid _scanGuid, const glm::dmat4& _modelMat, const ClippingAssembly& _clippingAssembly, const std::filesystem::path& _outPath, uint64_t& pointsDeletedCount)


### PR DESCRIPTION
### Motivation
- Prevent excessive open file handles and memory growth when many scans are registered (e.g. large import batches) by avoiding keeping every `EmbeddedScan` loaded in memory.
- Ensure TLS file handles are properly closed when `EmbeddedScan` instances are destroyed to avoid file locking and removal failures.
- Make batch import/save behavior idempotent and less noisy by requesting a single save at the end of a successful batch and ignoring redundant concurrent save launches.
- Improve diagnostics for file open failures and context lifecycle logging for easier debugging.

### Description
- Introduced a persistent scan path registry `m_knownScanPaths` and added lazy-loading helpers `ensureScanLoaded_nolock` and `resolveScanPath_nolock` to `TlScanOverseer` and its header, and updated many APIs to use these helpers so scans are loaded on demand.
- Modified `getScanGuid` to register a scan path without forcing the `EmbeddedScan` to remain active in memory, and updated copy/free flows to keep `m_knownScanPaths` in sync when paths change or scans are deleted.
- Updated `EmbeddedScan` to log `errno` and `strerror` when opening fails and to explicitly `reset()` the point cloud and `close()` the TLS file in the destructor so handles are released reliably; added includes for `<cerrno>` and `<cstring>`.
- Improved `ContextImportScan` to aggregate import results (`importSuccessCount`, `importFailureCount`, `importDuplicateCount`), only request a single `StartSave` when at least one import succeeded, and avoid launching saves from error branches; added summary logging.
- Adjusted `FunctionManager::launchFunction` to ignore duplicate `saveProject` launches when a save context is already active and added more detailed abort/context lifecycle logging.

### Testing
- Project built successfully with the modified code base using the normal build pipeline (CMake + compiler used in CI).
- Ran automated unit tests and the project's test suite in CI; all tests passed.
- Executed manual import batch scenarios to validate: single save request is issued per successful batch and TLS file handles are released after `EmbeddedScan` destruction, preventing file removal failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc04aee0c832f855d1d1fa07c8363)