### PR TITLE
Introduce FilterExecutionMode and propagate through filter messages and contexts

### DIFF
--- a/include/controller/functionSystem/ContextColorBalanceFilter.h
+++ b/include/controller/functionSystem/ContextColorBalanceFilter.h
@@ -2,6 +2,7 @@
 #define CONTEXT_COLOR_BALANCE_FILTER_H
 
 #include "controller/functionSystem/AContext.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "controller/messages/ColorBalanceFilterMessage.h"
 #include "io/FileUtils.h"
 #include "tls_def.h"
@@ -35,6 +36,7 @@ private:
     FileType m_outputFileType = FileType::TLS;
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = false;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
     bool m_warningModal = false;
 };
 

--- a/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
+++ b/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
@@ -2,6 +2,7 @@
 #define CONTEXT_STATISTICAL_OUTLIER_FILTER_H
 
 #include "controller/functionSystem/AContext.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "models/graph/TransformationModule.h"
 #include "io/FileUtils.h"
 
@@ -34,6 +35,7 @@ private:
     FileType m_outputFileType = FileType::TLS;
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = true;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 };
 
 #endif

--- a/include/controller/messages/ColorBalanceFilterMessage.h
+++ b/include/controller/messages/ColorBalanceFilterMessage.h
@@ -2,6 +2,7 @@
 #define COLOR_BALANCE_FILTER_MESSAGE_H
 
 #include "controller/messages/IMessage.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "io/FileUtils.h"
 
 #include <string>
@@ -15,7 +16,7 @@ enum class ColorBalanceMode
 class ColorBalanceFilterMessage : public IMessage
 {
 public:
-    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
+    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue, FilterExecutionMode executionModeValue = FilterExecutionMode::ExportFilteredAreas);
     ~ColorBalanceFilterMessage() {}
 
     MessageType getType() const override;
@@ -30,6 +31,7 @@ public:
     FileType outputFileType;
     std::wstring outputFolder;
     bool openFolderAfterExport;
+    FilterExecutionMode executionMode;
 };
 
 #endif

--- a/include/controller/messages/FilterExecutionMode.h
+++ b/include/controller/messages/FilterExecutionMode.h
@@ -1,0 +1,10 @@
+#ifndef FILTER_EXECUTION_MODE_H
+#define FILTER_EXECUTION_MODE_H
+
+enum class FilterExecutionMode
+{
+    ExportFilteredAreas,
+    ApplyOnCurrentProject
+};
+
+#endif

--- a/include/controller/messages/StatisticalOutlierFilterMessage.h
+++ b/include/controller/messages/StatisticalOutlierFilterMessage.h
@@ -2,6 +2,7 @@
 #define STATISTICAL_OUTLIER_FILTER_MESSAGE_H
 
 #include "controller/messages/IMessage.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "io/FileUtils.h"
 
 #include <string>
@@ -15,7 +16,7 @@ enum class OutlierFilterMode
 class StatisticalOutlierFilterMessage : public IMessage
 {
 public:
-    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
+    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport, FilterExecutionMode executionMode = FilterExecutionMode::ExportFilteredAreas);
     ~StatisticalOutlierFilterMessage() {}
 
     MessageType getType() const override;
@@ -29,6 +30,7 @@ public:
     FileType outputFileType;
     std::wstring outputFolder;
     bool openFolderAfterExport;
+    FilterExecutionMode executionMode;
 };
 
 #endif

--- a/src/controller/functionSystem/ContextColorBalanceFilter.cpp
+++ b/src/controller/functionSystem/ContextColorBalanceFilter.cpp
@@ -139,6 +139,7 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_COLOR_BALANCE_FILTER_QUESTION));

--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -126,6 +126,7 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_STAT_OUTLIER_FILTER_QUESTION));

--- a/src/controller/messages/ColorBalanceFilterMessage.cpp
+++ b/src/controller/messages/ColorBalanceFilterMessage.cpp
@@ -1,6 +1,6 @@
 #include "controller/messages/ColorBalanceFilterMessage.h"
 
-ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue, FilterExecutionMode executionModeValue)
     : kMin(kMinValue)
     , kMax(kMaxValue)
     , trimPercent(trimPercentValue)
@@ -10,6 +10,7 @@ ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValu
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
     , openFolderAfterExport(openFolderAfterExportValue)
+    , executionMode(executionModeValue)
 {}
 
 IMessage::MessageType ColorBalanceFilterMessage::getType() const
@@ -19,5 +20,5 @@ IMessage::MessageType ColorBalanceFilterMessage::getType() const
 
 IMessage* ColorBalanceFilterMessage::copy() const
 {
-    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
+    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport, executionMode);
 }

--- a/src/controller/messages/StatisticalOutlierFilterMessage.cpp
+++ b/src/controller/messages/StatisticalOutlierFilterMessage.cpp
@@ -1,6 +1,6 @@
 #include "controller/messages/StatisticalOutlierFilterMessage.h"
 
-StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue, FilterExecutionMode executionModeValue)
     : kNeighbors(kNeighborsValue)
     , nSigma(nSigmaValue)
     , samplingPercent(samplingPercentValue)
@@ -9,6 +9,7 @@ StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsV
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
     , openFolderAfterExport(openFolderAfterExportValue)
+    , executionMode(executionModeValue)
 {}
 
 IMessage::MessageType StatisticalOutlierFilterMessage::getType() const
@@ -18,5 +19,5 @@ IMessage::MessageType StatisticalOutlierFilterMessage::getType() const
 
 IMessage* StatisticalOutlierFilterMessage::copy() const
 {
-    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, outputFileType, outputFolder, openFolderAfterExport);
+    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, outputFileType, outputFolder, openFolderAfterExport, executionMode);
 }

--- a/src/gui/Dialog/DialogColorBalanceFilter.cpp
+++ b/src/gui/Dialog/DialogColorBalanceFilter.cpp
@@ -212,7 +212,7 @@ void DialogColorBalanceFilter::startBalancing()
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
     bool applyOnIntensityAndRgb = m_ui.checkBox_balanceIntensityRGB->isChecked();
 
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder, FilterExecutionMode::ExportFilteredAreas)));
 
     hide();
 }

--- a/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
+++ b/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
@@ -156,7 +156,7 @@ void DialogStatisticalOutlierFilter::startFiltering()
     m_outputFileType = static_cast<FileType>(m_ui.comboBox_file_format->currentData().toInt());
 
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_outputFileType, m_outputFolder, openFolder, FilterExecutionMode::ExportFilteredAreas)));
 
     hide();
 }


### PR DESCRIPTION
### Motivation
- Provide a way to choose how filters are executed (either exporting filtered areas or applying changes to the current project) by adding an execution mode enum and plumbing it through messages, contexts and dialogs.

### Description
- Add a new enum `FilterExecutionMode` in `include/controller/messages/FilterExecutionMode.h` with values `ExportFilteredAreas` and `ApplyOnCurrentProject`.
- Extend `ColorBalanceFilterMessage` and `StatisticalOutlierFilterMessage` to accept and store a `FilterExecutionMode` value and update their `copy()` helpers accordingly, and include the new header where needed.
- Add an `m_executionMode` member with default `FilterExecutionMode::ExportFilteredAreas` to `ContextColorBalanceFilter` and `ContextStatisticalOutlierFilter`, and set it from incoming messages in `feedMessage()`.
- Update GUI dialogs `DialogColorBalanceFilter` and `DialogStatisticalOutlierFilter` to send the new execution mode (currently using `FilterExecutionMode::ExportFilteredAreas`) when constructing the filter parameter messages.

### Testing
- Performed a full project build using the standard build system and the build completed successfully (`make`/`cmake` step succeeded). 
- Ran the project's automated unit/integration test suite via `ctest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa15199f84832fb034f225d38baa6d)