### PR TITLE
Add lightweight scan GUID lookup and deferred scan activation with path registry

### DIFF
--- a/include/pointCloudEngine/PCE_core.h
+++ b/include/pointCloudEngine/PCE_core.h
@@ -28,6 +28,8 @@
 //************************************************
 
 bool tlGetScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
+// Lightweight GUID lookup from file header only (does not register the scan as active runtime resource).
+bool tlLookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
 
 // Force the specified Scan to free all its system resources.
 // All other scans housed on the same file are kept alive.

--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -188,6 +188,13 @@ public:
     static void setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingScans);
 
     // Management of the active resources
+    // Register or update a known file path for a scan GUID.
+    // Used to decouple GUID resolution from runtime activation.
+    void registerScanPath(tls::ScanGuid scanGuid, const std::filesystem::path& scanPath);
+    bool getRegisteredScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath);
+
+    // Lightweight lookup: reads GUID from TLS header without registering a runtime-active scan.
+    bool lookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
     bool getScanGuid(std::filesystem::path filePath, tls::ScanGuid& scanGuid);
     bool getScanHeader(tls::ScanGuid scanGuid, tls::ScanHeader& scanHeader);
     bool getScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath);
@@ -428,14 +435,34 @@ private:
 
     std::vector<glm::dvec3> samplePoints(const int& numberOfPoints, const ClippingAssembly& clippingAssembly);
     static bool isCylinderCloseToPreviousCylinders(const std::vector<glm::dvec3>& cylinderCenters, const std::vector<glm::dvec3>& cylinderDirections, const std::vector<double>& cylinderRadii, const glm::dvec3& cCenter, const glm::dvec3& cDirection, const double& cRadius);
+    // Ensure a scan is available in m_activeScans.
+    // The caller must hold m_activeMutex.
+    bool ensureScanActive_locked(tls::ScanGuid scanGuid);
 
 private:
+    // Aggregated counters to diagnose massive GUID reload behaviors
+    // (large projects reopening hundreds/thousands of scans).
+    struct GuidLookupStats
+    {
+        uint64_t totalCalls = 0;
+        uint64_t successCount = 0;
+        uint64_t failedOpenOrInvalidGuid = 0;
+        uint64_t cacheHitCount = 0;
+        uint64_t insertedActiveCount = 0;
+        uint64_t activeScanPeak = 0;
+    };
+
+    void logGuidLookupStatsLocked(const char* reason) const;
+
     std::mutex m_activeMutex;
     std::atomic<bool> m_haltStream;
 
     // Accessible files and scans
     std::unordered_map<tls::ScanGuid, EmbeddedScan*> m_activeScans;
+    // Persistent GUID->path knowledge, independent from currently active runtime scans.
+    std::unordered_map<tls::ScanGuid, std::filesystem::path> m_scanPathByGuid;
     static thread_local std::vector<WorkingScanInfo> s_workingScansTransfo;
