### PR TITLE
Add execution-mode option and in-place stub for Color Balance and Statistical Outlier filters

### DIFF
--- a/include/controller/functionSystem/ContextColorBalanceFilter.h
+++ b/include/controller/functionSystem/ContextColorBalanceFilter.h
@@ -24,6 +24,8 @@ public:
 
 private:
     bool prepareOutputDirectory(Controller& controller, const std::filesystem::path& folderPath);
+    ContextState launchExportMode(Controller& controller);
+    ContextState launchInPlaceMode(Controller& controller);
 
     tls::ScanGuid m_panoramic;
     int m_kMin = 24;
@@ -36,6 +38,7 @@ private:
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = false;
     bool m_warningModal = false;
+    ColorBalanceFilterExecutionMode m_executionMode = ColorBalanceFilterExecutionMode::ExportFilteredAreas;
 };
 
 #endif

--- a/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
+++ b/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
@@ -23,6 +23,8 @@ public:
 
 private:
     bool prepareOutputDirectory(Controller& controller, const std::filesystem::path& folderPath);
+    ContextState launchExportMode(Controller& controller);
+    ContextState launchInPlaceMode(Controller& controller);
 
     bool m_warningModal = false;
     bool m_globalFiltering = false;
@@ -34,6 +36,7 @@ private:
     FileType m_outputFileType = FileType::TLS;
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = true;
+    OutlierFilterExecutionMode m_executionMode = OutlierFilterExecutionMode::ExportFilteredAreas;
 };
 
 #endif

--- a/include/controller/messages/ColorBalanceFilterMessage.h
+++ b/include/controller/messages/ColorBalanceFilterMessage.h
@@ -12,10 +12,16 @@ enum class ColorBalanceMode
     Global
 };
 
+enum class ColorBalanceFilterExecutionMode
+{
+    ApplyInProject,
+    ExportFilteredAreas
+};
+
 class ColorBalanceFilterMessage : public IMessage
 {
 public:
-    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
+    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, ColorBalanceFilterExecutionMode executionModeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
     ~ColorBalanceFilterMessage() {}
 
     MessageType getType() const override;
@@ -26,6 +32,7 @@ public:
     double trimPercent;
     double sharpnessBlend;
     ColorBalanceMode mode;
+    ColorBalanceFilterExecutionMode executionMode;
     bool applyOnIntensityAndRgb;
     FileType outputFileType;
     std::wstring outputFolder;

--- a/include/controller/messages/StatisticalOutlierFilterMessage.h
+++ b/include/controller/messages/StatisticalOutlierFilterMessage.h
@@ -12,10 +12,16 @@ enum class OutlierFilterMode
     Global
 };
 
+enum class OutlierFilterExecutionMode
+{
+    ApplyInProject,
+    ExportFilteredAreas
+};
+
 class StatisticalOutlierFilterMessage : public IMessage
 {
 public:
-    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
+    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, OutlierFilterExecutionMode executionMode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
     ~StatisticalOutlierFilterMessage() {}
 
     MessageType getType() const override;
@@ -26,6 +32,7 @@ public:
     int samplingPercent;
     double beta;
     OutlierFilterMode mode;
+    OutlierFilterExecutionMode executionMode;
     FileType outputFileType;
     std::wstring outputFolder;
     bool openFolderAfterExport;

--- a/src/controller/functionSystem/ContextColorBalanceFilter.cpp
+++ b/src/controller/functionSystem/ContextColorBalanceFilter.cpp
@@ -139,6 +139,7 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_COLOR_BALANCE_FILTER_QUESTION));
@@ -152,6 +153,14 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
 }
 
 ContextState ContextColorBalanceFilter::launch(Controller& controller)
+{
+    if (m_executionMode == ColorBalanceFilterExecutionMode::ApplyInProject)
+        return launchInPlaceMode(controller);
+
+    return launchExportMode(controller);
+}
+
+ContextState ContextColorBalanceFilter::launchExportMode(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
 
@@ -358,6 +367,15 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
 
     m_state = wasAborted ? ContextState::abort : ContextState::done;
     return (m_state);
+}
+
+
+ContextState ContextColorBalanceFilter::launchInPlaceMode(Controller& controller)
+{
+    // Pass 1 intentionally keeps in-project execution isolated from export logic.
+    // The in-place pipeline will be implemented in a dedicated patch pass.
+    controller.updateInfo(new GuiDataWarning(QString("Apply filter on current project is not available yet.")));
+    return (m_state = ContextState::abort);
 }
 
 bool ContextColorBalanceFilter::canAutoRelaunch() const

--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -126,6 +126,7 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_STAT_OUTLIER_FILTER_QUESTION));
@@ -140,6 +141,14 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
 }
 
 ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
