### PR TITLE
Add lightweight TLS GUID lookup and path registry; cap active scans to avoid mass activation during project load

### DIFF
--- a/include/pointCloudEngine/PCE_core.h
+++ b/include/pointCloudEngine/PCE_core.h
@@ -28,6 +28,8 @@
 //************************************************
 
 bool tlGetScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
+// Lightweight GUID lookup from file header only (does not register the scan as active runtime resource).
+bool tlLookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
 
 // Force the specified Scan to free all its system resources.
 // All other scans housed on the same file are kept alive.

--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -188,6 +188,13 @@ public:
     static void setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingScans);
 
     // Management of the active resources
+    // Register or update a known file path for a scan GUID.
+    // Used to decouple GUID resolution from runtime activation.
+    void registerScanPath(tls::ScanGuid scanGuid, const std::filesystem::path& scanPath);
+    bool getRegisteredScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath);
+
+    // Lightweight lookup: reads GUID from TLS header without registering a runtime-active scan.
+    bool lookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid);
     bool getScanGuid(std::filesystem::path filePath, tls::ScanGuid& scanGuid);
     bool getScanHeader(tls::ScanGuid scanGuid, tls::ScanHeader& scanHeader);
     bool getScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath);
@@ -428,14 +435,36 @@ private:
 
     std::vector<glm::dvec3> samplePoints(const int& numberOfPoints, const ClippingAssembly& clippingAssembly);
     static bool isCylinderCloseToPreviousCylinders(const std::vector<glm::dvec3>& cylinderCenters, const std::vector<glm::dvec3>& cylinderDirections, const std::vector<double>& cylinderRadii, const glm::dvec3& cCenter, const glm::dvec3& cDirection, const double& cRadius);
+    // Ensure a scan is available in m_activeScans.
+    // The caller must hold m_activeMutex.
+    bool ensureScanActive_locked(tls::ScanGuid scanGuid);
+    // Evict deletable active scans until size <= targetMax (excluding preserveGuid).
+    void trimActiveScans_locked(size_t targetMax, tls::ScanGuid preserveGuid);
 
 private:
+    // Aggregated counters to diagnose massive GUID reload behaviors
+    // (large projects reopening hundreds/thousands of scans).
+    struct GuidLookupStats
+    {
+        uint64_t totalCalls = 0;
+        uint64_t successCount = 0;
+        uint64_t failedOpenOrInvalidGuid = 0;
+        uint64_t cacheHitCount = 0;
+        uint64_t insertedActiveCount = 0;
+        uint64_t activeScanPeak = 0;
+    };
+
+    void logGuidLookupStatsLocked(const char* reason) const;
+
     std::mutex m_activeMutex;
     std::atomic<bool> m_haltStream;
 
     // Accessible files and scans
     std::unordered_map<tls::ScanGuid, EmbeddedScan*> m_activeScans;
+    // Persistent GUID->path knowledge, independent from currently active runtime scans.
+    std::unordered_map<tls::ScanGuid, std::filesystem::path> m_scanPathByGuid;
     static thread_local std::vector<WorkingScanInfo> s_workingScansTransfo;
+    GuidLookupStats m_guidLookupStats;
 
     // Inaccessible scans waiting to be deleted (some frames after their last rendering)
     std::list<EmbeddedScan*> m_scansToFree;

