### PR TITLE
Add execution mode for filters and preserve unclipped points in filtering/writing

### DIFF
--- a/include/controller/functionSystem/ContextColorBalanceFilter.h
+++ b/include/controller/functionSystem/ContextColorBalanceFilter.h
@@ -3,6 +3,7 @@
 
 #include "controller/functionSystem/AContext.h"
 #include "controller/messages/ColorBalanceFilterMessage.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "io/FileUtils.h"
 #include "tls_def.h"
 
@@ -36,6 +37,7 @@ private:
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = false;
     bool m_warningModal = false;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 };
 
 #endif

--- a/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
+++ b/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
@@ -2,6 +2,7 @@
 #define CONTEXT_STATISTICAL_OUTLIER_FILTER_H
 
 #include "controller/functionSystem/AContext.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "models/graph/TransformationModule.h"
 #include "io/FileUtils.h"
 
@@ -25,6 +26,7 @@ private:
     bool prepareOutputDirectory(Controller& controller, const std::filesystem::path& folderPath);
 
     bool m_warningModal = false;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
     bool m_globalFiltering = false;
     int m_kNeighbors = 20;
     double m_nSigma = 1.0;

--- a/include/controller/messages/ColorBalanceFilterMessage.h
+++ b/include/controller/messages/ColorBalanceFilterMessage.h
@@ -2,6 +2,7 @@
 #define COLOR_BALANCE_FILTER_MESSAGE_H
 
 #include "controller/messages/IMessage.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "io/FileUtils.h"
 
 #include <string>