+    GuidLookupStats m_guidLookupStats;
 
     // Inaccessible scans waiting to be deleted (some frames after their last rendering)
     std::list<EmbeddedScan*> m_scansToFree;

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -390,7 +390,22 @@ std::unordered_set<SafePtr<AGraphNode>> SaveLoadSystem::LoadFileObjects(Controll
                 continue;
 
             std::filesystem::path pcPath = findPointCloudPath(wPCNode, internalInfo, folder);
-            wPCNode->setTlsFilePath(pcPath, false, tls::ScanGuid(), false);
+            tls::ScanGuid resolvedGuid;
+            if (forceCopy)
+            {
+                // Keep the previous behavior for copy workflows:
+                // the scan must be registered as active to be used by tlCopyScanFile.
+                tlGetScanGuid(pcPath, resolvedGuid);
+            }
+            else
+            {
+                // Pass 2.1:
+                // For standard project reload, resolve GUID without activating
+                // a runtime scan resource (prevents massive active-scan buildup).
+                tlLookupScanGuid(pcPath, resolvedGuid);
+            }
+
+            wPCNode->setTlsFilePath(pcPath, false, resolvedGuid, false);
             if (wPCNode->getScanGuid() == tls::ScanGuid())
                 failedFileImport.insert(object);
             else if (forceCopy)

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -12,6 +12,7 @@
 #include "controller/ControllerContext.h"
 
 #include "utils/ProjectColor.hpp"
+#include "pointCloudEngine/PCE_core.h"
 
 #include "models/graph/TagNode.h"
 #include "models/graph/PointNode.h"
@@ -378,7 +379,19 @@ bool ImportPointCloudNode(const nlohmann::json& json, PointCloudNode& data)
     bool retVal = true;
 
     if (json.find(Key_Path) != json.end())
-        data.setTlsFilePath(Utils::from_utf8(json.at(Key_Path).get<std::string>()), false, tls::ScanGuid(), false);
+    {
+        const std::filesystem::path scanPath = Utils::from_utf8(json.at(Key_Path).get<std::string>());
+        tls::ScanGuid scanGuid;
+
+        // Pass 2.1:
+        // Use a lightweight GUID lookup during project reload to avoid
+        // registering hundreds of scans as active runtime resources.
+        // Runtime activation is handled later by rendering/streaming needs.
+        if (!tlLookupScanGuid(scanPath, scanGuid))
+            scanGuid = tls::ScanGuid();
+
+        data.setTlsFilePath(scanPath, false, scanGuid, false);
+    }
     else
     {
         IOLOG << "Scan Path read error" << LOGENDL;

--- a/src/models/graph/PointCloudNode.cpp
+++ b/src/models/graph/PointCloudNode.cpp
@@ -71,8 +71,13 @@ void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool 
 std::filesystem::path PointCloudNode::getTlsFilePath() const
 {
     std::filesystem::path file_path;
-    tlGetCurrentScanPath(m_scanGuid, file_path);
-    return file_path;
+    if (tlGetCurrentScanPath(m_scanGuid, file_path))
+        return file_path;
+
+    // Pass 2.2.C:
+    // Keep serialization robust when runtime scan activation is deferred.
+    // backup_file_path_ is populated during load/import setTlsFilePath calls.
+    return backup_file_path_;
 }
 
 void PointCloudNode::setManipulable(bool is_manipulable)

--- a/src/pointCloudEngine/PCE_core.cpp
+++ b/src/pointCloudEngine/PCE_core.cpp
@@ -7,6 +7,11 @@ bool tlGetScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGui
     return TlScanOverseer::getInstance().getScanGuid(filePath, scanGuid);
 }
 
+bool tlLookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid)
+{
+    return TlScanOverseer::getInstance().lookupScanGuid(filePath, scanGuid);
+}
+
 void tlFreeScan(tls::ScanGuid scanGuid)
 {
     TlScanOverseer::getInstance().freeScan_async(scanGuid, false);

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -5,6 +5,8 @@
 #include "pointCloudEngine/PCE_graphics.h"
 #include "models/3d/Measures.h"
 #include "utils/Logger.h"
+#include "tls_core.h"
+#include <algorithm>
 #include <queue>
 #include <glm/gtx/quaternion.hpp>
 using namespace std::chrono;
@@ -24,6 +26,20 @@ TlScanOverseer::~TlScanOverseer()
     Logger::log(IOLog) << "Destroy TlScanOverseer" << Logger::endl;
 }
 
+void TlScanOverseer::logGuidLookupStatsLocked(const char* reason) const
+{
+    Logger::log(IOLog)
+        << "ScanGuidLookupStats [" << reason << "] "
+        << "calls=" << m_guidLookupStats.totalCalls
+        << ", success=" << m_guidLookupStats.successCount
+        << ", failed=" << m_guidLookupStats.failedOpenOrInvalidGuid
+        << ", cacheHit=" << m_guidLookupStats.cacheHitCount
+        << ", insertedActive=" << m_guidLookupStats.insertedActiveCount
+        << ", activeNow=" << m_activeScans.size()
+        << ", activePeak=" << m_guidLookupStats.activeScanPeak
+        << Logger::endl;
+}
+
 void TlScanOverseer::init()
 {
     Logger::log(IOLog) << "Init TlScanOverseer." << Logger::endl;
@@ -32,6 +48,7 @@ void TlScanOverseer::init()
 void TlScanOverseer::shutdown()
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    logGuidLookupStatsLocked("shutdown-begin");
         
     // Force the deletion of Scanresources even if the safe frame is not reached
     for (auto scan : m_scansToFree)
@@ -45,6 +62,7 @@ void TlScanOverseer::shutdown()
         delete (scan.second);
     }
     m_activeScans.clear();
+    m_scanPathByGuid.clear();
 }
 
 void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingTransfo)
@@ -55,6 +73,10 @@ void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudIns
     // Else find the working scans instance in the active scans
     for (const tls::PointCloudInstance& guid_transfo : workingTransfo)
     {
+        // Pass 2.2.B:
+        // Ensure runtime activation on demand from the registered GUID->path map.
+        instance.ensureScanActive_locked(guid_transfo.header.guid);
+
         auto it_scan = instance.m_activeScans.find(guid_transfo.header.guid);
         if (it_scan == instance.m_activeScans.end())
         {
@@ -66,8 +88,57 @@ void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudIns
     }
 }
 
