### PR TITLE
Add lightweight scan GUID lookup to avoid activating scans during project load

### DIFF
--- a/include/pointCloudEngine/PCE_core.h
+++ b/include/pointCloudEngine/PCE_core.h
@@ -28,6 +28,8 @@
 //************************************************
 
 bool tlGetScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
+// Lightweight GUID lookup from file header only (does not register the scan as active runtime resource).
+bool tlLookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
 
 // Force the specified Scan to free all its system resources.
 // All other scans housed on the same file are kept alive.

--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -188,6 +188,8 @@ public:
     static void setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingScans);
 
     // Management of the active resources
+    // Lightweight lookup: reads GUID from TLS header without registering a runtime-active scan.
+    bool lookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
     bool getScanGuid(std::filesystem::path filePath, tls::ScanGuid& scanGuid);
     bool getScanHeader(tls::ScanGuid scanGuid, tls::ScanHeader& scanHeader);
     bool getScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath);
@@ -430,12 +432,27 @@ private:
     static bool isCylinderCloseToPreviousCylinders(const std::vector<glm::dvec3>& cylinderCenters, const std::vector<glm::dvec3>& cylinderDirections, const std::vector<double>& cylinderRadii, const glm::dvec3& cCenter, const glm::dvec3& cDirection, const double& cRadius);
 
 private:
+    // Aggregated counters to diagnose massive GUID reload behaviors
+    // (large projects reopening hundreds/thousands of scans).
+    struct GuidLookupStats
+    {
+        uint64_t totalCalls = 0;
+        uint64_t successCount = 0;
+        uint64_t failedOpenOrInvalidGuid = 0;
+        uint64_t cacheHitCount = 0;
+        uint64_t insertedActiveCount = 0;
+        uint64_t activeScanPeak = 0;
+    };
+
+    void logGuidLookupStatsLocked(const char* reason) const;
+
     std::mutex m_activeMutex;
     std::atomic<bool> m_haltStream;
 
     // Accessible files and scans
     std::unordered_map<tls::ScanGuid, EmbeddedScan*> m_activeScans;
     static thread_local std::vector<WorkingScanInfo> s_workingScansTransfo;
+    GuidLookupStats m_guidLookupStats;
 
     // Inaccessible scans waiting to be deleted (some frames after their last rendering)
     std::list<EmbeddedScan*> m_scansToFree;

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -390,7 +390,22 @@ std::unordered_set<SafePtr<AGraphNode>> SaveLoadSystem::LoadFileObjects(Controll
                 continue;
 
             std::filesystem::path pcPath = findPointCloudPath(wPCNode, internalInfo, folder);
-            wPCNode->setTlsFilePath(pcPath, false, tls::ScanGuid(), false);
+            tls::ScanGuid resolvedGuid;
+            if (forceCopy)
+            {
+                // Keep the previous behavior for copy workflows:
+                // the scan must be registered as active to be used by tlCopyScanFile.
+                tlGetScanGuid(pcPath, resolvedGuid);
+            }
+            else
+            {
+                // Pass 2.1:
+                // For standard project reload, resolve GUID without activating
+                // a runtime scan resource (prevents massive active-scan buildup).
+                tlLookupScanGuid(pcPath, resolvedGuid);
+            }
+
+            wPCNode->setTlsFilePath(pcPath, false, resolvedGuid, false);
             if (wPCNode->getScanGuid() == tls::ScanGuid())
                 failedFileImport.insert(object);
             else if (forceCopy)

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -12,6 +12,7 @@
 #include "controller/ControllerContext.h"
 
 #include "utils/ProjectColor.hpp"
+#include "pointCloudEngine/PCE_core.h"
 
 #include "models/graph/TagNode.h"
 #include "models/graph/PointNode.h"
@@ -378,7 +379,19 @@ bool ImportPointCloudNode(const nlohmann::json& json, PointCloudNode& data)
     bool retVal = true;
 
     if (json.find(Key_Path) != json.end())
-        data.setTlsFilePath(Utils::from_utf8(json.at(Key_Path).get<std::string>()), false, tls::ScanGuid(), false);
+    {
+        const std::filesystem::path scanPath = Utils::from_utf8(json.at(Key_Path).get<std::string>());
+        tls::ScanGuid scanGuid;
+
+        // Pass 2.1:
+        // Use a lightweight GUID lookup during project reload to avoid
+        // registering hundreds of scans as active runtime resources.
+        // Runtime activation is handled later by rendering/streaming needs.
+        if (!tlLookupScanGuid(scanPath, scanGuid))
+            scanGuid = tls::ScanGuid();
+
+        data.setTlsFilePath(scanPath, false, scanGuid, false);
+    }
     else
     {
         IOLOG << "Scan Path read error" << LOGENDL;

--- a/src/pointCloudEngine/PCE_core.cpp
+++ b/src/pointCloudEngine/PCE_core.cpp
@@ -7,6 +7,11 @@ bool tlGetScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGui
     return TlScanOverseer::getInstance().getScanGuid(filePath, scanGuid);
 }
 
+bool tlLookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid)
+{
+    return TlScanOverseer::getInstance().lookupScanGuid(filePath, scanGuid);
+}
+
 void tlFreeScan(tls::ScanGuid scanGuid)
 {
     TlScanOverseer::getInstance().freeScan_async(scanGuid, false);

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -5,6 +5,8 @@
 #include "pointCloudEngine/PCE_graphics.h"
 #include "models/3d/Measures.h"
 #include "utils/Logger.h"
+#include "tls_core.h"
+#include <algorithm>
 #include <queue>
 #include <glm/gtx/quaternion.hpp>
 using namespace std::chrono;
@@ -24,6 +26,20 @@ TlScanOverseer::~TlScanOverseer()
     Logger::log(IOLog) << "Destroy TlScanOverseer" << Logger::endl;
 }
 