--- a/src/io/SaveLoadSystem.cpp
+++ b/src/io/SaveLoadSystem.cpp
@@ -390,7 +390,22 @@ std::unordered_set<SafePtr<AGraphNode>> SaveLoadSystem::LoadFileObjects(Controll
                 continue;
 
             std::filesystem::path pcPath = findPointCloudPath(wPCNode, internalInfo, folder);
-            wPCNode->setTlsFilePath(pcPath, false, tls::ScanGuid(), false);
+            tls::ScanGuid resolvedGuid;
+            if (forceCopy)
+            {
+                // Keep the previous behavior for copy workflows:
+                // the scan must be registered as active to be used by tlCopyScanFile.
+                tlGetScanGuid(pcPath, resolvedGuid);
+            }
+            else
+            {
+                // Pass 2.1:
+                // For standard project reload, resolve GUID without activating
+                // a runtime scan resource (prevents massive active-scan buildup).
+                tlLookupScanGuid(pcPath, resolvedGuid);
+            }
+
+            wPCNode->setTlsFilePath(pcPath, false, resolvedGuid, false);
             if (wPCNode->getScanGuid() == tls::ScanGuid())
                 failedFileImport.insert(object);
             else if (forceCopy)
@@ -1301,7 +1316,9 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
     ControllerContext& context = controller.getContext();
 
     tls::ScanGuid scanGuid;
-    if (tlGetScanGuid(filePath, scanGuid) == false)
+    // Block B (import/drag&drop):
+    // Resolve GUID without creating a long-lived active scan upfront.
+    if (tlLookupScanGuid(filePath, scanGuid) == false)
     {
         IOLOG << "Error: " << filePath << " is not a valid tls file." << LOGENDL;
         errorCode = ErrorCode::Failed_To_Open;
@@ -1321,40 +1338,37 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
     std::filesystem::path filename(filePath.filename());
     std::filesystem::path dst_path = context.cgetProjectInternalInfo().getPointCloudFolderPath(is_object) / filename;
     const bool fileAlreadyInProjectStorage = arePathsEquivalent(filePath, dst_path);
+    std::filesystem::path effectivePath = filePath;
+
     if (!fileAlreadyInProjectStorage)
     {
-        // Copy to project folder and force destination update to avoid keeping a source path
-        // when a file with the same name already exists in destination.
-        tlCopyScanFile(scanGuid, dst_path, true, true, false);
+        // Block B:
+        // Copy physically without requiring active runtime registration in TlScanOverseer.
+        // This avoids reaching the ~507 active scan resource ceiling during batch imports.
+        std::error_code sameFileEc;
+        if (!std::filesystem::equivalent(filePath, dst_path, sameFileEc))
+        {
+            try
+            {
+                std::filesystem::copy(filePath, dst_path, std::filesystem::copy_options::overwrite_existing);
+            }
+            catch (const std::exception& e)
+            {
+                IOLOG << "Error: TLS import copy failed from [" << filePath << "] to [" << dst_path << "]: " << e.what() << LOGENDL;
+                errorCode = ErrorCode::Failed_Write_Permission;
+                return SafePtr<PointCloudNode>();
+            }
+        }
+        effectivePath = dst_path;
     }
     else
     {
         IOLOG << "INFO - TLS file already in project storage, skip physical copy: " << dst_path << LOGENDL;
+        effectivePath = filePath;
     }
 
-    // Ensure copy queue is processed and the active scan path points to project storage
-    // before exposing the node to delete workflows.
-    std::filesystem::path currentPath;
-    bool copiedToProjectPath = false;
-    constexpr int maxRetry = 100; // 100 * 50ms = 5s max wait
-    for (int i = 0; i < maxRetry; ++i)
-    {
-        TlScanOverseer::getInstance().resourceManagement_sync();
-        if (tlGetCurrentScanPath(scanGuid, currentPath) && arePathsEquivalent(currentPath, dst_path))
-        {
-            copiedToProjectPath = true;
-            break;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    }
-
-    if (!copiedToProjectPath)
-    {
-        IOLOG << "Error: TLS import copy to project path failed or timed out. Source [" << filePath
-            << "], destination [" << dst_path << "], current [" << currentPath << "]." << LOGENDL;
-        errorCode = ErrorCode::Failed_Write_Permission;
-        return SafePtr<PointCloudNode>();
-    }
+    // Register the authoritative path so lazy activation can resolve runtime access on demand.
+    TlScanOverseer::getInstance().registerScanPath(scanGuid, effectivePath);
 
     uint64_t nbScanBeforeImport = controller.getGraphManager().getNodesByTypes({ ElementType::Scan }).size();
     SafePtr<PointCloudNode> pc = make_safe<PointCloudNode>(is_object);
@@ -1370,7 +1384,7 @@ SafePtr<PointCloudNode> SaveLoadSystem::ImportNewTlsFile(const std::filesystem::
         wpc->setDefaultData(controller);
         if (!is_object)
             wpc->setManipulable(Config::isUnlockScanManipulation());
-        wpc->setTlsFilePath(dst_path, true, scanGuid);
+        wpc->setTlsFilePath(effectivePath, true, scanGuid);
         if (!is_object)
             wpc->setColor(Color32(rand() % 255, rand() % 255, rand() % 255, 255));
     }

--- a/src/io/imports/DataDeserializer.cpp
+++ b/src/io/imports/DataDeserializer.cpp
@@ -12,6 +12,7 @@
 #include "controller/ControllerContext.h"
 
 #include "utils/ProjectColor.hpp"
+#include "pointCloudEngine/PCE_core.h"
 
 #include "models/graph/TagNode.h"
 #include "models/graph/PointNode.h"
@@ -378,7 +379,19 @@ bool ImportPointCloudNode(const nlohmann::json& json, PointCloudNode& data)
     bool retVal = true;
 
     if (json.find(Key_Path) != json.end())
-        data.setTlsFilePath(Utils::from_utf8(json.at(Key_Path).get<std::string>()), false, tls::ScanGuid(), false);
+    {
+        const std::filesystem::path scanPath = Utils::from_utf8(json.at(Key_Path).get<std::string>());
+        tls::ScanGuid scanGuid;
+
+        // Pass 2.1:
+        // Use a lightweight GUID lookup during project reload to avoid
+        // registering hundreds of scans as active runtime resources.
+        // Runtime activation is handled later by rendering/streaming needs.
+        if (!tlLookupScanGuid(scanPath, scanGuid))
+            scanGuid = tls::ScanGuid();
+
+        data.setTlsFilePath(scanPath, false, scanGuid, false);
+    }
     else
     {
         IOLOG << "Scan Path read error" << LOGENDL;

--- a/src/models/graph/PointCloudNode.cpp
+++ b/src/models/graph/PointCloudNode.cpp
@@ -71,8 +71,13 @@ void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool 
 std::filesystem::path PointCloudNode::getTlsFilePath() const
 {
     std::filesystem::path file_path;
-    tlGetCurrentScanPath(m_scanGuid, file_path);
-    return file_path;
+    if (tlGetCurrentScanPath(m_scanGuid, file_path))
+        return file_path;
+
+    // Pass 2.2.C:
+    // Keep serialization robust when runtime scan activation is deferred.
+    // backup_file_path_ is populated during load/import setTlsFilePath calls.
+    return backup_file_path_;
 }
 
 void PointCloudNode::setManipulable(bool is_manipulable)

--- a/src/pointCloudEngine/PCE_core.cpp
+++ b/src/pointCloudEngine/PCE_core.cpp
@@ -7,6 +7,11 @@ bool tlGetScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGui
     return TlScanOverseer::getInstance().getScanGuid(filePath, scanGuid);
 }
 
+bool tlLookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid)
+{
+    return TlScanOverseer::getInstance().lookupScanGuid(filePath, scanGuid);
+}
+
 void tlFreeScan(tls::ScanGuid scanGuid)
 {
     TlScanOverseer::getInstance().freeScan_async(scanGuid, false);

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -5,6 +5,9 @@
 #include "pointCloudEngine/PCE_graphics.h"
 #include "models/3d/Measures.h"
 #include "utils/Logger.h"
+#include "tls_core.h"
+#include <cstdio>
+#include <algorithm>
 #include <queue>
 #include <glm/gtx/quaternion.hpp>
 using namespace std::chrono;
@@ -15,6 +18,15 @@ constexpr double M_PI = 3.14159265358979323846;  /* pi */
 
 thread_local std::vector<TlScanOverseer::WorkingScanInfo> TlScanOverseer::s_workingScansTransfo = {};
 
+namespace
+{
+#ifdef _WIN32
+constexpr size_t kMaxActiveScanBudget = 1536;
+#else
+constexpr size_t kMaxActiveScanBudget = 768;
+#endif
+}
+
 TlScanOverseer::TlScanOverseer()
     : m_haltStream(false)
 {}
@@ -24,14 +36,38 @@ TlScanOverseer::~TlScanOverseer()
     Logger::log(IOLog) << "Destroy TlScanOverseer" << Logger::endl;
 }
 
+void TlScanOverseer::logGuidLookupStatsLocked(const char* reason) const
+{
+    Logger::log(IOLog)
+        << "ScanGuidLookupStats [" << reason << "] "
+        << "calls=" << m_guidLookupStats.totalCalls
+        << ", success=" << m_guidLookupStats.successCount
+        << ", failed=" << m_guidLookupStats.failedOpenOrInvalidGuid
+        << ", cacheHit=" << m_guidLookupStats.cacheHitCount
+        << ", insertedActive=" << m_guidLookupStats.insertedActiveCount
+        << ", activeNow=" << m_activeScans.size()
+        << ", activePeak=" << m_guidLookupStats.activeScanPeak
+        << Logger::endl;
+}
+
 void TlScanOverseer::init()
 {
     Logger::log(IOLog) << "Init TlScanOverseer." << Logger::endl;
+#ifdef _WIN32
+    // Pass B2.1 (hotfix):
+    // Raise CRT stream limit to reduce "open TLS failed" saturation around ~507 scans
+    // during large import/render batches on Windows.
+    constexpr int kRequestedMaxStdio = 2048;
+    const int appliedMaxStdio = _setmaxstdio(kRequestedMaxStdio);
+    Logger::log(IOLog) << "Init TlScanOverseer: _setmaxstdio requested=" << kRequestedMaxStdio
+        << ", applied=" << appliedMaxStdio << Logger::endl;
+#endif
 }
 
 void TlScanOverseer::shutdown()
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    logGuidLookupStatsLocked("shutdown-begin");
         
     // Force the deletion of Scanresources even if the safe frame is not reached
     for (auto scan : m_scansToFree)
@@ -45,6 +81,7 @@ void TlScanOverseer::shutdown()
         delete (scan.second);
     }
     m_activeScans.clear();
+    m_scanPathByGuid.clear();
 }
 
 void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingTransfo)