+{
+    if (m_executionMode == OutlierFilterExecutionMode::ApplyInProject)
+        return launchInPlaceMode(controller);
+
+    return launchExportMode(controller);
+}
+
+ContextState ContextStatisticalOutlierFilter::launchExportMode(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
 
@@ -290,6 +299,15 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 
     m_state = wasAborted ? ContextState::abort : ContextState::done;
     return (m_state);
+}
+
+
+ContextState ContextStatisticalOutlierFilter::launchInPlaceMode(Controller& controller)
+{
+    // Pass 1 intentionally keeps in-project execution isolated from export logic.
+    // The in-place pipeline will be implemented in a dedicated patch pass.
+    controller.updateInfo(new GuiDataWarning(QString("Apply filter on current project is not available yet.")));
+    return (m_state = ContextState::abort);
 }
 
 bool ContextStatisticalOutlierFilter::canAutoRelaunch() const

--- a/src/controller/messages/ColorBalanceFilterMessage.cpp
+++ b/src/controller/messages/ColorBalanceFilterMessage.cpp
@@ -1,11 +1,12 @@
 #include "controller/messages/ColorBalanceFilterMessage.h"
 
-ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, ColorBalanceFilterExecutionMode executionModeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
     : kMin(kMinValue)
     , kMax(kMaxValue)
     , trimPercent(trimPercentValue)
     , sharpnessBlend(sharpnessBlendValue)
     , mode(modeValue)
+    , executionMode(executionModeValue)
     , applyOnIntensityAndRgb(applyOnIntensityAndRgbValue)
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
@@ -19,5 +20,5 @@ IMessage::MessageType ColorBalanceFilterMessage::getType() const
 
 IMessage* ColorBalanceFilterMessage::copy() const
 {
-    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
+    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, executionMode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
 }

--- a/src/controller/messages/StatisticalOutlierFilterMessage.cpp
+++ b/src/controller/messages/StatisticalOutlierFilterMessage.cpp
@@ -1,11 +1,12 @@
 #include "controller/messages/StatisticalOutlierFilterMessage.h"
 
-StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, OutlierFilterExecutionMode executionModeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
     : kNeighbors(kNeighborsValue)
     , nSigma(nSigmaValue)
     , samplingPercent(samplingPercentValue)
     , beta(betaValue)
     , mode(modeValue)
+    , executionMode(executionModeValue)
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
     , openFolderAfterExport(openFolderAfterExportValue)
@@ -18,5 +19,5 @@ IMessage::MessageType StatisticalOutlierFilterMessage::getType() const
 
 IMessage* StatisticalOutlierFilterMessage::copy() const
 {
-    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, outputFileType, outputFolder, openFolderAfterExport);
+    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, executionMode, outputFileType, outputFolder, openFolderAfterExport);
 }

--- a/src/gui/Dialog/DialogColorBalanceFilter.cpp
+++ b/src/gui/Dialog/DialogColorBalanceFilter.cpp
@@ -212,7 +212,17 @@ void DialogColorBalanceFilter::startBalancing()
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
     bool applyOnIntensityAndRgb = m_ui.checkBox_balanceIntensityRGB->isChecked();
 
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(
+        kMin,
+        kMax,
+        trimPercent,
+        sharpnessBlend,
+        m_mode,
+        ColorBalanceFilterExecutionMode::ExportFilteredAreas,
+        applyOnIntensityAndRgb,
+        m_outputFileType,
+        m_outputFolder,
+        openFolder)));
 
     hide();
 }

--- a/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
+++ b/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
@@ -156,7 +156,16 @@ void DialogStatisticalOutlierFilter::startFiltering()
     m_outputFileType = static_cast<FileType>(m_ui.comboBox_file_format->currentData().toInt());
 
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(
+        kNeighbors,
+        nSigma,
+        samplingPercent,
+        beta,
+        m_mode,
+        OutlierFilterExecutionMode::ExportFilteredAreas,
+        m_outputFileType,
+        m_outputFolder,
+        openFolder)));
 
     hide();
 }


### PR DESCRIPTION
### Motivation
- Introduce an execution mode to let filters run either by exporting filtered areas or (eventually) applying changes directly in the project, and prepare the code to support both flows.
- Keep export logic unchanged while isolating the in-project execution path so in-place behavior can be implemented later.
- Surface the chosen execution mode from the UI dialogs into the controller message pipeline.

### Description
- Added `ColorBalanceFilterExecutionMode` and `OutlierFilterExecutionMode` enums and an `executionMode` field to `ColorBalanceFilterMessage` and `StatisticalOutlierFilterMessage`, updating constructors and `copy()` methods accordingly.
- Added `m_executionMode` members to `ContextColorBalanceFilter` and `ContextStatisticalOutlierFilter` and wired message handling to populate them from incoming messages.
- Updated `launch()` in both contexts to dispatch to `launchExportMode()` or `launchInPlaceMode()` based on the execution mode, and implemented `launchInPlaceMode()` stubs that show a warning and abort until the in-project pipeline is implemented.
- Updated UI dialogs `DialogColorBalanceFilter` and `DialogStatisticalOutlierFilter` to send the `ExportFilteredAreas` execution mode currently supported.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9db8ca10c832f90e5e804258940ef)