### PR TITLE
Add selectable execution mode (Export vs Apply-in-place) for Color Balance and Statistical Outlier filters

### DIFF
--- a/include/controller/functionSystem/ContextColorBalanceFilter.h
+++ b/include/controller/functionSystem/ContextColorBalanceFilter.h
@@ -2,6 +2,7 @@
 #define CONTEXT_COLOR_BALANCE_FILTER_H
 
 #include "controller/functionSystem/AContext.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "controller/messages/ColorBalanceFilterMessage.h"
 #include "io/FileUtils.h"
 #include "tls_def.h"
@@ -35,6 +36,7 @@ private:
     FileType m_outputFileType = FileType::TLS;
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = false;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
     bool m_warningModal = false;
 };
 

--- a/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
+++ b/include/controller/functionSystem/ContextStatisticalOutlierFilter.h
@@ -2,6 +2,7 @@
 #define CONTEXT_STATISTICAL_OUTLIER_FILTER_H
 
 #include "controller/functionSystem/AContext.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "models/graph/TransformationModule.h"
 #include "io/FileUtils.h"
 
@@ -34,6 +35,7 @@ private:
     FileType m_outputFileType = FileType::TLS;
     std::filesystem::path m_outputFolder;
     bool m_openFolderAfterExport = true;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 };
 
 #endif

--- a/include/controller/messages/ColorBalanceFilterMessage.h
+++ b/include/controller/messages/ColorBalanceFilterMessage.h
@@ -2,6 +2,7 @@
 #define COLOR_BALANCE_FILTER_MESSAGE_H
 
 #include "controller/messages/IMessage.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "io/FileUtils.h"
 
 #include <string>
@@ -15,7 +16,7 @@ enum class ColorBalanceMode
 class ColorBalanceFilterMessage : public IMessage
 {
 public:
-    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue);
+    ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue, FilterExecutionMode executionModeValue = FilterExecutionMode::ExportFilteredAreas);
     ~ColorBalanceFilterMessage() {}
 
     MessageType getType() const override;
@@ -30,6 +31,7 @@ public:
     FileType outputFileType;
     std::wstring outputFolder;
     bool openFolderAfterExport;
+    FilterExecutionMode executionMode;
 };
 
 #endif

--- a/include/controller/messages/FilterExecutionMode.h
+++ b/include/controller/messages/FilterExecutionMode.h
@@ -1,0 +1,10 @@
+#ifndef FILTER_EXECUTION_MODE_H
+#define FILTER_EXECUTION_MODE_H
+
+enum class FilterExecutionMode
+{
+    ExportFilteredAreas,
+    ApplyOnCurrentProject
+};
+
+#endif

--- a/include/controller/messages/StatisticalOutlierFilterMessage.h
+++ b/include/controller/messages/StatisticalOutlierFilterMessage.h
@@ -2,6 +2,7 @@
 #define STATISTICAL_OUTLIER_FILTER_MESSAGE_H
 
 #include "controller/messages/IMessage.h"
+#include "controller/messages/FilterExecutionMode.h"
 #include "io/FileUtils.h"
 
 #include <string>
@@ -15,7 +16,7 @@ enum class OutlierFilterMode
 class StatisticalOutlierFilterMessage : public IMessage
 {
 public:
-    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport);
+    StatisticalOutlierFilterMessage(int kNeighbors, double nSigma, int samplingPercent, double beta, OutlierFilterMode mode, FileType outputFileType, const std::wstring& outputFolder, bool openFolderAfterExport, FilterExecutionMode executionMode = FilterExecutionMode::ExportFilteredAreas);
     ~StatisticalOutlierFilterMessage() {}
 
     MessageType getType() const override;
@@ -29,6 +30,7 @@ public:
     FileType outputFileType;
     std::wstring outputFolder;
     bool openFolderAfterExport;
+    FilterExecutionMode executionMode;
 };
 
 #endif

--- a/include/gui/Dialog/DialogColorBalanceFilter.h
+++ b/include/gui/Dialog/DialogColorBalanceFilter.h
@@ -32,6 +32,7 @@ private:
     void refreshUI();
     void applyPreset(BalancePreset preset);
     void syncUiFromValues();
+    void updateExecutionModeUi();
     void updateAvailability(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable);
 
     Ui::DialogColorBalanceFilter m_ui;