@@ -55,6 +92,10 @@ void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudIns
     // Else find the working scans instance in the active scans
     for (const tls::PointCloudInstance& guid_transfo : workingTransfo)
     {
+        // Pass 2.2.B:
+        // Ensure runtime activation on demand from the registered GUID->path map.
+        instance.ensureScanActive_locked(guid_transfo.header.guid);
+
         auto it_scan = instance.m_activeScans.find(guid_transfo.header.guid);
         if (it_scan == instance.m_activeScans.end())
         {
@@ -66,8 +107,103 @@ void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudIns
     }
 }
 
+bool TlScanOverseer::ensureScanActive_locked(tls::ScanGuid scanGuid)
+{
+    if (scanGuid == tls::ScanGuid())
+        return false;
+
+    if (m_activeScans.find(scanGuid) != m_activeScans.end())
+        return true;
+
+    auto itPath = m_scanPathByGuid.find(scanGuid);
+    if (itPath == m_scanPathByGuid.end())
+        return false;
+
+    // Pass B2.2:
+    // Keep active runtime scans under a bounded budget by evicting deletable scans.
+    // This prevents unbounded growth during huge imports/navigation sessions.
+    if (m_activeScans.size() >= kMaxActiveScanBudget)
+    {
+        trimActiveScans_locked(kMaxActiveScanBudget - 1, scanGuid);
+    }
+    if (m_activeScans.size() >= kMaxActiveScanBudget)
+    {
+        static uint32_t s_budgetWarningCount = 0;
+        ++s_budgetWarningCount;
+        if ((s_budgetWarningCount % 50u) == 1u)
+        {
+            Logger::log(IOLog) << "Warning: active scan budget reached (" << m_activeScans.size()
+                << "/" << kMaxActiveScanBudget << "), cannot activate GUID=" << scanGuid
+                << " [occurrence=" << s_budgetWarningCount << "]" << Logger::endl;
+        }
+        return false;
+    }
+
+    EmbeddedScan* newScan = new EmbeddedScan(itPath->second);
+    if (newScan->getGuid() != scanGuid)
+    {
+        delete newScan;
+        return false;
+    }
+
+    m_activeScans.insert({ scanGuid, newScan });
+    ++m_guidLookupStats.insertedActiveCount;
+    m_guidLookupStats.activeScanPeak = std::max<uint64_t>(m_guidLookupStats.activeScanPeak, m_activeScans.size());
+    return true;
+}
+
+void TlScanOverseer::trimActiveScans_locked(size_t targetMax, tls::ScanGuid preserveGuid)
+{
+    if (m_activeScans.size() <= targetMax)
+        return;
+
+    for (auto it = m_activeScans.begin(); it != m_activeScans.end() && m_activeScans.size() > targetMax; )
+    {
+        if (it->first == preserveGuid || it->second == nullptr)
+        {
+            ++it;
+            continue;
+        }
+
+        EmbeddedScan* scan = it->second;
+        if (scan->canBeDeleted())
+        {
+            m_scansToFree.push_back(scan);
+            it = m_activeScans.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+void TlScanOverseer::registerScanPath(tls::ScanGuid scanGuid, const std::filesystem::path& scanPath)
+{
+    if (scanGuid == tls::ScanGuid() || scanPath.empty())
+        return;
+
+    std::lock_guard<std::mutex> lock(m_activeMutex);
+    m_scanPathByGuid.insert_or_assign(scanGuid, scanPath);
+}
+
+bool TlScanOverseer::getRegisteredScanPath(tls::ScanGuid scanGuid, std::filesystem::path& scanPath)
+{
+    std::lock_guard<std::mutex> lock(m_activeMutex);
+    auto it = m_scanPathByGuid.find(scanGuid);
+    if (it == m_scanPathByGuid.end())
+        return false;
+    scanPath = it->second;
+    return true;
+}
+
 bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid& _scanGuid)
 {
+    {
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        ++m_guidLookupStats.totalCalls;
+    }
+
     EmbeddedScan* newScan = new EmbeddedScan(_filePath);
     xg::Guid nullGuid;
 
@@ -76,6 +212,10 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
         _scanGuid = nullGuid;
         // No memory leak
         delete newScan; 
+
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        ++m_guidLookupStats.failedOpenOrInvalidGuid;
+        logGuidLookupStatsLocked("failed-open-or-invalid-guid");
         return false;
     }
 
@@ -84,20 +224,60 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     if (it_scan != m_activeScans.end())
     {
         _scanGuid = it_scan->second->getGuid();
+        // Keep path registry in sync even on cache hits.
+        m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
         // No memory leak
         delete newScan;
+        ++m_guidLookupStats.successCount;
+        ++m_guidLookupStats.cacheHitCount;
+        if ((m_guidLookupStats.totalCalls % 100) == 0)
+            logGuidLookupStatsLocked("periodic");
         return true;
     }
 
     m_activeScans.insert({ newScan->getGuid(), newScan });
     _scanGuid = newScan->getGuid();
+    m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
+    ++m_guidLookupStats.successCount;
+    ++m_guidLookupStats.insertedActiveCount;
+    m_guidLookupStats.activeScanPeak = std::max<uint64_t>(m_guidLookupStats.activeScanPeak, m_activeScans.size());
+    if ((m_guidLookupStats.totalCalls % 100) == 0)
+        logGuidLookupStatsLocked("periodic");
 
+    return true;
+}
+
+bool TlScanOverseer::lookupScanGuid(const std::filesystem::path& filePath, tls::ScanGuid& scanGuid)
+{
+    scanGuid = tls::ScanGuid();
+
+    tls::ImageFile imageFile;
+    if (!imageFile.open(filePath, tls::usage::read))
+    {
+        return false;
+    }
+
+    // NOTE:
+    // This path is intentionally "header-only lookup":
+    // - no insertion in m_activeScans
+    // - no long-lived runtime scan object
+    // - deterministic handle release right after header read
+    scanGuid = imageFile.getPointCloudHeader(0).guid;
+    imageFile.close();
+
+    if (scanGuid == tls::ScanGuid())
+        return false;
+
+    // Pass 2.2.A:
+    // Persist GUID->path knowledge without forcing active runtime registration.
+    registerScanPath(scanGuid, filePath);
     return true;
 }
 
 bool TlScanOverseer::getScanHeader(tls::ScanGuid scanGuid, tls::ScanHeader& info)
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    ensureScanActive_locked(scanGuid);
 
     auto it_scan = m_activeScans.find(scanGuid);
     if (it_scan != m_activeScans.end())
@@ -122,11 +302,19 @@ bool TlScanOverseer::getScanPath(tls::ScanGuid scanGuid, std::filesystem::path& 
         scanPath = it_scan->second->getPath();
         return true;
     }
-    else
+
+    // Pass 2.2.C:
+    // Save/serialization paths must remain available even when scans are not
+    // currently active in runtime. Fall back to the persistent GUID->path map.
+    auto it_registered = m_scanPathByGuid.find(scanGuid);
+    if (it_registered != m_scanPathByGuid.end())
     {
-        Logger::log(IOLog) << "Info: try to get information of a Scan not present, UUID = " << scanGuid << Logger::endl;
-        return false;
+        scanPath = it_registered->second;
+        return true;
     }
+
+    Logger::log(IOLog) << "Info: try to get information of a Scan not present, UUID = " << scanGuid << Logger::endl;
+    return false;
 }
 
 bool  TlScanOverseer::isScanLeftTofree()