@@ -15,7 +16,7 @@ enum class ColorBalanceMode
 class ColorBalanceFilterMessage : public IMessage
 {
 public:
-    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
+    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, FilterExecutionMode executionModeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
     ~ColorBalanceFilterMessage() {}
 
     MessageType getType() const override;
@@ -26,6 +27,7 @@ public:
     double trimPercent;
     double sharpnessBlend;
     ColorBalanceMode mode;
+    FilterExecutionMode executionMode;
     bool applyOnIntensityAndRgb;
     FileType outputFileType;
     std::wstring outputFolder;

--- a/include/controller/messages/FilterExecutionMode.h
+++ b/include/controller/messages/FilterExecutionMode.h
@@ -1,0 +1,10 @@
+#ifndef FILTER_EXECUTION_MODE_H
+#define FILTER_EXECUTION_MODE_H
+
+enum class FilterExecutionMode
+{
+    ApplyOnCurrentProject,
+    ExportFilteredAreas
+};
+
+#endif

--- a/include/controller/messages/StatisticalOutlierFilterMessage.h
+++ b/include/controller/messages/StatisticalOutlierFilterMessage.h
@@ -2,6 +2,7 @@
 #define STATISTICAL_OUTLIER_FILTER_MESSAGE_H
 
 #include "controller/messages/IMessage.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "io/FileUtils.h"
 
 #include <string>
@@ -15,7 +16,7 @@ enum class OutlierFilterMode
 class StatisticalOutlierFilterMessage : public IMessage
 {
 public:
-    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
+    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FilterExecutionMode executionMode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
     ~StatisticalOutlierFilterMessage() {}
 
     MessageType getType() const override;
@@ -26,6 +27,7 @@ public:
     int samplingPercent;
     double beta;
     OutlierFilterMode mode;
+    FilterExecutionMode executionMode;
     FileType outputFileType;
     std::wstring outputFolder;
     bool openFolderAfterExport;

--- a/include/gui/Dialog/DialogColorBalanceFilter.h
+++ b/include/gui/Dialog/DialogColorBalanceFilter.h
@@ -48,6 +48,7 @@ private:
     bool m_intensityAvailable = false;
     bool m_rgbAndIntensityAvailable = false;
     FileType m_outputFileType = FileType::TLS;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 
     QString m_openPath;
     std::wstring m_outputFolder;

--- a/include/gui/Dialog/DialogStatisticalOutlierFilter.h
+++ b/include/gui/Dialog/DialogStatisticalOutlierFilter.h
@@ -40,6 +40,7 @@ private:
     int m_samplingPercent = 2;
     double m_beta = 4.0;
     FileType m_outputFileType = FileType::TLS;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
     std::wstring m_outputFolder;
     QString m_openPath;
 };

--- a/src/controller/functionSystem/ContextColorBalanceFilter.cpp
+++ b/src/controller/functionSystem/ContextColorBalanceFilter.cpp
@@ -135,6 +135,7 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
         m_trimPercent = decodedMsg->trimPercent;
         m_sharpnessBlend = decodedMsg->sharpnessBlend;
         m_globalBalancing = decodedMsg->mode == ColorBalanceMode::Global;
+        m_executionMode = decodedMsg->executionMode;
         m_applyOnIntensityAndRgb = decodedMsg->applyOnIntensityAndRgb;
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
@@ -155,7 +156,12 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
 
-    if (!prepareOutputDirectory(controller, m_outputFolder))
+    const bool applyOnCurrentProject = (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
+    std::filesystem::path outputFolder = m_outputFolder;
+    if (applyOnCurrentProject)
+        outputFolder = controller.getContext().cgetProjectInternalInfo().getPointCloudFolderPath(false) / "temp_color_balance_apply";
+
+    if (!prepareOutputDirectory(controller, outputFolder))
     {
         m_state = ContextState::abort;
         return m_state;
@@ -254,7 +260,7 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
         IScanFileWriter* scan_writer = nullptr;
         std::wstring log;
         std::wstring outputName = wScan->getName() + L"_CB";
-        if (!getScanFileWriter(m_outputFolder, outputName, m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
+        if (!getScanFileWriter(outputFolder, outputName, applyOnCurrentProject ? FileType::TLS : m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
             continue;
 
         tls::ScanHeader header;
@@ -324,6 +330,13 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
         auto progressCallback = makeProgressCallback(scanCount, 0, 100);
         bool res = TlScanOverseer::getInstance().balanceColorsAndWrite(balanceGuid, balanceTransform, *clippingToUse, m_kMin, m_kMax, m_trimPercent, m_sharpnessBlend, applyOnIntensity, applyOnRgb, externalProvider, scan_writer, modifiedPointCount, progressCallback);
         res &= scan_writer->finalizePointCloud();
+        std::filesystem::path writtenPath;
+        if (applyOnCurrentProject)
+        {
+            TlsFileWriter* tlsWriter = dynamic_cast<TlsFileWriter*>(scan_writer);
+            if (tlsWriter != nullptr)
+                writtenPath = tlsWriter->getFilePath();
+        }
         delete scan_writer;
         if (balanceGuid != old_guid)
         {
@@ -343,6 +356,18 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
         else
             controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Scan %1 not affected by color balance.").arg(qScanName)));
 
+        if (applyOnCurrentProject && !writtenPath.empty())
+        {
+            tls::ScanGuid newGuid = xg::Guid();
+            if (TlScanOverseer::getInstance().getScanGuid(writtenPath, newGuid))
+            {
+                std::filesystem::path absolutePath = wScan->getTlsFilePath();
+                TlScanOverseer::getInstance().freeScan_async(old_guid, false);
+                wScan->setTlsFilePath(writtenPath, false, tls::ScanGuid(), false);
+                TlScanOverseer::getInstance().copyScanFile_async(newGuid, absolutePath, false, true, true);
+            }
+        }
+
         if (m_state != ContextState::running)
         {
             wasAborted = true;
@@ -353,7 +378,7 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
     controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Total points updated: %1").arg(totalModifiedPoints)));
     controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 
-    if (m_openFolderAfterExport && !wasAborted)
+    if (m_openFolderAfterExport && !wasAborted && !applyOnCurrentProject)
         controller.updateInfo(new GuiDataOpenInExplorer(m_outputFolder));
 
     m_state = wasAborted ? ContextState::abort : ContextState::done;

--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -12,6 +12,7 @@
 #include "gui/texts/ExportTexts.hpp"
 #include "gui/texts/SplashScreenTexts.hpp"
 #include "io/exports/IScanFileWriter.h"
+#include "io/exports/TlsFileWriter.h"
 #include "models/graph/GraphManager.h"
 #include "models/graph/PointCloudNode.h"
 #include "pointCloudEngine/PCE_core.h"
@@ -123,6 +124,7 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
         m_samplingPercent = decodedMsg->samplingPercent;
         m_beta = decodedMsg->beta;
         m_globalFiltering = decodedMsg->mode == OutlierFilterMode::Global;
+        m_executionMode = decodedMsg->executionMode;
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
@@ -143,7 +145,12 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
 
-    if (!prepareOutputDirectory(controller, m_outputFolder))
+    const bool applyOnCurrentProject = (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
+    std::filesystem::path outputFolder = m_outputFolder;
+    if (applyOnCurrentProject)
+        outputFolder = controller.getContext().cgetProjectInternalInfo().getPointCloudFolderPath(false) / "temp_stat_outlier";
+
+    if (!prepareOutputDirectory(controller, outputFolder))
     {
         m_state = ContextState::abort;
         return m_state;
@@ -244,7 +251,7 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         IScanFileWriter* scan_writer = nullptr;
         std::wstring log;
         std::wstring outputName = wScan->getName() + L"_SOF";
-        if (!getScanFileWriter(m_outputFolder, outputName, m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
+        if (!getScanFileWriter(outputFolder, outputName, applyOnCurrentProject ? FileType::TLS : m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
             continue;
         tls::ScanHeader header;
         TlScanOverseer::getInstance().getScanHeader(old_guid, header);
@@ -261,6 +268,13 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         auto filterProgress = makeProgressCallback(scan_count, m_globalFiltering ? 0 : 50, m_globalFiltering ? 100 : 50);
         bool res = TlScanOverseer::getInstance().filterOutliersAndWrite(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, statsToUse, m_nSigma, m_beta, scan_writer, deleted_point_count, filterProgress);
         res &= scan_writer->finalizePointCloud();
+        std::filesystem::path writtenPath;
+        if (applyOnCurrentProject)
+        {
+            TlsFileWriter* tlsWriter = dynamic_cast<TlsFileWriter*>(scan_writer);
+            if (tlsWriter != nullptr)
+                writtenPath = tlsWriter->getFilePath();
+        }
         delete scan_writer;
 
         total_deleted_points += deleted_point_count;
@@ -275,6 +289,18 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         else
             controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Scan %1 not affected by outlier filter.").arg(qScanName)));
 
+        if (applyOnCurrentProject && !writtenPath.empty())
+        {
+            tls::ScanGuid newGuid = xg::Guid();
+            if (TlScanOverseer::getInstance().getScanGuid(writtenPath, newGuid))
+            {
+                std::filesystem::path absolutePath = wScan->getTlsFilePath();
+                TlScanOverseer::getInstance().freeScan_async(old_guid, false);
+                wScan->setTlsFilePath(writtenPath, false, tls::ScanGuid(), false);
+                TlScanOverseer::getInstance().copyScanFile_async(newGuid, absolutePath, false, true, true);
+            }
+        }
+
         if (m_state != ContextState::running)
         {
             wasAborted = true;
@@ -285,7 +311,7 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
     controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Total points deleted: %1").arg(total_deleted_points)));
     controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 
-    if (m_openFolderAfterExport && !wasAborted)
+    if (m_openFolderAfterExport && !wasAborted && !applyOnCurrentProject)
         controller.updateInfo(new GuiDataOpenInExplorer(m_outputFolder));
 
     m_state = wasAborted ? ContextState::abort : ContextState::done;

--- a/src/controller/messages/ColorBalanceFilterMessage.cpp
+++ b/src/controller/messages/ColorBalanceFilterMessage.cpp
@@ -1,11 +1,12 @@
 #include "controller/messages/ColorBalanceFilterMessage.h"
 
-ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, FilterExecutionMode executionModeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
     : kMin(kMinValue)
     , kMax(kMaxValue)
     , trimPercent(trimPercentValue)
     , sharpnessBlend(sharpnessBlendValue)
     , mode(modeValue)
+    , executionMode(executionModeValue)
     , applyOnIntensityAndRgb(applyOnIntensityAndRgbValue)
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
@@ -19,5 +20,5 @@ IMessage::MessageType ColorBalanceFilterMessage::getType() const
 
 IMessage* ColorBalanceFilterMessage::copy() const
 {
-    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
+    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, executionMode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
 }

--- a/src/controller/messages/StatisticalOutlierFilterMessage.cpp
+++ b/src/controller/messages/StatisticalOutlierFilterMessage.cpp
@@ -1,11 +1,12 @@
 #include "controller/messages/StatisticalOutlierFilterMessage.h"
 
-StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FilterExecutionMode executionModeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
     : kNeighbors(kNeighborsValue)
     , nSigma(nSigmaValue)
     , samplingPercent(samplingPercentValue)
     , beta(betaValue)
     , mode(modeValue)
+    , executionMode(executionModeValue)
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
     , openFolderAfterExport(openFolderAfterExportValue)
@@ -18,5 +19,5 @@ IMessage::MessageType StatisticalOutlierFilterMessage::getType() const
 
 IMessage* StatisticalOutlierFilterMessage::copy() const
 {
-    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, outputFileType, outputFolder, openFolderAfterExport);
+    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, executionMode, outputFileType, outputFolder, openFolderAfterExport);
 }

--- a/src/gui/Dialog/DialogColorBalanceFilter.cpp
+++ b/src/gui/Dialog/DialogColorBalanceFilter.cpp
@@ -114,6 +114,20 @@ DialogColorBalanceFilter::DialogColorBalanceFilter(IDataDispatcher& dataDispatch
         m_mode = ColorBalanceMode::Global;
         applyPreset(m_preset);
     });
+    connect(m_ui.radioButton_applyCurrentProject, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ApplyOnCurrentProject;
+        syncUiFromValues();
+    });
+    connect(m_ui.radioButton_exportFilteredAreas, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ExportFilteredAreas;
+        syncUiFromValues();
+    });
     connect(m_ui.radioButton_balanceLight, &QRadioButton::toggled, this, [this](bool checked)
     {
         if (checked)
@@ -198,7 +212,7 @@ void DialogColorBalanceFilter::informData(IGuiData* data)
 void DialogColorBalanceFilter::startBalancing()
 {
     m_outputFolder = m_ui.lineEdit_folder->text().toStdWString();
-    if (m_outputFolder.empty())
+    if (m_executionMode == FilterExecutionMode::ExportFilteredAreas && m_outputFolder.empty())
     {
         m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_NO_DIRECTORY_SELECTED));
         return;
@@ -212,7 +226,7 @@ void DialogColorBalanceFilter::startBalancing()
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
     bool applyOnIntensityAndRgb = m_ui.checkBox_balanceIntensityRGB->isChecked();
 
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, m_executionMode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder)));
 
     hide();
 }
@@ -260,6 +274,8 @@ void DialogColorBalanceFilter::syncUiFromValues()
     const QSignalBlocker blockSharpnessSlider(m_ui.horizontalSlider_sharpness);
     const QSignalBlocker blockSharpnessSpin(m_ui.spinBox_sharpness);
     const QSignalBlocker blockFormat(m_ui.comboBox_file_format);
+    const QSignalBlocker blockExecProject(m_ui.radioButton_applyCurrentProject);
+    const QSignalBlocker blockExecExport(m_ui.radioButton_exportFilteredAreas);
 
     m_ui.radioButton_balanceLight->setChecked(m_preset == BalancePreset::Light);
     m_ui.radioButton_balanceMedium->setChecked(m_preset == BalancePreset::Medium);
@@ -274,6 +290,16 @@ void DialogColorBalanceFilter::syncUiFromValues()
     m_ui.horizontalSlider_sharpness->setValue(m_sharpnessPercent);
     m_ui.spinBox_sharpness->setValue(m_sharpnessPercent);
     m_ui.checkBox_balanceIntensityRGB->setChecked(m_applyOnIntensityAndRgb);
+    m_ui.radioButton_applyCurrentProject->setChecked(m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
+    m_ui.radioButton_exportFilteredAreas->setChecked(m_executionMode == FilterExecutionMode::ExportFilteredAreas);
+
+    const bool exportMode = m_executionMode == FilterExecutionMode::ExportFilteredAreas;
+    m_ui.comboBox_file_format->setEnabled(exportMode);
+    m_ui.label_format->setEnabled(exportMode);
+    m_ui.lineEdit_folder->setEnabled(exportMode);
+    m_ui.label_folder->setEnabled(exportMode);
+    m_ui.toolButton_folder->setEnabled(exportMode);
+    m_ui.checkBox_openFolderAfterExport->setEnabled(exportMode);
     int formatIndex = m_ui.comboBox_file_format->findData(QVariant(static_cast<int>(m_outputFileType)));
     if (formatIndex >= 0)
         m_ui.comboBox_file_format->setCurrentIndex(formatIndex);

--- a/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
+++ b/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
@@ -77,6 +77,30 @@ DialogStatisticalOutlierFilter::DialogStatisticalOutlierFilter(IDataDispatcher& 
         if (checked)
             m_mode = OutlierFilterMode::Global;
     });
+    connect(m_ui.radioButton_applyCurrentProject, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ApplyOnCurrentProject;
+        m_ui.comboBox_file_format->setEnabled(false);
+        m_ui.label_format->setEnabled(false);
+        m_ui.lineEdit_folder->setEnabled(false);
+        m_ui.label_folder->setEnabled(false);
+        m_ui.toolButton_folder->setEnabled(false);
+        m_ui.checkBox_openFolderAfterExport->setEnabled(false);
+    });
+    connect(m_ui.radioButton_exportFilteredAreas, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ExportFilteredAreas;
+        m_ui.comboBox_file_format->setEnabled(true);
+        m_ui.label_format->setEnabled(true);
+        m_ui.lineEdit_folder->setEnabled(true);
+        m_ui.label_folder->setEnabled(true);
+        m_ui.toolButton_folder->setEnabled(true);
+        m_ui.checkBox_openFolderAfterExport->setEnabled(true);
+    });
     connect(m_ui.radioButton_soLow, &QRadioButton::toggled, this, [this](bool checked)
     {
         if (checked)
@@ -143,7 +167,7 @@ void DialogStatisticalOutlierFilter::informData(IGuiData* data)
 void DialogStatisticalOutlierFilter::startFiltering()
 {
     m_outputFolder = m_ui.lineEdit_folder->text().toStdWString();
-    if (m_outputFolder.empty())
+    if (m_executionMode == FilterExecutionMode::ExportFilteredAreas && m_outputFolder.empty())
     {
         m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_NO_DIRECTORY_SELECTED));
         return;
@@ -156,7 +180,7 @@ void DialogStatisticalOutlierFilter::startFiltering()
     m_outputFileType = static_cast<FileType>(m_ui.comboBox_file_format->currentData().toInt());
 
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_executionMode, m_outputFileType, m_outputFolder, openFolder)));
 
     hide();
 }
@@ -216,6 +240,8 @@ void DialogStatisticalOutlierFilter::syncUiFromValues()
     const QSignalBlocker blockSampling(m_ui.spinBox_soSampling);
     const QSignalBlocker blockBeta(m_ui.doubleSpinBox_soBeta);
     const QSignalBlocker blockFormat(m_ui.comboBox_file_format);
+    const QSignalBlocker blockExecProject(m_ui.radioButton_applyCurrentProject);
+    const QSignalBlocker blockExecExport(m_ui.radioButton_exportFilteredAreas);
 
     m_ui.radioButton_soLow->setChecked(m_preset == OutlierPreset::Low);
     m_ui.radioButton_soMid->setChecked(m_preset == OutlierPreset::Mid);
@@ -225,6 +251,16 @@ void DialogStatisticalOutlierFilter::syncUiFromValues()
     m_ui.doubleSpinBox_nSigma->setValue(m_nSigma);
     m_ui.spinBox_soSampling->setValue(m_samplingPercent);
     m_ui.doubleSpinBox_soBeta->setValue(m_beta);
+    m_ui.radioButton_applyCurrentProject->setChecked(m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
+    m_ui.radioButton_exportFilteredAreas->setChecked(m_executionMode == FilterExecutionMode::ExportFilteredAreas);
+
+    const bool exportMode = m_executionMode == FilterExecutionMode::ExportFilteredAreas;
+    m_ui.comboBox_file_format->setEnabled(exportMode);
+    m_ui.label_format->setEnabled(exportMode);
+    m_ui.lineEdit_folder->setEnabled(exportMode);
+    m_ui.label_folder->setEnabled(exportMode);
+    m_ui.toolButton_folder->setEnabled(exportMode);
+    m_ui.checkBox_openFolderAfterExport->setEnabled(exportMode);
     int formatIndex = m_ui.comboBox_file_format->findData(QVariant(static_cast<int>(m_outputFileType)));
     if (formatIndex >= 0)
         m_ui.comboBox_file_format->setCurrentIndex(formatIndex);

--- a/src/gui/forms/DialogColorBalanceFilter.ui
+++ b/src/gui/forms/DialogColorBalanceFilter.ui
@@ -205,6 +205,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_filteringExecution">
+     <property name="title">
+      <string>Filtering execution</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_filteringExecution">
+      <item>
+       <widget class="QRadioButton" name="radioButton_applyCurrentProject">
+        <property name="text">
+         <string>Apply filter on current project</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButton_exportFilteredAreas">
+        <property name="text">
+         <string>Export filtered areas</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="checkBox_balanceIntensityRGB">
      <property name="text">
       <string>Apply on RGB and i</string>

--- a/src/gui/forms/DialogStatisticalOutlierFilter.ui
+++ b/src/gui/forms/DialogStatisticalOutlierFilter.ui
@@ -185,6 +185,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_filteringExecution">
+     <property name="title">
+      <string>Filtering execution</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_filteringExecution">
+      <item>
+       <widget class="QRadioButton" name="radioButton_applyCurrentProject">
+        <property name="text">
+         <string>Apply filter on current project</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButton_exportFilteredAreas">
+        <property name="text">
+         <string>Export filtered areas</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_folder">
      <item row="0" column="0">
       <widget class="QLabel" name="label_format">

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -423,6 +423,26 @@ void clipIndividualPoints(const std::vector<PointXYZIRGB>& inPoints, std::vector
     }
 }
 
+// Split points for partial clipping processing:
+// - pointsInside: affected by filter logic
+// - pointsOutside: kept unchanged in output
+void splitPointsByClippingMask(const std::vector<PointXYZIRGB>& inPoints,
+                               std::vector<PointXYZIRGB>& pointsInside,
+                               std::vector<PointXYZIRGB>& pointsOutside,
+                               const ClippingAssembly& clippingAssembly)
+{
+    pointsInside.reserve(inPoints.size());
+    pointsOutside.reserve(inPoints.size());
+    for (const PointXYZIRGB& point : inPoints)
+    {
+        glm::dvec4 pos = { point.x, point.y, point.z, 1.0 };
+        if (clippingAssembly.testPoint(pos))
+            pointsInside.push_back(point);
+        else
+            pointsOutside.push_back(point);
+    }
+}
+
 bool EmbeddedScan::testPointsClippedOut(const TransformationModule& src_transfo, const ClippingAssembly& _clippingAssembly) const
 {
     ClippingAssembly localAssembly = _clippingAssembly;
@@ -866,8 +886,9 @@ bool EmbeddedScan::computeOutlierStats(const TransformationModule& src_transfo, 
             }
 
             std::vector<PointXYZIRGB> visiblePoints;
+            std::vector<PointXYZIRGB> untouchedPoints;
             if (cell.second)
-                clipIndividualPoints(points, visiblePoints, localAssembly);
+                splitPointsByClippingMask(points, visiblePoints, untouchedPoints, localAssembly);
             else
                 visiblePoints.swap(points);
 
@@ -1046,8 +1067,9 @@ bool EmbeddedScan::filterOutliersAndWrite(const TransformationModule& src_transf
             }
 
             std::vector<PointXYZIRGB> visiblePoints;
+            std::vector<PointXYZIRGB> untouchedPoints;
             if (cell.second)
-                clipIndividualPoints(points, visiblePoints, localAssembly);
+                splitPointsByClippingMask(points, visiblePoints, untouchedPoints, localAssembly);
             else
                 visiblePoints.swap(points);
 
@@ -1090,7 +1112,11 @@ bool EmbeddedScan::filterOutliersAndWrite(const TransformationModule& src_transf
             }
 
             removedPointsAtomic.fetch_add(visiblePoints.size() - filtered.size());
-            sequentialOk &= writer->mergePoints(filtered.data(), filtered.size(), src_transfo, pt_format_);
+            std::vector<PointXYZIRGB> outputPoints;
+            outputPoints.reserve(filtered.size() + untouchedPoints.size());
+            outputPoints.insert(outputPoints.end(), filtered.begin(), filtered.end());
+            outputPoints.insert(outputPoints.end(), untouchedPoints.begin(), untouchedPoints.end());
+            sequentialOk &= writer->mergePoints(outputPoints.data(), outputPoints.size(), src_transfo, pt_format_);
 
             if (progress)
                 progress(cellIndex + 1, totalCells);
@@ -1139,8 +1165,9 @@ bool EmbeddedScan::filterOutliersAndWrite(const TransformationModule& src_transf
             }
 
             std::vector<PointXYZIRGB> visiblePoints;
+            std::vector<PointXYZIRGB> untouchedPoints;
             if (cell.second)
-                clipIndividualPoints(points, visiblePoints, threadAssembly);
+                splitPointsByClippingMask(points, visiblePoints, untouchedPoints, threadAssembly);
             else
                 visiblePoints.swap(points);
 
@@ -1196,10 +1223,15 @@ bool EmbeddedScan::filterOutliersAndWrite(const TransformationModule& src_transf
                     filtered.push_back(visiblePoints[i]);
             }
 
+            std::vector<PointXYZIRGB> outputPoints;
+            outputPoints.reserve(filtered.size() + untouchedPoints.size());
+            outputPoints.insert(outputPoints.end(), filtered.begin(), filtered.end());
+            outputPoints.insert(outputPoints.end(), untouchedPoints.begin(), untouchedPoints.end());
+
             {
                 std::unique_lock<std::mutex> lock(writeMutex);
                 writeCv.wait(lock, [&]() { return cellIndex == nextWriteIndex; });
-                bool ok = writer->mergePoints(filtered.data(), filtered.size(), src_transfo, pt_format_);
+                bool ok = writer->mergePoints(outputPoints.data(), outputPoints.size(), src_transfo, pt_format_);
                 if (!ok)
                     resultOk.store(false);
                 removedPointsAtomic.fetch_add(visiblePoints.size() - filtered.size());
@@ -1493,8 +1525,9 @@ bool EmbeddedScan::balanceColorsAndWrite(const TransformationModule& src_transfo
             }
 
             std::vector<PointXYZIRGB> visiblePoints;
+            std::vector<PointXYZIRGB> untouchedPoints;
             if (cell.second)
-                clipIndividualPoints(points, visiblePoints, localAssembly);
+                splitPointsByClippingMask(points, visiblePoints, untouchedPoints, localAssembly);
             else
                 visiblePoints.swap(points);
 
@@ -1583,7 +1616,11 @@ bool EmbeddedScan::balanceColorsAndWrite(const TransformationModule& src_transfo
             {
                 filtered = visiblePoints;
                 modifiedPointsAtomic.fetch_add(filtered.size());
-                sequentialOk &= writer->addPoints(filtered.data(), filtered.size());
+                std::vector<PointXYZIRGB> outputPoints;
+                outputPoints.reserve(filtered.size() + untouchedPoints.size());
+                outputPoints.insert(outputPoints.end(), filtered.begin(), filtered.end());
+                outputPoints.insert(outputPoints.end(), untouchedPoints.begin(), untouchedPoints.end());
+                sequentialOk &= writer->addPoints(outputPoints.data(), outputPoints.size());
                 if (progress)
                     progress(cellIndex + 1, totalCells);
                 continue;
@@ -1651,7 +1688,11 @@ bool EmbeddedScan::balanceColorsAndWrite(const TransformationModule& src_transfo
             }
 
             modifiedPointsAtomic.fetch_add(filtered.size());
-            sequentialOk &= writer->addPoints(filtered.data(), filtered.size());
+            std::vector<PointXYZIRGB> outputPoints;
+            outputPoints.reserve(filtered.size() + untouchedPoints.size());
+            outputPoints.insert(outputPoints.end(), filtered.begin(), filtered.end());
+            outputPoints.insert(outputPoints.end(), untouchedPoints.begin(), untouchedPoints.end());
+            sequentialOk &= writer->addPoints(outputPoints.data(), outputPoints.size());
 
             if (progress)
                 progress(cellIndex + 1, totalCells);
@@ -1695,8 +1736,9 @@ bool EmbeddedScan::balanceColorsAndWrite(const TransformationModule& src_transfo
             }
 
             std::vector<PointXYZIRGB> visiblePoints;
+            std::vector<PointXYZIRGB> untouchedPoints;
             if (cell.second)
-                clipIndividualPoints(points, visiblePoints, threadAssembly);
+                splitPointsByClippingMask(points, visiblePoints, untouchedPoints, threadAssembly);
             else
                 visiblePoints.swap(points);
 
@@ -1859,10 +1901,15 @@ bool EmbeddedScan::balanceColorsAndWrite(const TransformationModule& src_transfo
                 }
             }
 
+            std::vector<PointXYZIRGB> outputPoints;
+            outputPoints.reserve(filtered.size() + untouchedPoints.size());
+            outputPoints.insert(outputPoints.end(), filtered.begin(), filtered.end());
+            outputPoints.insert(outputPoints.end(), untouchedPoints.begin(), untouchedPoints.end());
+
             {
                 std::unique_lock<std::mutex> lock(writeMutex);
                 writeCv.wait(lock, [&]() { return cellIndex == nextWriteIndex; });
-                bool ok = writer->addPoints(filtered.data(), filtered.size());
+                bool ok = writer->addPoints(outputPoints.data(), outputPoints.size());
                 if (!ok)
                     resultOk.store(false);
                 modifiedPointsAtomic.fetch_add(filtered.size());


### PR DESCRIPTION
### Motivation
- Provide an execution mode choice for filters so users can either `ApplyOnCurrentProject` (in-place) or `ExportFilteredAreas` (export new files). 
- Ensure partial clipping does not discard points outside the clipping mask when writing filtered/exported scans.

### Description
- Introduce `FilterExecutionMode` enum and propagate it through messages (`ColorBalanceFilterMessage`, `StatisticalOutlierFilterMessage`), contexts (`ContextColorBalanceFilter`, `ContextStatisticalOutlierFilter`) and dialogs.
- UI changes: add a `Filtering execution` group with `Apply filter on current project` and `Export filtered areas` radio buttons in `DialogColorBalanceFilter` and `DialogStatisticalOutlierFilter`, and enable/disable export controls depending on the selected mode; pass the execution mode in control messages.
- Context behavior: when `ApplyOnCurrentProject` is selected, contexts write temporary TLS files into the project point-cloud folder and replace the original scan file references (using `TlsFileWriter` and `TlScanOverseer::copyScanFile_async`); opening explorer after export is suppressed for in-place mode.
- Point-level change: add `splitPointsByClippingMask` and update `EmbeddedScan` routines (`computeOutlierStats`, `filterOutliersAndWrite`, `balanceColorsAndWrite`) to keep `untouchedPoints` (points outside clipping mask) and merge them back into output so only clipped-region points are modified/removed.
- Add include of `TlsFileWriter.h` where needed and minor wiring adjustments for output folder resolution when applying in-place.

### Testing
- Project build completed locally with the modified sources (`cmake`/`ninja` or equivalent) and the application linked successfully.
- Ran the repository's automated unit/integration tests and the filter-related test cases; all tests passed.
- Performed automated GUI dialog serialization/smoke checks for the new radio buttons and export control enable/disable logic; checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90d30c478832faa3d7da8b90a8c66)