@@ -48,6 +49,7 @@ private:
     bool m_intensityAvailable = false;
     bool m_rgbAndIntensityAvailable = false;
     FileType m_outputFileType = FileType::TLS;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
 
     QString m_openPath;
     std::wstring m_outputFolder;

--- a/include/gui/Dialog/DialogStatisticalOutlierFilter.h
+++ b/include/gui/Dialog/DialogStatisticalOutlierFilter.h
@@ -31,6 +31,7 @@ private:
     void refreshUI();
     void applyPreset(OutlierPreset preset);
     void syncUiFromValues();
+    void updateExecutionModeUi();
 
     Ui::DialogStatisticalOutlierFilter m_ui;
     OutlierFilterMode m_mode = OutlierFilterMode::Separate;
@@ -40,6 +41,7 @@ private:
     int m_samplingPercent = 2;
     double m_beta = 4.0;
     FileType m_outputFileType = FileType::TLS;
+    FilterExecutionMode m_executionMode = FilterExecutionMode::ExportFilteredAreas;
     std::wstring m_outputFolder;
     QString m_openPath;
 };

--- a/src/controller/functionSystem/ContextColorBalanceFilter.cpp
+++ b/src/controller/functionSystem/ContextColorBalanceFilter.cpp
@@ -28,6 +28,18 @@
 
 namespace
 {
+    bool resolveExecutionOutputFolder(Controller& controller, FilterExecutionMode executionMode, std::filesystem::path& outputFolder)
+    {
+        if (executionMode == FilterExecutionMode::ExportFilteredAreas)
+            return true;
+
+        // Passe 3A: route in-place mode to a dedicated temporary workspace.
+        // The final commit/replacement phase will be introduced in later passes.
+        std::filesystem::path pointCloudFolder = controller.getContext().cgetProjectInternalInfo().getPointCloudFolderPath(false);
+        outputFolder = pointCloudFolder / "temp_color_balance_inplace";
+        return true;
+    }
+
     void cleanupTempColorBalanceFiles(const std::filesystem::path& tempFolder)
     {
         if (!std::filesystem::is_directory(tempFolder))
@@ -65,6 +77,34 @@ namespace
                 return;
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
+    }
+
+    bool replaceScanFileInProject(const std::filesystem::path& sourcePath, const std::filesystem::path& targetPath)
+    {
+        if (sourcePath.empty() || targetPath.empty())
+            return false;
+
+        std::error_code ec;
+        const std::filesystem::path backupPath = targetPath;
+        const std::filesystem::path backupFile = backupPath.wstring() + L".bak";
+        std::filesystem::remove(backupFile, ec);
+        ec.clear();
+
+        std::filesystem::rename(targetPath, backupFile, ec);
+        if (ec)
+            return false;
+
+        ec.clear();
+        std::filesystem::rename(sourcePath, targetPath, ec);
+        if (ec)
+        {
+            std::error_code restoreEc;
+            std::filesystem::rename(backupFile, targetPath, restoreEc);
+            return false;
+        }
+
+        std::filesystem::remove(backupFile, ec);
+        return true;
     }
 }
 
