### PR TITLE
Expose filter execution mode in UI/messages for color-balance and outlier filters; stub in-place execution

### DIFF
--- a/include/controller/functionSystem/ContextColorBalanceFilter.h
+++ b/include/controller/functionSystem/ContextColorBalanceFilter.h
@@ -36,6 +36,7 @@ private:
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = false;
     bool m_warningModal = false;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 };
 
 #endif

--- a/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
+++ b/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
@@ -2,6 +2,7 @@
 #define CONTEXT_STATISTICAL_OUTLIER_FILTER_H
 
 #include "controller/functionSystem/AContext.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "models/graph/TransformationModule.h"
 #include "io/FileUtils.h"
 
@@ -34,6 +35,7 @@ private:
     FileType m_outputFileType = FileType::TLS;
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = true;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 };
 
 #endif

--- a/include/controller/messages/ColorBalanceFilterMessage.h
+++ b/include/controller/messages/ColorBalanceFilterMessage.h
@@ -3,6 +3,7 @@
 
 #include "controller/messages/IMessage.h"
 #include "io/FileUtils.h"
+#include "controller/messages/FilterExecutionMode.h"
 
 #include <string>
 
@@ -15,7 +16,7 @@ enum class ColorBalanceMode
 class ColorBalanceFilterMessage : public IMessage
 {
 public:
-    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
+    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, FilterExecutionMode executionModeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
     ~ColorBalanceFilterMessage() {}
 
     MessageType getType() const override;
@@ -26,6 +27,7 @@ public:
     double trimPercent;
     double sharpnessBlend;
     ColorBalanceMode mode;
+    FilterExecutionMode executionMode;
     bool applyOnIntensityAndRgb;
     FileType outputFileType;
     std::wstring outputFolder;

--- a/include/controller/messages/FilterExecutionMode.h
+++ b/include/controller/messages/FilterExecutionMode.h
@@ -1,0 +1,10 @@
+#ifndef FILTER_EXECUTION_MODE_H
+#define FILTER_EXECUTION_MODE_H
+
+enum class FilterExecutionMode
+{
+    ExportFilteredAreas,
+    ApplyOnCurrentProject
+};
+
+#endif

--- a/include/controller/messages/StatisticalOutlierFilterMessage.h
+++ b/include/controller/messages/StatisticalOutlierFilterMessage.h
@@ -3,6 +3,7 @@
 
 #include "controller/messages/IMessage.h"
 #include "io/FileUtils.h"
+#include "controller/messages/FilterExecutionMode.h"
 
 #include <string>
 
@@ -12,10 +13,11 @@ enum class OutlierFilterMode
     Global
 };
 
