### PR TITLE
feat(scantra): add 'Disable Auto-Zoom on Block Adjustment' toggle

### DIFF
--- a/include/controller/Controller.h
+++ b/include/controller/Controller.h
@@ -82,6 +82,8 @@ public:
     void stopScantraInterface();
     void scantra_notify_project_created();
     void scantra_notify_project_opened();
+    void setScantraAutoZoomOnAdjustment(bool enabled);
+    bool getScantraAutoZoomOnAdjustment() const;
 
     uint32_t getNextUserId(ElementType type) const;
     std::vector<uint32_t> getMultipleUserId(ElementType type, int indexAmount) const;

--- a/include/controller/controls/ControlApplication.h
+++ b/include/controller/controls/ControlApplication.h
@@ -420,6 +420,20 @@ namespace control::application
     private:
         bool start_;
     };
+
+    // Toggles whether OpenScanTools auto-frames the scene after Scantra signals
+    // a finished block adjustment. When disabled, the user-controlled camera
+    // position is preserved across adjustments. The flag is also persisted
+    // application-wide via QSettings (see ToolBarImportScantra).
+    class SetScantraAutoZoomOnAdjustment : public AControl
+    {
+    public:
+        SetScantraAutoZoomOnAdjustment(bool enabled);
+        void doFunction(Controller& controller) override;
+        ControlType getType() const override;
+    private:
+        bool enabled_;
+    };
 }
 
 #endif // !CONTROLAPPLICATION_H_

--- a/include/controller/controls/IControl.h
+++ b/include/controller/controls/IControl.h
@@ -101,6 +101,7 @@ enum class ControlType
 	refreshScanLink,
 	importScantraModifications,
 	switchScantraConnexion,
+	setScantraAutoZoomOnAdjustment,
 	convertImage,
 
     // control::exportPC

--- a/include/gui/toolBars/ToolBarImportScantra.h
+++ b/include/gui/toolBars/ToolBarImportScantra.h
@@ -21,8 +21,14 @@ private:
 
 public slots:
 	void slotImportScantra();
+	void slotDisableAutoZoomToggled(bool checked);
 
 private:
+	// Reads the persisted "disable auto-zoom" preference from QSettings and
+	// pushes it to the controller so the ScantraInterface picks it up on
+	// startup, regardless of whether the user toggles the checkbox later.
+	void loadAutoZoomPreference();
+
 	Ui::ToolBarImportScantra m_ui;
     IDataDispatcher &m_dataDispatcher;
 	QString m_openPath;

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -201,6 +201,16 @@ void Controller::scantra_notify_project_opened()
     m_p->scantra_interface_.project_opened(proj_internal.getProjectFolderPath());
 }
 
+void Controller::setScantraAutoZoomOnAdjustment(bool enabled)
+{
+    m_p->scantra_interface_.setAutoZoomOnAdjustment(enabled);
+}
+
+bool Controller::getScantraAutoZoomOnAdjustment() const
+{
+    return m_p->scantra_interface_.getAutoZoomOnAdjustment();
+}
+
 uint32_t Controller::getNextUserId(ElementType type) const
 {
     return m_p->graphManager.getNextUserId({ type }, m_p->context.getIndexationMethod());

--- a/src/controller/controls/ControlApplication.cpp
+++ b/src/controller/controls/ControlApplication.cpp
@@ -1051,4 +1051,23 @@ namespace control::application
         return ControlType::switchScantraConnexion;
     }
 
+    /*
+    ** SetScantraAutoZoomOnAdjustment
+    */
+
+    SetScantraAutoZoomOnAdjustment::SetScantraAutoZoomOnAdjustment(bool enabled)
+        : enabled_(enabled)
+    {
+    }
+
+    void SetScantraAutoZoomOnAdjustment::doFunction(Controller& controller)
+    {
+        controller.setScantraAutoZoomOnAdjustment(enabled_);
+    }
+
+    ControlType SetScantraAutoZoomOnAdjustment::getType() const
+    {
+        return ControlType::setScantraAutoZoomOnAdjustment;
+    }
+
 }