@@ -139,6 +179,7 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_COLOR_BALANCE_FILTER_QUESTION));
@@ -154,8 +195,14 @@ ContextState ContextColorBalanceFilter::feedMessage(IMessage* message, Controlle
 ContextState ContextColorBalanceFilter::launch(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
+    std::filesystem::path effectiveOutputFolder = m_outputFolder;
+    if (!resolveExecutionOutputFolder(controller, m_executionMode, effectiveOutputFolder))
+    {
+        m_state = ContextState::abort;
+        return m_state;
+    }
 
-    if (!prepareOutputDirectory(controller, m_outputFolder))
+    if (!prepareOutputDirectory(controller, effectiveOutputFolder))
     {
         m_state = ContextState::abort;
         return m_state;
@@ -163,6 +210,8 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
 
     TlStreamLock streamLock;
     std::unordered_set<SafePtr<PointCloudNode>> scans = graphManager.getVisibleScans(m_panoramic);
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
+        m_outputFileType = FileType::TLS;
 
     if (m_globalBalancing && scans.size() < 2)
     {
@@ -187,6 +236,12 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
     std::unordered_set<SafePtr<AClippingNode>> clippings = graphManager.getActivatedOrSelectedClippingObjects();
     if (!clippings.empty())
         graphManager.getClippingAssembly(clippingAssembly, clippings);
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject && !clippingAssembly.empty())
+    {
+        controller.updateInfo(new GuiDataWarning(QString("Apply-on-project with active clipping is scheduled for the next pass.")));
+        m_state = ContextState::abort;
+        return m_state;
+    }
     const bool useTempClippedScans = m_globalBalancing && !clippingAssembly.empty();
     std::filesystem::path tempFolder;
     if (useTempClippedScans)
@@ -254,7 +309,7 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
         IScanFileWriter* scan_writer = nullptr;
         std::wstring log;
         std::wstring outputName = wScan->getName() + L"_CB";
-        if (!getScanFileWriter(m_outputFolder, outputName, m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
+        if (!getScanFileWriter(effectiveOutputFolder, outputName, m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
             continue;
 
         tls::ScanHeader header;
@@ -330,6 +385,26 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
             TlScanOverseer::getInstance().freeScan_async(balanceGuid, false);
             deleteFileWithRetry(tempPath);
         }
+        if (res && m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
+        {
+            std::filesystem::path originalScanPath;
+            if (!TlScanOverseer::getInstance().getScanPath(old_guid, originalScanPath))
+            {
+                controller.updateInfo(new GuiDataWarning(QString("Failed to resolve original scan path for in-place update.")));
+                m_state = ContextState::abort;
+                wasAborted = true;
+                break;
+            }
+
+            std::filesystem::path producedPath = effectiveOutputFolder / (outputName + L".tls");
+            if (!replaceScanFileInProject(producedPath, originalScanPath))
+            {
+                controller.updateInfo(new GuiDataWarning(QString("Failed to replace scan file during in-place update.")));
+                m_state = ContextState::abort;
+                wasAborted = true;
+                break;
+            }
+        }
 
         totalModifiedPoints += modifiedPointCount;
 
@@ -353,8 +428,8 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
     controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Total points updated: %1").arg(totalModifiedPoints)));
     controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 
-    if (m_openFolderAfterExport && !wasAborted)
-        controller.updateInfo(new GuiDataOpenInExplorer(m_outputFolder));
+    if (m_executionMode == FilterExecutionMode::ExportFilteredAreas && m_openFolderAfterExport && !wasAborted)
+        controller.updateInfo(new GuiDataOpenInExplorer(effectiveOutputFolder));
 
     m_state = wasAborted ? ContextState::abort : ContextState::done;
     return (m_state);

--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
+#include <system_error>
 
 // Note (Aurélien) QT::StandardButtons enum values in qmessagebox.h
 #define Yes 0x00004000
@@ -28,6 +29,46 @@
 
 namespace
 {
+    bool resolveExecutionOutputFolder(Controller& controller, FilterExecutionMode executionMode, std::filesystem::path& outputFolder)
+    {
+        if (executionMode == FilterExecutionMode::ExportFilteredAreas)
+            return true;
+
+        // Passe 3A: route in-place mode to a dedicated temporary workspace.
+        // The final commit/replacement phase will be introduced in later passes.
+        std::filesystem::path pointCloudFolder = controller.getContext().cgetProjectInternalInfo().getPointCloudFolderPath(false);
+        outputFolder = pointCloudFolder / "temp_statistical_outlier_inplace";
+        return true;
+    }
+
+    bool replaceScanFileInProject(const std::filesystem::path& sourcePath, const std::filesystem::path& targetPath)
+    {
+        if (sourcePath.empty() || targetPath.empty())
+            return false;
+
+        std::error_code ec;
+        const std::filesystem::path backupPath = targetPath;
+        const std::filesystem::path backupFile = backupPath.wstring() + L".bak";
+        std::filesystem::remove(backupFile, ec);
+        ec.clear();
+
+        std::filesystem::rename(targetPath, backupFile, ec);
+        if (ec)
+            return false;
+
+        ec.clear();
+        std::filesystem::rename(sourcePath, targetPath, ec);
+        if (ec)
+        {
+            std::error_code restoreEc;
+            std::filesystem::rename(backupFile, targetPath, restoreEc);
+            return false;
+        }
+
+        std::filesystem::remove(backupFile, ec);
+        return true;
+    }
+
     struct RunningStats
     {
         uint64_t count = 0;
@@ -126,6 +167,7 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
         m_outputFileType = decodedMsg->outputFileType;
         m_outputFolder = decodedMsg->outputFolder;
         m_openFolderAfterExport = decodedMsg->openFolderAfterExport;
+        m_executionMode = decodedMsg->executionMode;
 
         m_warningModal = true;
         controller.updateInfo(new GuiDataModal(Yes | No, TEXT_STAT_OUTLIER_FILTER_QUESTION));
@@ -142,8 +184,14 @@ ContextState ContextStatisticalOutlierFilter::feedMessage(IMessage* message, Con
 ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 {
     GraphManager& graphManager = controller.getGraphManager();
+    std::filesystem::path effectiveOutputFolder = m_outputFolder;
+    if (!resolveExecutionOutputFolder(controller, m_executionMode, effectiveOutputFolder))
+    {
+        m_state = ContextState::abort;
+        return m_state;
+    }
 
-    if (!prepareOutputDirectory(controller, m_outputFolder))
+    if (!prepareOutputDirectory(controller, effectiveOutputFolder))
     {
         m_state = ContextState::abort;
         return m_state;
@@ -152,6 +200,8 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
     TlStreamLock streamLock;
 
     std::unordered_set<SafePtr<PointCloudNode>> scans = graphManager.getVisibleScans(m_panoramic);
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
+        m_outputFileType = FileType::TLS;
 
     controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString()));
     const uint64_t totalScans = scans.size();
@@ -160,6 +210,12 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 
     ClippingAssembly clippingAssembly;
     graphManager.getClippingAssembly(clippingAssembly, true, false);
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject && !clippingAssembly.empty())
+    {
+        controller.updateInfo(new GuiDataWarning(QString("Apply-on-project with active clipping is scheduled for the next pass.")));
+        m_state = ContextState::abort;
+        return m_state;
+    }
 
     OutlierStats globalStats;
     bool wasAborted = false;
@@ -244,7 +300,7 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         IScanFileWriter* scan_writer = nullptr;
         std::wstring log;
         std::wstring outputName = wScan->getName() + L"_SOF";
-        if (!getScanFileWriter(m_outputFolder, outputName, m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
+        if (!getScanFileWriter(effectiveOutputFolder, outputName, m_outputFileType, log, &scan_writer, true) || scan_writer == nullptr)
             continue;
         tls::ScanHeader header;
         TlScanOverseer::getInstance().getScanHeader(old_guid, header);
@@ -262,6 +318,26 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         bool res = TlScanOverseer::getInstance().filterOutliersAndWrite(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, statsToUse, m_nSigma, m_beta, scan_writer, deleted_point_count, filterProgress);
         res &= scan_writer->finalizePointCloud();
         delete scan_writer;
+        if (res && m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
+        {
+            std::filesystem::path originalScanPath;
+            if (!TlScanOverseer::getInstance().getScanPath(old_guid, originalScanPath))
+            {
+                controller.updateInfo(new GuiDataWarning(QString("Failed to resolve original scan path for in-place update.")));
+                m_state = ContextState::abort;
+                wasAborted = true;
+                break;
+            }
+
+            std::filesystem::path producedPath = effectiveOutputFolder / (outputName + L".tls");
+            if (!replaceScanFileInProject(producedPath, originalScanPath))
+            {
+                controller.updateInfo(new GuiDataWarning(QString("Failed to replace scan file during in-place update.")));
+                m_state = ContextState::abort;
+                wasAborted = true;
+                break;
+            }
+        }
 
         total_deleted_points += deleted_point_count;
 
@@ -285,8 +361,8 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
     controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Total points deleted: %1").arg(total_deleted_points)));
     controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 
-    if (m_openFolderAfterExport && !wasAborted)
-        controller.updateInfo(new GuiDataOpenInExplorer(m_outputFolder));
+    if (m_executionMode == FilterExecutionMode::ExportFilteredAreas && m_openFolderAfterExport && !wasAborted)
+        controller.updateInfo(new GuiDataOpenInExplorer(effectiveOutputFolder));
 
     m_state = wasAborted ? ContextState::abort : ContextState::done;
     return (m_state);

--- a/src/controller/messages/ColorBalanceFilterMessage.cpp
+++ b/src/controller/messages/ColorBalanceFilterMessage.cpp
@@ -1,6 +1,6 @@
 #include "controller/messages/ColorBalanceFilterMessage.h"
 
-ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValue, double trimPercentValue, double sharpnessBlendValue, ColorBalanceMode modeValue, bool applyOnIntensityAndRgbValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue, FilterExecutionMode executionModeValue)
     : kMin(kMinValue)
     , kMax(kMaxValue)
     , trimPercent(trimPercentValue)
@@ -10,6 +10,7 @@ ColorBalanceFilterMessage::ColorBalanceFilterMessage(int kMinValue, int kMaxValu
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
     , openFolderAfterExport(openFolderAfterExportValue)
+    , executionMode(executionModeValue)
 {}
 
 IMessage::MessageType ColorBalanceFilterMessage::getType() const
@@ -19,5 +20,5 @@ IMessage::MessageType ColorBalanceFilterMessage::getType() const
 
 IMessage* ColorBalanceFilterMessage::copy() const
 {
-    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport);
+    return new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, mode, applyOnIntensityAndRgb, outputFileType, outputFolder, openFolderAfterExport, executionMode);
 }

--- a/src/controller/messages/StatisticalOutlierFilterMessage.cpp
+++ b/src/controller/messages/StatisticalOutlierFilterMessage.cpp
@@ -1,6 +1,6 @@
 #include "controller/messages/StatisticalOutlierFilterMessage.h"
 
-StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue)
+StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsValue, double nSigmaValue, int samplingPercentValue, double betaValue, OutlierFilterMode modeValue, FileType outputFileTypeValue, const std::wstring& outputFolderValue, bool openFolderAfterExportValue, FilterExecutionMode executionModeValue)
     : kNeighbors(kNeighborsValue)
     , nSigma(nSigmaValue)
     , samplingPercent(samplingPercentValue)
@@ -9,6 +9,7 @@ StatisticalOutlierFilterMessage::StatisticalOutlierFilterMessage(int kNeighborsV
     , outputFileType(outputFileTypeValue)
     , outputFolder(outputFolderValue)
     , openFolderAfterExport(openFolderAfterExportValue)
+    , executionMode(executionModeValue)
 {}
 
 IMessage::MessageType StatisticalOutlierFilterMessage::getType() const
@@ -18,5 +19,5 @@ IMessage::MessageType StatisticalOutlierFilterMessage::getType() const
 
 IMessage* StatisticalOutlierFilterMessage::copy() const
 {
-    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, outputFileType, outputFolder, openFolderAfterExport);
+    return new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, mode, outputFileType, outputFolder, openFolderAfterExport, executionMode);
 }

--- a/src/gui/Dialog/DialogColorBalanceFilter.cpp
+++ b/src/gui/Dialog/DialogColorBalanceFilter.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QSignalBlocker>
 #include <QtCore/QStandardPaths>
 #include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMessageBox>
 
 #include <unordered_map>
 #include <vector>
@@ -158,6 +159,20 @@ DialogColorBalanceFilter::DialogColorBalanceFilter(IDataDispatcher& dataDispatch
     {
         m_applyOnIntensityAndRgb = checked;
     });
+    connect(m_ui.radioButton_applyOnCurrentProject, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ApplyOnCurrentProject;
+        updateExecutionModeUi();
+    });
+    connect(m_ui.radioButton_exportFilteredAreas, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ExportFilteredAreas;
+        updateExecutionModeUi();
+    });
 
     m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
     m_dataDispatcher.registerObserverOnKey(this, guiDType::colorBalanceFilterDialogDisplay);
@@ -197,11 +212,25 @@ void DialogColorBalanceFilter::informData(IGuiData* data)
 
 void DialogColorBalanceFilter::startBalancing()
 {
-    m_outputFolder = m_ui.lineEdit_folder->text().toStdWString();
-    if (m_outputFolder.empty())
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
     {
-        m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_NO_DIRECTORY_SELECTED));
-        return;
+        // Passe 2: explicit irreversible warning before in-place execution.
+        const auto answer = QMessageBox::warning(this,
+            tr("Apply filter on current project"),
+            tr("This action will modify the current project scans and cannot be undone.\nDo you want to continue?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+        if (answer != QMessageBox::Yes)
+            return;
+    }
+    else
+    {
+        m_outputFolder = m_ui.lineEdit_folder->text().toStdWString();
+        if (m_outputFolder.empty())
+        {
+            m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_NO_DIRECTORY_SELECTED));
+            return;
+        }
     }
 
     int kMin = m_ui.spinBox_kMin->value();
@@ -212,7 +241,7 @@ void DialogColorBalanceFilter::startBalancing()
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
     bool applyOnIntensityAndRgb = m_ui.checkBox_balanceIntensityRGB->isChecked();
 
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new ColorBalanceFilterMessage(kMin, kMax, trimPercent, sharpnessBlend, m_mode, applyOnIntensityAndRgb, m_outputFileType, m_outputFolder, openFolder, m_executionMode)));
 
     hide();
 }
@@ -278,7 +307,22 @@ void DialogColorBalanceFilter::syncUiFromValues()
     if (formatIndex >= 0)
         m_ui.comboBox_file_format->setCurrentIndex(formatIndex);
 
+    m_ui.radioButton_applyOnCurrentProject->setChecked(m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
+    m_ui.radioButton_exportFilteredAreas->setChecked(m_executionMode == FilterExecutionMode::ExportFilteredAreas);
+    updateExecutionModeUi();
+
     m_ui.checkBox_balanceIntensityRGB->setEnabled(m_rgbAndIntensityAvailable);
+}
+
+void DialogColorBalanceFilter::updateExecutionModeUi()
+{
+    const bool exportMode = m_executionMode == FilterExecutionMode::ExportFilteredAreas;
+    m_ui.label_format->setEnabled(exportMode);
+    m_ui.comboBox_file_format->setEnabled(exportMode);
+    m_ui.label_folder->setEnabled(exportMode);
+    m_ui.lineEdit_folder->setEnabled(exportMode);
+    m_ui.toolButton_folder->setEnabled(exportMode);
+    m_ui.checkBox_openFolderAfterExport->setEnabled(exportMode);
 }
 
 void DialogColorBalanceFilter::updateAvailability(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable)

--- a/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
+++ b/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QSignalBlocker>
 #include <QtCore/qstandardpaths.h>
 #include <QtWidgets/qfiledialog.h>
+#include <QtWidgets/QMessageBox>
 
 #include <vector>
 
@@ -109,6 +110,20 @@ DialogStatisticalOutlierFilter::DialogStatisticalOutlierFilter(IDataDispatcher& 
     {
         m_beta = value;
     });
+    connect(m_ui.radioButton_applyOnCurrentProject, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ApplyOnCurrentProject;
+        updateExecutionModeUi();
+    });
+    connect(m_ui.radioButton_exportFilteredAreas, &QRadioButton::toggled, this, [this](bool checked)
+    {
+        if (!checked)
+            return;
+        m_executionMode = FilterExecutionMode::ExportFilteredAreas;
+        updateExecutionModeUi();
+    });
 
     m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
     m_dataDispatcher.registerObserverOnKey(this, guiDType::statisticalOutlierFilterDialogDisplay);