+
 class StatisticalOutlierFilterMessage : public IMessage
 {
 public:
-    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
+    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FilterExecutionMode executionMode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
     ~StatisticalOutlierFilterMessage() {}
 
     MessageType getType() const override;
@@ -26,6 +28,7 @@ public:
     int samplingPercent;
     double beta;
     OutlierFilterMode mode;
+    FilterExecutionMode executionMode;
     FileType outputFileType;
     std::wstring outputFolder;
     bool openFolderAfterExport;

--- a/include/gui/Dialog/DialogColorBalanceFilter.h
+++ b/include/gui/Dialog/DialogColorBalanceFilter.h
@@ -38,6 +38,7 @@ private:
 
     BalancePreset m_preset = BalancePreset::Medium;
     ColorBalanceMode m_mode = ColorBalanceMode::Separate;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 
     int m_kMin = 24;
     int m_kMax = 40;

--- a/include/gui/Dialog/DialogStatisticalOutlierFilter.h
+++ b/include/gui/Dialog/DialogStatisticalOutlierFilter.h
@@ -34,6 +34,7 @@ private:
 
     Ui::DialogStatisticalOutlierFilter m_ui;
     OutlierFilterMode m_mode = OutlierFilterMode::Separate;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
     OutlierPreset m_preset = OutlierPreset::Mid;
     int m_kNeighbors = 20;
     double m_nSigma = 1.0;

--- a/include/gui/texts/ContextTexts.hpp
+++ b/include/gui/texts/ContextTexts.hpp
@@ -106,6 +106,7 @@
 
 //ContextColorBalanceFilter
 #define TEXT_COLOR_BALANCE_FILTER_QUESTION QObject::tr("Warning: some points will be permanently modified.\nDepending on the size of the scans, the calculation time may be significant. We recommend that you first perform a test on a small clipped portion.\nDo you confirm?")
+#define TEXT_FILTER_IN_PLACE_NOT_IMPLEMENTED QObject::tr("Apply filter on current project is not available yet in this build. Please use Export filtered areas.")
 
 //ContextDeleteTags
 #define TEXT_DELETE_TAGS_QUESTION QObject::tr("Warning: some tags use this template. Deleting the template will also delete the related tags.\nDo you confirm?")

--- a/src/controller/functionSystem/ContextColorBalanceFilter.cpp
+++ b/src/controller/functionSystem/ContextColorBalanceFilter.cpp
@@ -139,6 +139,7 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_COLOR_BALANCE_FILTER_QUESTION));
@@ -154,6 +155,14 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
 ContextState ContextColorBalanceFilter::launch(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
+
+    // Passe 1: expose the in-place mode in UI/controller flow, but keep current export behavior unchanged.
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
+    {
+        controller.updateInfo(new GuiDataWarning(TEXT_FILTER_IN_PLACE_NOT_IMPLEMENTED));
+        m_state = ContextState::abort;
+        return m_state;
+    }
 
     if (!prepareOutputDirectory(controller, m_outputFolder))
     {

--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -126,6 +126,7 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_STAT_OUTLIER_FILTER_QUESTION));
@@ -142,6 +143,14 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
 ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
+
+    // Passe 1: expose the in-place mode in UI/controller flow, but keep current export behavior unchanged.
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
+    {
+        controller.updateInfo(new GuiDataWarning(TEXT_FILTER_IN_PLACE_NOT_IMPLEMENTED));
+        m_state = ContextState::abort;
+        return m_state;
+    }
 
     if (!prepareOutputDirectory(controller, m_outputFolder))
     {

--- a/src/controller/messages/ColorBalanceFilterMessage.cpp
+++ b/src/controller/messages/ColorBalanceFilterMessage.cpp
@@ -1,11 +1,12 @@
 #include "controller/messages/ColorBalanceFilterMessage.h"
 
-ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, FilterExecutionMode executionModeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
     : kMin(kMinValue)
     , kMax(kMaxValue)
     , trimPercent(trimPercentValue)
     , sharpnessBlend(sharpnessBlendValue)
     , mode(modeValue)
+    , executionMode(executionModeValue)
     , applyOnIntensityAndRgb(applyOnIntensityAndRgbValue)
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
@@ -19,5 +20,5 @@ IMessage::MessageType ColorBalanceFilterMessage::getType() const
 
 IMessage* ColorBalanceFilterMessage::copy() const
 {
-    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
+    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, executionMode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
 }

--- a/src/controller/messages/StatisticalOutlierFilterMessage.cpp
+++ b/src/controller/messages/StatisticalOutlierFilterMessage.cpp
@@ -1,11 +1,12 @@
 #include "controller/messages/StatisticalOutlierFilterMessage.h"
 
-StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FilterExecutionMode executionModeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
     : kNeighbors(kNeighborsValue)
     , nSigma(nSigmaValue)
     , samplingPercent(samplingPercentValue)
     , beta(betaValue)
     , mode(modeValue)
+    , executionMode(executionModeValue)
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
     , openFolderAfterExport(openFolderAfterExportValue)
@@ -18,5 +19,5 @@ IMessage::MessageType StatisticalOutlierFilterMessage::getType() const
 
 IMessage* StatisticalOutlierFilterMessage::copy() const
 {
-    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, outputFileType, outputFolder, openFolderAfterExport);
+    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, executionMode, outputFileType, outputFolder, openFolderAfterExport);
 }