+bool TlScanOverseer::ensureScanActive_locked(tls::ScanGuid scanGuid)
+{
+    if (scanGuid == tls::ScanGuid())
+        return false;
+
+    if (m_activeScans.find(scanGuid) != m_activeScans.end())
+        return true;
+
+    auto itPath = m_scanPathByGuid.find(scanGuid);
+    if (itPath == m_scanPathByGuid.end())
+        return false;
+
+    EmbeddedScan* newScan = new EmbeddedScan(itPath->second);
+    if (newScan->getGuid() != scanGuid)
+    {
+        delete newScan;
+        return false;
+    }
+
+    m_activeScans.insert({ scanGuid, newScan });
+    ++m_guidLookupStats.insertedActiveCount;
+    m_guidLookupStats.activeScanPeak = std::max<uint64_t>(m_guidLookupStats.activeScanPeak, m_activeScans.size());
+    return true;
+}
+
+void TlScanOverseer::registerScanPath(tls::ScanGuid scanGuid, const std::filesystem::path& scanPath)
+{
+    if (scanGuid == tls::ScanGuid() || scanPath.empty())
+        return;
+
+    std::lock_guard<std::mutex> lock(m_activeMutex);
+    m_scanPathByGuid.insert_or_assign(scanGuid, scanPath);
+}
+
+bool TlScanOverseer::getRegisteredScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath)
+{
+    std::lock_guard<std::mutex> lock(m_activeMutex);
+    auto it = m_scanPathByGuid.find(scanGuid);
+    if (it == m_scanPathByGuid.end())
+        return false;
+    scanPath = it->second;
+    return true;
+}
+
 bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid& _scanGuid)
 {
+    {
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        ++m_guidLookupStats.totalCalls;
+    }
+
     EmbeddedScan* newScan = new EmbeddedScan(_filePath);
     xg::Guid nullGuid;
 
@@ -76,6 +147,10 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
         _scanGuid = nullGuid;
         // No memory leak
         delete newScan; 
+
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        ++m_guidLookupStats.failedOpenOrInvalidGuid;
+        logGuidLookupStatsLocked("failed-open-or-invalid-guid");
         return false;
     }
 
@@ -84,20 +159,60 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     if (it_scan != m_activeScans.end())
     {
         _scanGuid = it_scan->second->getGuid();
+        // Keep path registry in sync even on cache hits.
+        m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
         // No memory leak
         delete newScan;
+        ++m_guidLookupStats.successCount;
+        ++m_guidLookupStats.cacheHitCount;
+        if ((m_guidLookupStats.totalCalls % 100) == 0)
+            logGuidLookupStatsLocked("periodic");
         return true;
     }
 
     m_activeScans.insert({ newScan->getGuid(), newScan });
     _scanGuid = newScan->getGuid();
+    m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
+    ++m_guidLookupStats.successCount;
+    ++m_guidLookupStats.insertedActiveCount;
+    m_guidLookupStats.activeScanPeak = std::max<uint64_t>(m_guidLookupStats.activeScanPeak, m_activeScans.size());
+    if ((m_guidLookupStats.totalCalls % 100) == 0)
+        logGuidLookupStatsLocked("periodic");
 
+    return true;
+}
+
+bool TlScanOverseer::lookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid)
+{
+    scanGuid = tls::ScanGuid();
+
+    tls::ImageFile imageFile;
+    if (!imageFile.open(filePath, tls::usage::read))
+    {
+        return false;
+    }
+
+    // NOTE:
+    // This path is intentionally "header-only lookup":
+    // - no insertion in m_activeScans
+    // - no long-lived runtime scan object
+    // - deterministic handle release right after header read
+    scanGuid = imageFile.getPointCloudHeader(0).guid;
+    imageFile.close();
+
+    if (scanGuid == tls::ScanGuid())
+        return false;
+
+    // Pass 2.2.A:
+    // Persist GUID->path knowledge without forcing active runtime registration.
+    registerScanPath(scanGuid, filePath);
     return true;
 }
 
 bool TlScanOverseer::getScanHeader(tls::ScanGuid scanGuid, tls::ScanHeader& info)
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    ensureScanActive_locked(scanGuid);
 
     auto it_scan = m_activeScans.find(scanGuid);
     if (it_scan != m_activeScans.end())