@@ -142,11 +157,25 @@ void DialogStatisticalOutlierFilter::informData(IGuiData* data)
 
 void DialogStatisticalOutlierFilter::startFiltering()
 {
-    m_outputFolder = m_ui.lineEdit_folder->text().toStdWString();
-    if (m_outputFolder.empty())
+    if (m_executionMode == FilterExecutionMode::ApplyOnCurrentProject)
     {
-        m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_NO_DIRECTORY_SELECTED));
-        return;
+        // Passe 2: explicit irreversible warning before in-place execution.
+        const auto answer = QMessageBox::warning(this,
+            tr("Apply filter on current project"),
+            tr("This action will modify the current project scans and cannot be undone.\nDo you want to continue?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+        if (answer != QMessageBox::Yes)
+            return;
+    }
+    else
+    {
+        m_outputFolder = m_ui.lineEdit_folder->text().toStdWString();
+        if (m_outputFolder.empty())
+        {
+            m_dataDispatcher.updateInformation(new GuiDataWarning(TEXT_NO_DIRECTORY_SELECTED));
+            return;
+        }
     }
 
     int kNeighbors = m_ui.spinBox_kNeighbors->value();
@@ -156,7 +185,7 @@ void DialogStatisticalOutlierFilter::startFiltering()
     m_outputFileType = static_cast<FileType>(m_ui.comboBox_file_format->currentData().toInt());
 
     bool openFolder = m_ui.checkBox_openFolderAfterExport->isChecked();
-    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_outputFileType, m_outputFolder, openFolder)));
+    m_dataDispatcher.sendControl(new control::function::ForwardMessage(new StatisticalOutlierFilterMessage(kNeighbors, nSigma, samplingPercent, beta, m_mode, m_outputFileType, m_outputFolder, openFolder, m_executionMode)));
 
     hide();
 }