--- a/src/gui/Dialog/DialogColorBalanceFilter.cpp
+++ b/src/gui/Dialog/DialogColorBalanceFilter.cpp
@@ -114,6 +114,16 @@ DialogColorBalanceFilter::DialogColorBalanceFilter(IDataDispatcher& dataDispatch
         m_mode = ColorBalanceMode::Global;
         applyPreset(m_preset);
     });
+    connect(m_ui.radioButton_exportFilteredAreas, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (checked)
+            m_executionMode = FilterExecutionMode::ExportFilteredAreas;
+    });
+    connect(m_ui.radioButton_applyOnCurrentProject, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (checked)
+            m_executionMode = FilterExecutionMode::ApplyOnCurrentProject;
+    });
     connect(m_ui.radioButton_balanceLight, &QRadioButton::toggled, this, [this](bool checked)
     {
         if (checked)
@@ -212,7 +222,7 @@ void DialogColorBalanceFilter::startBalancing()
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
     bool applyOnIntensityAndRgb = m_ui.checkBox_balanceIntensityRGB->isChecked();
 
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, m_executionMode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder)));
 
     hide();
 }
@@ -260,6 +270,8 @@ void DialogColorBalanceFilter::syncUiFromValues()
     const QSignalBlocker blockSharpnessSlider(m_ui.horizontalSlider_sharpness);
     const QSignalBlocker blockSharpnessSpin(m_ui.spinBox_sharpness);
     const QSignalBlocker blockFormat(m_ui.comboBox_file_format);
+    const QSignalBlocker blockExportMode(m_ui.radioButton_exportFilteredAreas);
+    const QSignalBlocker blockInPlaceMode(m_ui.radioButton_applyOnCurrentProject);
 
     m_ui.radioButton_balanceLight->setChecked(m_preset == BalancePreset::Light);
     m_ui.radioButton_balanceMedium->setChecked(m_preset == BalancePreset::Medium);
@@ -267,6 +279,9 @@ void DialogColorBalanceFilter::syncUiFromValues()
 
     m_ui.radioButton_separate->setChecked(m_mode == ColorBalanceMode::Separate);
     m_ui.radioButton_global->setChecked(m_mode == ColorBalanceMode::Global);
+
+    m_ui.radioButton_exportFilteredAreas->setChecked(m_executionMode == FilterExecutionMode::ExportFilteredAreas);
+    m_ui.radioButton_applyOnCurrentProject->setChecked(m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
 
     m_ui.spinBox_kMin->setValue(m_kMin);
     m_ui.spinBox_kMax->setValue(m_kMax);

--- a/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
+++ b/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
@@ -77,6 +77,16 @@ DialogStatisticalOutlierFilter::DialogStatisticalOutlierFilter(IDataDispatcher& 
         if (checked)
             m_mode = OutlierFilterMode::Global;
     });
+    connect(m_ui.radioButton_exportFilteredAreas, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (checked)
+            m_executionMode = FilterExecutionMode::ExportFilteredAreas;
+    });
+    connect(m_ui.radioButton_applyOnCurrentProject, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (checked)
+            m_executionMode = FilterExecutionMode::ApplyOnCurrentProject;
+    });
     connect(m_ui.radioButton_soLow, &QRadioButton::toggled, this, [this](bool checked)
     {
         if (checked)
@@ -156,7 +166,7 @@ void DialogStatisticalOutlierFilter::startFiltering()
     m_outputFileType = static_cast<FileType>(m_ui.comboBox_file_format->currentData().toInt());
 
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_executionMode, m_outputFileType, m_outputFolder, openFolder)));
 
     hide();
 }
@@ -216,10 +226,15 @@ void DialogStatisticalOutlierFilter::syncUiFromValues()
     const QSignalBlocker blockSampling(m_ui.spinBox_soSampling);
     const QSignalBlocker blockBeta(m_ui.doubleSpinBox_soBeta);
     const QSignalBlocker blockFormat(m_ui.comboBox_file_format);