@@ -122,11 +237,19 @@ bool TlScanOverseer::getScanPath(tls::ScanGuid scanGuid, std::filesystem::path& 
         scanPath = it_scan->second->getPath();
         return true;
     }
-    else
+
+    // Pass 2.2.C:
+    // Save/serialization paths must remain available even when scans are not
+    // currently active in runtime. Fall back to the persistent GUID->path map.
+    auto it_registered = m_scanPathByGuid.find(scanGuid);
+    if (it_registered != m_scanPathByGuid.end())
     {
-        Logger::log(IOLog) << "Info: try to get information of a Scan not present, UUID = " << scanGuid << Logger::endl;
-        return false;
+        scanPath = it_registered->second;
+        return true;
     }
+
+    Logger::log(IOLog) << "Info: try to get information of a Scan not present, UUID = " << scanGuid << Logger::endl;
+    return false;
 }
 
 bool  TlScanOverseer::isScanLeftTofree()
@@ -145,6 +268,10 @@ void TlScanOverseer::copyScanFile_async(const tls::ScanGuid& scanGuid, const std
 void TlScanOverseer::freeScan_async(tls::ScanGuid scanGuid, bool deletePhysicalFile)
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    // Pass 2.2.B:
+    // Deletion/free workflows may target a scan resolved by GUID/path registry
+    // but not yet active in runtime. Activate on demand before freeing.
+    ensureScanActive_locked(scanGuid);
 
     // Find the Scanfile
     auto it_scan = m_activeScans.find(scanGuid);
@@ -241,6 +368,7 @@ bool TlScanOverseer::doFileCopy(scanCopyInfo& copyInfo)
                 delete oldScan;
 
                 m_activeScans.insert({ copyInfo.guid, newScanFile });
+                m_scanPathByGuid.insert_or_assign(copyInfo.guid, copyInfo.path);
                 return true;
             }
             else
@@ -259,7 +387,11 @@ bool TlScanOverseer::doFileCopy(scanCopyInfo& copyInfo)
             std::filesystem::copy(old_path, copyInfo.path, options);
 
             if (copyInfo.savePath || copyInfo.removeSource)
+            {
                 oldScan->setPath(copyInfo.path);
+                std::lock_guard<std::mutex> lock(m_activeMutex);
+                m_scanPathByGuid.insert_or_assign(copyInfo.guid, copyInfo.path);
+            }
 
             if (copyInfo.removeSource)
                 std::filesystem::remove(old_path);
@@ -302,6 +434,7 @@ bool TlScanOverseer::getScanView(tls::ScanGuid _scanGuid, const TlProjectionInfo
     EmbeddedScan* scan;
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
+        ensureScanActive_locked(_scanGuid);
 
         auto it_scan = m_activeScans.find(_scanGuid);
         if (it_scan == m_activeScans.end())


### PR DESCRIPTION
### Motivation
- Avoid creating long-lived runtime `EmbeddedScan` objects during project reloads by introducing a header-only GUID lookup that does not register active scan resources.
- Persist GUID->path associations so serialization, copy/delete and lazy activation can operate even when scans are not currently active.
- Add simple diagnostics to observe excessive GUID lookup/activation behavior for large projects.

### Description
- Added `tlLookupScanGuid` declaration to `PCE_core.h` and implementation in `PCE_core.cpp` delegating to `TlScanOverseer::lookupScanGuid`.
- Extended `TlScanOverseer` with a persistent `m_scanPathByGuid` map, `registerScanPath`, `getRegisteredScanPath`, `lookupScanGuid`, `ensureScanActive_locked`, and `GuidLookupStats` with `logGuidLookupStatsLocked` to collect and emit lookup statistics.
- Adjusted `getScanGuid`, `getScanHeader`, `getScanPath`, `freeScan_async`, `setWorkingScansTransfo`, and copy logic to consult the new registry and perform on-demand activation of `EmbeddedScan` objects when needed.
- Updated serialization/loading code to use header-only lookup: `DataDeserializer::ImportPointCloudNode` and `SaveLoadSystem::LoadFileObjects` now call `tlLookupScanGuid` for normal project loads while keeping previous `tlGetScanGuid` behavior for `forceCopy` workflows.
- Made `PointCloudNode::getTlsFilePath` robust to deferred activation by returning the stored `backup_file_path_` when the runtime path is not available.
- Ensured copy operations update the GUID->path registry when destination is saved or replaces an existing scan.

### Testing
- Performed a full project build (`CMake`/`make`) to validate compilation after changes and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2f73a8e4832f849da61e57ecf6da)