--- a/src/gui/forms/toolbar_importScantra.ui
+++ b/src/gui/forms/toolbar_importScantra.ui
@@ -35,7 +35,7 @@
    <property name="verticalSpacing">
     <number>6</number>
    </property>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -56,6 +56,25 @@ The names of the scans must be the same between Scantra and OpenScanTools</strin
      </property>
      <property name="text">
       <string>Apply Scantra registration</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="disableAutoZoomCheckBox">
+     <property name="toolTip">
+      <string>When checked, OpenScanTools will NOT automatically zoom to the scene
+after Scantra finishes a block adjustment. Your current camera position
+and zoom level are preserved, which is useful when inspecting a specific
+detail across multiple adjustment iterations.
+
+When unchecked (default), the legacy behavior is used and the viewport
+is re-framed to the full scene after every adjustment.</string>
+     </property>
+     <property name="text">
+      <string>Disable Auto-Zoom on Block Adjustment</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/src/gui/toolBars/ToolBarImportScantra.cpp
+++ b/src/gui/toolBars/ToolBarImportScantra.cpp
@@ -9,6 +9,15 @@
 
 #include <QtWidgets/qfiledialog.h>
 #include <QtCore/qstandardpaths.h>
+#include <QtCore/qsettings.h>
+
+namespace {
+    // QSettings key for the application-wide "disable auto-zoom on Scantra
+    // block adjustment" preference. Stored under the same organization name
+    // OST already uses for window layout (see Gui.cpp). Default = false
+    // (i.e. auto-zoom remains ENABLED) to preserve legacy behavior.
+    constexpr const char* kDisableAutoZoomKey = "scantra/disableAutoZoomOnAdjustment";
+}
 
 ToolBarImportScantra::ToolBarImportScantra(IDataDispatcher &dataDispatcher, QWidget *parent, const float& guiScale)
 	: QWidget(parent)
@@ -20,9 +29,12 @@ ToolBarImportScantra::ToolBarImportScantra(IDataDispatcher &dataDispatcher, QWid
 	m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
 
 	connect(m_ui.importScanTraButton, &QPushButton::clicked, this, &ToolBarImportScantra::slotImportScantra);
+	connect(m_ui.disableAutoZoomCheckBox, &QCheckBox::toggled, this, &ToolBarImportScantra::slotDisableAutoZoomToggled);
 
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::projectLoaded);
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::projectPath);
+
+	loadAutoZoomPreference();
 }
 
 ToolBarImportScantra::~ToolBarImportScantra()
@@ -64,4 +76,27 @@ void ToolBarImportScantra::slotImportScantra()
 	m_openPath = qFilepath;
 
 	m_dataDispatcher.sendControl(new control::io::ImportScantraModifications(filePath));
+}
+
+void ToolBarImportScantra::slotDisableAutoZoomToggled(bool checked)
+{
+	// Persist the preference so it survives application restarts.
+	QSettings settings;
+	settings.setValue(kDisableAutoZoomKey, checked);
+
+	// Push the new value through the controller. Note: the checkbox semantics
+	// are the inverse of the underlying ScantraInterface flag ("auto zoom
+	// ENABLED"), so we negate here.
+	m_dataDispatcher.sendControl(new control::application::SetScantraAutoZoomOnAdjustment(!checked));
+}
+
+void ToolBarImportScantra::loadAutoZoomPreference()
+{
+	QSettings settings;
+	const bool disableAutoZoom = settings.value(kDisableAutoZoomKey, false).toBool();
+
+	QSignalBlocker blocker(m_ui.disableAutoZoomCheckBox);
+	m_ui.disableAutoZoomCheckBox->setChecked(disableAutoZoom);
+
+	m_dataDispatcher.sendControl(new control::application::SetScantraAutoZoomOnAdjustment(!disableAutoZoom));
 }

--- a/src/io/ScantraInterface.cpp
+++ b/src/io/ScantraInterface.cpp
@@ -644,8 +644,27 @@ void ScantraInterface::manageVisibility(int current_station, int total_station, 
             }
         }
         controller_.actualizeTreeView(tree_update);