+    const QSignalBlocker blockExportMode(m_ui.radioButton_exportFilteredAreas);
+    const QSignalBlocker blockInPlaceMode(m_ui.radioButton_applyOnCurrentProject);
 
     m_ui.radioButton_soLow->setChecked(m_preset == OutlierPreset::Low);
     m_ui.radioButton_soMid->setChecked(m_preset == OutlierPreset::Mid);
     m_ui.radioButton_soHigh->setChecked(m_preset == OutlierPreset::High);
+
+    m_ui.radioButton_exportFilteredAreas->setChecked(m_executionMode == FilterExecutionMode::ExportFilteredAreas);
+    m_ui.radioButton_applyOnCurrentProject->setChecked(m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
 
     m_ui.spinBox_kNeighbors->setValue(m_kNeighbors);
     m_ui.doubleSpinBox_nSigma->setValue(m_nSigma);

--- a/src/gui/forms/DialogColorBalanceFilter.ui
+++ b/src/gui/forms/DialogColorBalanceFilter.ui
@@ -215,6 +215,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_executionMode">
+     <property name="title">
+      <string>Filter execution</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_executionMode">
+      <item>
+       <widget class="QRadioButton" name="radioButton_exportFilteredAreas">
+        <property name="text">
+         <string>Export filtered areas</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButton_applyOnCurrentProject">
+        <property name="text">
+         <string>Apply filter on current project</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_folder">
      <item row="0" column="0">
       <widget class="QLabel" name="label_format">

--- a/src/gui/forms/DialogStatisticalOutlierFilter.ui
+++ b/src/gui/forms/DialogStatisticalOutlierFilter.ui
@@ -185,6 +185,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_executionMode">
+     <property name="title">
+      <string>Filter execution</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_executionMode">
+      <item>
+       <widget class="QRadioButton" name="radioButton_exportFilteredAreas">
+        <property name="text">
+         <string>Export filtered areas</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButton_applyOnCurrentProject">
+        <property name="text">
+         <string>Apply filter on current project</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_folder">
      <item row="0" column="0">
       <widget class="QLabel" name="label_format">


### PR DESCRIPTION
### Motivation

- Add an execution-mode control to filtering workflows so users can choose between exporting filtered areas or applying the filter in-place on the current project. 
- Provide a first-phase implementation that surfaces the option in the UI and message path while preserving the existing export behavior until in-place execution is implemented.

### Description

- Introduce a new enum `FilterExecutionMode` with values `ExportFilteredAreas` and `ApplyOnCurrentProject` in `controller/messages/FilterExecutionMode.h`.
- Extend `ColorBalanceFilterMessage` and `StatisticalOutlierFilterMessage` to carry a `FilterExecutionMode` value and update constructors and `copy()` implementations accordingly.
- Add execution-mode state to `DialogColorBalanceFilter` and `DialogStatisticalOutlierFilter`, add radio buttons in the dialog `.ui` files, handle toggles, sync UI state, and include the selected mode when sending control messages.
- Add `m_executionMode` members to `ContextColorBalanceFilter` and `ContextStatisticalOutlierFilter`, read execution mode from incoming messages, and in `launch()` detect `ApplyOnCurrentProject` to show a warning (`TEXT_FILTER_IN_PLACE_NOT_IMPLEMENTED`) and abort, preserving the current export behavior.
- Add the UI/user-facing text `TEXT_FILTER_IN_PLACE_NOT_IMPLEMENTED` to `ContextTexts.hpp`.

### Testing

- Performed a full project build (`make`/`ninja`) after the changes, which completed successfully.
- Exercised both dialogs to verify the new radio buttons toggle state propagation and that messages include the selected `FilterExecutionMode`, and confirmed that choosing `ApplyOnCurrentProject` results in the expected warning and abort behavior in the current build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f3b49c08832fbfa61421ea41ee99)