+void TlScanOverseer::logGuidLookupStatsLocked(const char* reason) const
+{
+    Logger::log(IOLog)
+        << "ScanGuidLookupStats [" << reason << "] "
+        << "calls=" << m_guidLookupStats.totalCalls
+        << ", success=" << m_guidLookupStats.successCount
+        << ", failed=" << m_guidLookupStats.failedOpenOrInvalidGuid
+        << ", cacheHit=" << m_guidLookupStats.cacheHitCount
+        << ", insertedActive=" << m_guidLookupStats.insertedActiveCount
+        << ", activeNow=" << m_activeScans.size()
+        << ", activePeak=" << m_guidLookupStats.activeScanPeak
+        << Logger::endl;
+}
+
 void TlScanOverseer::init()
 {
     Logger::log(IOLog) << "Init TlScanOverseer." << Logger::endl;
@@ -32,6 +48,7 @@ void TlScanOverseer::init()
 void TlScanOverseer::shutdown()
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    logGuidLookupStatsLocked("shutdown-begin");
         
     // Force the deletion of Scanresources even if the safe frame is not reached
     for (auto scan : m_scansToFree)
@@ -68,6 +85,11 @@ void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudIns
 
 bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid& _scanGuid)
 {
+    {
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        ++m_guidLookupStats.totalCalls;
+    }
+
     EmbeddedScan* newScan = new EmbeddedScan(_filePath);
     xg::Guid nullGuid;
 
@@ -76,6 +98,10 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
         _scanGuid = nullGuid;
         // No memory leak
         delete newScan; 
+
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        ++m_guidLookupStats.failedOpenOrInvalidGuid;
+        logGuidLookupStatsLocked("failed-open-or-invalid-guid");
         return false;
     }
 
@@ -86,13 +112,43 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
         _scanGuid = it_scan->second->getGuid();
         // No memory leak
         delete newScan;
+        ++m_guidLookupStats.successCount;
+        ++m_guidLookupStats.cacheHitCount;
+        if ((m_guidLookupStats.totalCalls % 100) == 0)
+            logGuidLookupStatsLocked("periodic");
         return true;
     }
 
     m_activeScans.insert({ newScan->getGuid(), newScan });
     _scanGuid = newScan->getGuid();
+    ++m_guidLookupStats.successCount;
+    ++m_guidLookupStats.insertedActiveCount;
+    m_guidLookupStats.activeScanPeak = std::max<uint64_t>(m_guidLookupStats.activeScanPeak, m_activeScans.size());
+    if ((m_guidLookupStats.totalCalls % 100) == 0)
+        logGuidLookupStatsLocked("periodic");
 
     return true;
+}
+
+bool TlScanOverseer::lookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid)
+{
+    scanGuid = tls::ScanGuid();
+
+    tls::ImageFile imageFile;
+    if (!imageFile.open(filePath, tls::usage::read))
+    {
+        return false;
+    }
+
+    // NOTE:
+    // This path is intentionally "header-only lookup":
+    // - no insertion in m_activeScans
+    // - no long-lived runtime scan object
+    // - deterministic handle release right after header read
+    scanGuid = imageFile.getPointCloudHeader(0).guid;
+    imageFile.close();
+
+    return scanGuid != tls::ScanGuid();
 }
 
 bool TlScanOverseer::getScanHeader(tls::ScanGuid scanGuid, tls::ScanHeader& info)


### PR DESCRIPTION
### Motivation
- Prevent creating large numbers of active runtime scan resources when reloading projects by offering a header-only GUID lookup that does not register the scan as active.

### Description
- Added a new API `tlLookupScanGuid` (declared in `PCE_core.h`, implemented in `PCE_core.cpp`) to perform a lightweight GUID lookup from the file header without inserting an active `EmbeddedScan`.
- Implemented `TlScanOverseer::lookupScanGuid` which reads the TLS header via `tls::ImageFile` and returns the scan GUID without creating/storing an `EmbeddedScan` instance.
- Added `GuidLookupStats` counters and periodic logging to diagnose excessive GUID lookup behavior, and added logging call in `shutdown` plus stats updates in `getScanGuid` for cache/insert/failure accounting.
- Updated project import/load paths to use the lightweight lookup where appropriate: `DataDeserializer::ImportPointCloudNode` and `SaveLoadSystem::LoadFileObjects` now call `tlLookupScanGuid` for standard reloads and keep the old `tlGetScanGuid` behavior for copy workflows that require an active runtime registration.
- Added missing include of `PCE_core.h` in `DataDeserializer.cpp` and minor housekeeping changes in headers.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2f73a8e4832f849da61e57ecf6da)