-        controller_.getControlListener()->notifyUIControl(new control::viewport::AdjustZoomToScene(SafePtr<CameraNode>()));
+        if (auto_zoom_on_adjustment_.load())
+        {
+            controller_.getControlListener()->notifyUIControl(new control::viewport::AdjustZoomToScene(SafePtr<CameraNode>()));
+        }
+        else
+        {
+            Logger::log(LoggerMode::IOLog) << "Auto-zoom on Scantra block adjustment is disabled by user setting.\n" << Logger::endl;
+        }
     }
+}
+
+void ScantraInterface::setAutoZoomOnAdjustment(bool enabled)
+{
+    auto_zoom_on_adjustment_.store(enabled);
+    Logger::log(LoggerMode::IOLog) << "Scantra auto-zoom on block adjustment set to "
+        << (enabled ? "ENABLED" : "DISABLED") << ".\n" << Logger::endl;
+}
+
+bool ScantraInterface::getAutoZoomOnAdjustment() const
+{
+    return auto_zoom_on_adjustment_.load();
 }
 
 void ScantraInterface::changeGraphicSettings()

--- a/src/io/ScantraInterface.h
+++ b/src/io/ScantraInterface.h
@@ -11,6 +11,7 @@
 #include "glm/glm.hpp"
 #include "glm/gtc/quaternion.hpp"
 
+#include <atomic>
 #include <filesystem>
 #include <thread>
 #include <unordered_set>
@@ -32,6 +33,12 @@ public:
 
     void project_created(const std::filesystem::path& path, const std::wstring& name);
     void project_opened(const std::filesystem::path& path);
+
+    // Controls whether OpenScanTools automatically re-frames (zooms-to-scene)
+    // the viewport after Scantra signals a finished block adjustment.
+    // Default: true (legacy behavior).
+    void setAutoZoomOnAdjustment(bool enabled);
+    bool getAutoZoomOnAdjustment() const;
 
 private:
     void run();
@@ -93,6 +100,9 @@ private:
     std::vector<Registration> scans_registered_;
     std::unordered_set<SafePtr<AGraphNode>> scan_selection_;
     GraphManager& graph_;
+
+    // Feature flag: see setAutoZoomOnAdjustment().
+    std::atomic<bool> auto_zoom_on_adjustment_{ true };
 };
 
 #endif


### PR DESCRIPTION
This PR is written by AI (Claude Opus 4.7 thinking)
Sorry, I am no dev ~~and don't have a running build env to test the patch~~ :(
I hope it still helps to implement a Zoom toggle for Scantra.

EDIT: I managed to set up the build env and can at least confirm that the patch works :)


AI:
When Scantra signals a finished block adjustment via the shared-memory interprocess channel, OpenScanTools currently always re-frames the viewport by dispatching control::viewport::AdjustZoomToScene at the end of ScantraInterface::manageVisibility(). This is disruptive when a user is iterating on the registration of a specific area: every adjustment zooms them back out to the full scene.

This commit introduces a user-controlled toggle that disables that auto-zoom call without otherwise altering the registration pipeline:

- ScantraInterface gains an atomic flag auto_zoom_on_adjustment_ (default = true, i.e. legacy behavior) plus matching setAutoZoomOnAdjustment() / getAutoZoomOnAdjustment() accessors.
- The unconditional AdjustZoomToScene dispatch in manageVisibility() is now gated on that flag; when disabled, a one-line log entry is written instead.
- A new control::application::SetScantraAutoZoomOnAdjustment control carries the toggle from the UI thread to the controller, mirroring the existing SwitchScantraConnexion pattern.
- Controller exposes setScantraAutoZoomOnAdjustment() / getScantraAutoZoomOnAdjustment() wrappers around the ScantraInterface flag.
- ToolBarImportScantra gains a 'Disable Auto-Zoom on Block Adjustment' QCheckBox just below the existing 'Apply Scantra registration' button. The checked state is persisted application-wide via QSettings under the key 'scantra/disableAutoZoomOnAdjustment' and is re-applied on every startup.

Default behavior is unchanged for existing users: the checkbox is unchecked, auto-zoom remains enabled.

Closes: -