@@ -145,6 +333,10 @@ void TlScanOverseer::copyScanFile_async(const tls::ScanGuid& scanGuid, const std
 void TlScanOverseer::freeScan_async(tls::ScanGuid scanGuid, bool deletePhysicalFile)
 {
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    // Pass 2.2.B:
+    // Deletion/free workflows may target a scan resolved by GUID/path registry
+    // but not yet active in runtime. Activate on demand before freeing.
+    ensureScanActive_locked(scanGuid);
 
     // Find the Scanfile
     auto it_scan = m_activeScans.find(scanGuid);
@@ -241,6 +433,7 @@ bool TlScanOverseer::doFileCopy(scanCopyInfo& copyInfo)
                 delete oldScan;
 
                 m_activeScans.insert({ copyInfo.guid, newScanFile });
+                m_scanPathByGuid.insert_or_assign(copyInfo.guid, copyInfo.path);
                 return true;
             }
             else
@@ -259,7 +452,11 @@ bool TlScanOverseer::doFileCopy(scanCopyInfo& copyInfo)
             std::filesystem::copy(old_path, copyInfo.path, options);
 
             if (copyInfo.savePath || copyInfo.removeSource)
+            {
                 oldScan->setPath(copyInfo.path);
+                std::lock_guard<std::mutex> lock(m_activeMutex);
+                m_scanPathByGuid.insert_or_assign(copyInfo.guid, copyInfo.path);
+            }
 
             if (copyInfo.removeSource)
                 std::filesystem::remove(old_path);
@@ -302,6 +499,7 @@ bool TlScanOverseer::getScanView(tls::ScanGuid _scanGuid, const TlProjectionInfo
     EmbeddedScan* scan;
     {
         std::lock_guard<std::mutex> lock(m_activeMutex);
+        ensureScanActive_locked(_scanGuid);
 
         auto it_scan = m_activeScans.find(_scanGuid);
         if (it_scan == m_activeScans.end())


### PR DESCRIPTION
### Motivation

- Avoid creating hundreds/thousands of long-lived runtime scan objects during project reload/import by providing a header-only GUID lookup and a GUID->path registry.
- Prevent exhaustion of OS/C runtime file descriptors on Windows during large batch imports by increasing CRT stdio limit and bounding active runtime scans.
- Make serialization and file-copy workflows robust when runtime activation is deferred so UI/model code can still access scan paths without forcing activation.

### Description

- Added a lightweight API `tlLookupScanGuid` in `PCE_core` that reads the TLS header only (uses `tls::ImageFile`) and does not register an active `EmbeddedScan` instance.
- Introduced a persistent GUID->path registry (`m_scanPathByGuid`) and new methods `registerScanPath` and `getRegisteredScanPath` in `TlScanOverseer` to decouple path resolution from runtime activation.
- Implemented on-demand activation helpers `ensureScanActive_locked` and `trimActiveScans_locked` and enforced an active-scan budget (`kMaxActiveScanBudget`) to evict deletable scans when the budget is reached.
- Added `lookupScanGuid` implementation, GUID lookup statistics (`GuidLookupStats`) and periodic logging to help diagnose excessive lookup traffic.
- On Windows, raised CRT `maxstdio` in `TlScanOverseer::init()` to reduce "open TLS failed" saturation during large batches.
- Updated import/load paths: `SaveLoadSystem`, `DataDeserializer`, and `PointCloudNode` now use `tlLookupScanGuid` and `registerScanPath` to avoid pre-creating many active scans; import copy uses direct `std::filesystem::copy` for header-only copy workflows and registers the effective path. `PointCloudNode::getTlsFilePath` now falls back to `backup_file_path_` when a runtime scan is not active.
- Kept existing copy/free APIs working by ensuring `freeScan_async` and rendering code will activate scans on-demand (via `ensureScanActive_locked`) when necessary and keep the registry in sync during file copy operations.

### Testing

- Ran the project's automated unit test suite and integration import/load tests in CI, which passed without regressions.
- Executed automated large-batch TLS import/integration tests (simulating many scans) to verify that imports complete without exhausting active scan resources and that GUIDs/paths remain resolvable; these tests passed.
- Verified Windows CI job reflects the `_setmaxstdio` change and that file-open saturation is reduced in the automated import scenario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2f73a8e4832f849da61e57ecf6da)