@@ -228,4 +257,19 @@ void DialogStatisticalOutlierFilter::syncUiFromValues()
     int formatIndex = m_ui.comboBox_file_format->findData(QVariant(static_cast<int>(m_outputFileType)));
     if (formatIndex >= 0)
         m_ui.comboBox_file_format->setCurrentIndex(formatIndex);
+
+    m_ui.radioButton_applyOnCurrentProject->setChecked(m_executionMode == FilterExecutionMode::ApplyOnCurrentProject);
+    m_ui.radioButton_exportFilteredAreas->setChecked(m_executionMode == FilterExecutionMode::ExportFilteredAreas);
+    updateExecutionModeUi();
+}
+
+void DialogStatisticalOutlierFilter::updateExecutionModeUi()
+{
+    const bool exportMode = m_executionMode == FilterExecutionMode::ExportFilteredAreas;
+    m_ui.label_format->setEnabled(exportMode);
+    m_ui.comboBox_file_format->setEnabled(exportMode);
+    m_ui.label_folder->setEnabled(exportMode);
+    m_ui.lineEdit_folder->setEnabled(exportMode);
+    m_ui.toolButton_folder->setEnabled(exportMode);
+    m_ui.checkBox_openFolderAfterExport->setEnabled(exportMode);
 }

--- a/src/gui/forms/DialogColorBalanceFilter.ui
+++ b/src/gui/forms/DialogColorBalanceFilter.ui
@@ -215,6 +215,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_execution">
+     <property name="title">
+      <string>Filtering execution</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_execution">
+      <item>
+       <widget class="QRadioButton" name="radioButton_applyOnCurrentProject">
+        <property name="text">
+         <string>Apply filter on current project</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButton_exportFilteredAreas">
+        <property name="text">
+         <string>Export filtered areas</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_folder">
      <item row="0" column="0">
       <widget class="QLabel" name="label_format">

--- a/src/gui/forms/DialogStatisticalOutlierFilter.ui
+++ b/src/gui/forms/DialogStatisticalOutlierFilter.ui
@@ -185,6 +185,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_execution">
+     <property name="title">
+      <string>Filtering execution</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_execution">
+      <item>
+       <widget class="QRadioButton" name="radioButton_applyOnCurrentProject">
+        <property name="text">
+         <string>Apply filter on current project</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButton_exportFilteredAreas">
+        <property name="text">
+         <string>Export filtered areas</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_folder">
      <item row="0" column="0">
       <widget class="QLabel" name="label_format">


### PR DESCRIPTION
### Motivation

- Provide a way to choose between exporting filtered results to a folder or applying filters directly on the current project scans, enabling an "in-place" workflow in addition to the existing export behavior.

### Description

- Introduces a new enum `FilterExecutionMode` and propagates an `executionMode` field through `*FilterMessage` classes, contexts and dialogs to carry the user selection.
- Adds UI controls (radio group) to `DialogColorBalanceFilter` and `DialogStatisticalOutlierFilter` and disables/enables format/folder controls depending on the selected mode, including an irreversible confirmation dialog when choosing apply-on-project.
- Implements `resolveExecutionOutputFolder` to route in-place executions to a temporary workspace and `replaceScanFileInProject` to atomically replace original scan files with produced results (with backup/restore on failure), and integrates these into `ContextColorBalanceFilter` and `ContextStatisticalOutlierFilter` flows; uses an `effectiveOutputFolder` for writers and only opens explorer when exporting.
- Adds safety checks that abort apply-on-project when active clipping is present and forces TLS output file type for in-place mode; keeps default behavior set to `ExportFilteredAreas`.

### Testing

- Project compiled successfully after the changes.
- The automated unit test suite was executed and completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa15199f84832fb034f225d38baa6d)