### PR TITLE
Add SOF pre-analysis and subdivision-shadow decision to outlier filtering pipeline

### DIFF
--- a/include/pointCloudEngine/EmbeddedScan.h
+++ b/include/pointCloudEngine/EmbeddedScan.h
@@ -117,6 +117,7 @@ public:
     // For File Clipping
     bool testPointsClippedOut(const TransformationModule& src_transfo, const ClippingAssembly& _clippingAssembly) const;
     bool clipAndWrite(const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, IScanFileWriter* writer, const ProgressCallback& progress = {});
+    bool computeOutlierPreAnalysis(const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, int kNeighbors, int samplingPercent, double beta, SofPreAnalysisStats& preAnalysis, const ProgressCallback& progress = {});
     bool computeOutlierStats(const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, int kNeighbors, int samplingPercent, double beta, OutlierStats& stats, const ProgressCallback& progress = {});
     bool filterOutliersAndWrite(const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, int kNeighbors, const OutlierStats& stats, double nSigma, double beta, IScanFileWriter* writer, uint64_t& removedPoints, const ProgressCallback& progress = {});
     bool filterAndWrite(const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, const ColorimetricFilterSettings& colorimetricSettings, const PolygonalSelectorSettings& polygonalSelectorSettings, UiRenderMode mode, IScanFileWriter* writer, uint64_t& keptPoints, const ProgressCallback& progress = {});

--- a/include/pointCloudEngine/OutlierStats.h
+++ b/include/pointCloudEngine/OutlierStats.h
@@ -10,4 +10,40 @@ struct OutlierStats
     double stddev = 0.0;
 };
 
+enum class SofPreAnalysisRiskClass
+{
+    Low,
+    Borderline,
+    High
+};
+
+enum class SofPreAnalysisAction
+{
+    NoSubdivision,
+    SubdivisionRecommended
+};
+
+struct SofPreAnalysisStats
+{
+    uint64_t occupiedCells = 0;
+    uint64_t testedPointsEstimate = 0;
+    double spacingMean = 0.0;
+    double spacingStddev = 0.0;
+    double spacingCv = 0.0;
+    double meanDistanceMean = 0.0;
+    double meanDistanceStddev = 0.0;
+    double meanDistanceCv = 0.0;
+    double interZoneVarMeanDistance = 0.0;
+    double interZoneVarSpacing = 0.0;
+    double nonEmptyZoneRatio = 0.0;
+    double riskScore = 0.0;
+    SofPreAnalysisRiskClass riskClass = SofPreAnalysisRiskClass::Low;
+    SofPreAnalysisAction recommendedAction = SofPreAnalysisAction::NoSubdivision;
+    bool subdivisionShadowEnabled = false;
+    uint32_t subdivisionShadowFactor = 1;
+    uint32_t subdivisionShadowSubBoxCount = 1;
+    double subdivisionShadowHalo = 0.0;
+    uint32_t subdivisionShadowFallbackSubBoxCount = 0;
+};
+
 #endif

--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -229,6 +229,7 @@ public:
     // Compute
     bool testClippingEffect(tls::ScanGuid scanGuid, const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly);
     bool clipScan(tls::ScanGuid scanGuid, const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, IScanFileWriter* outScan, const ProgressCallback& progress = {});
+    bool computeOutlierPreAnalysis(tls::ScanGuid scanGuid, const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, int kNeighbors, int samplingPercent, double beta, SofPreAnalysisStats& preAnalysis, const ProgressCallback& progress = {});
     bool computeOutlierStats(tls::ScanGuid scanGuid, const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, int kNeighbors, int samplingPercent, double beta, OutlierStats& stats, const ProgressCallback& progress = {});
     bool filterOutliersAndWrite(tls::ScanGuid scanGuid, const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, int kNeighbors, const OutlierStats& stats, double nSigma, double beta, IScanFileWriter* outScan, uint64_t& removedPoints, const ProgressCallback& progress = {});
     bool filterAndWrite(tls::ScanGuid scanGuid, const TransformationModule& modelMat, const ClippingAssembly& clippingAssembly, const ColorimetricFilterSettings& colorimetricSettings, const PolygonalSelectorSettings& polygonalSelectorSettings, UiRenderMode mode, IScanFileWriter* outScan, uint64_t& keptPoints, const ProgressCallback& progress = {});

--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -28,6 +28,40 @@
 
 namespace
 {
+    struct SofSubdivisionShadowConfig
+    {
+        bool enabled = false;
+        uint32_t factor = 1;
+        uint32_t subBoxCount = 1;
+        double haloMeters = 0.0;
+        uint32_t fallbackSubBoxCount = 0;
+    };
+
+    SofSubdivisionShadowConfig buildSubdivisionShadowConfig(const SofPreAnalysisStats& preAnalysis)
+    {
+        // Passe 2A: décision conservative en "shadow mode" uniquement.
+        SofSubdivisionShadowConfig config;
+        config.enabled = preAnalysis.riskClass == SofPreAnalysisRiskClass::High;
+        if (!config.enabled)
+            return config;
+
+        // Facteur borné pour éviter les explosions de coûts dès la passe d'ossature.
+        const uint32_t maxFactor = 4;
+        uint32_t suggestedFactor = preAnalysis.testedPointsEstimate > 50000000 ? 4 : 2;
+        config.factor = std::clamp(suggestedFactor, 2u, maxFactor);
+        config.subBoxCount = config.factor * config.factor * config.factor;
+
+        // Halo "proxy" basé sur les métriques existantes. La valeur n'est pas encore appliquée au filtre.
+        config.haloMeters = std::clamp(preAnalysis.spacingMean * 2.0, 0.01, 1.0);
+
+        // Fallback planifié (non exécuté en 2A) pour sous-zones peu peuplées.
+        uint32_t minPointsPerSubBox = 5000;
+        double avgPointsPerSubBox = static_cast<double>(std::max<uint64_t>(preAnalysis.testedPointsEstimate, 1)) / static_cast<double>(config.subBoxCount);
+        if (avgPointsPerSubBox < static_cast<double>(minPointsPerSubBox))
+            config.fallbackSubBoxCount = config.subBoxCount;
+        return config;
+    }
+
     struct RunningStats
     {
         uint64_t count = 0;
@@ -195,6 +229,12 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 
     uint64_t scan_count = 0;
     uint64_t total_deleted_points = 0;
+    uint64_t preAnalysisLowCount = 0;
+    uint64_t preAnalysisBorderlineCount = 0;
+    uint64_t preAnalysisHighCount = 0;
+    uint64_t subdivisionShadowEnabledCount = 0;
+    uint64_t subdivisionShadowFallbackCount = 0;
+    double preAnalysisRiskScoreSum = 0.0;
     auto updateProgress = [&](uint64_t scansDone, int percent, uint64_t progressValue)
     {
         QString state = QString("%1 - %2%")
@@ -240,6 +280,39 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         uint64_t deleted_point_count = 0;
         std::chrono::steady_clock::time_point startTime = std::chrono::steady_clock::now();
         tls::ScanGuid old_guid = wScan->getScanGuid();
+        QString qScanName = QString::fromStdWString(wScan->getName());
+
+        auto preAnalysisStart = std::chrono::steady_clock::now();
+        SofPreAnalysisStats preAnalysis;
+        TlScanOverseer::getInstance().computeOutlierPreAnalysis(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, m_samplingPercent, m_beta, preAnalysis);
+        SofSubdivisionShadowConfig subdivisionShadow = buildSubdivisionShadowConfig(preAnalysis);
+        preAnalysis.subdivisionShadowEnabled = subdivisionShadow.enabled;
+        preAnalysis.subdivisionShadowFactor = subdivisionShadow.factor;
+        preAnalysis.subdivisionShadowSubBoxCount = subdivisionShadow.subBoxCount;
+        preAnalysis.subdivisionShadowHalo = subdivisionShadow.haloMeters;
+        preAnalysis.subdivisionShadowFallbackSubBoxCount = subdivisionShadow.fallbackSubBoxCount;
+        float preAnalysisSeconds = std::chrono::duration<float, std::ratio<1>>(std::chrono::steady_clock::now() - preAnalysisStart).count();
+        preAnalysisRiskScoreSum += preAnalysis.riskScore;
+        if (preAnalysis.subdivisionShadowEnabled)
+        {
+            ++subdivisionShadowEnabledCount;
+            if (preAnalysis.subdivisionShadowFallbackSubBoxCount > 0)
+                ++subdivisionShadowFallbackCount;
+        }
+        switch (preAnalysis.riskClass)
+        {
+        case SofPreAnalysisRiskClass::Low:
+            ++preAnalysisLowCount;
+            break;
+        case SofPreAnalysisRiskClass::Borderline:
+            ++preAnalysisBorderlineCount;
+            break;
+        case SofPreAnalysisRiskClass::High:
+            ++preAnalysisHighCount;
+            break;
+        default:
+            break;
+        }
 
         IScanFileWriter* scan_writer = nullptr;
         std::wstring log;
@@ -252,13 +325,27 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         scan_writer->appendPointCloud(header, wScan->getTransformation());
 
         OutlierStats statsToUse = globalStats;
-        if (!m_globalFiltering)
+        const bool forceLocalStatsForHighRisk = preAnalysis.subdivisionShadowEnabled;
+        if (!m_globalFiltering || forceLocalStatsForHighRisk)
         {
             auto statsProgress = makeProgressCallback(scan_count, 0, 50);
             TlScanOverseer::getInstance().computeOutlierStats(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, m_samplingPercent, m_beta, statsToUse, statsProgress);
+
+            // Passe 2B: fallback de sécurité vers les stats globales si l'échantillon local est insuffisant.
+            const uint64_t minLocalSampleCount = 500;
+            if (forceLocalStatsForHighRisk && statsToUse.count < minLocalSampleCount)
+            {
+                uint64_t localSampleCount = statsToUse.count;
+                statsToUse = globalStats;
+                controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(
+                    QString("SOF fallback to global stats for scan %1 (local samples=%2 < %3)")
+                        .arg(qScanName)
+                        .arg(localSampleCount)
+                        .arg(minLocalSampleCount)));
+            }
         }
 
-        auto filterProgress = makeProgressCallback(scan_count, m_globalFiltering ? 0 : 50, m_globalFiltering ? 100 : 50);
+        auto filterProgress = makeProgressCallback(scan_count, (m_globalFiltering && !forceLocalStatsForHighRisk) ? 0 : 50, (m_globalFiltering && !forceLocalStatsForHighRisk) ? 100 : 50);
         bool res = TlScanOverseer::getInstance().filterOutliersAndWrite(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, statsToUse, m_nSigma, m_beta, scan_writer, deleted_point_count, filterProgress);
         res &= scan_writer->finalizePointCloud();
         delete scan_writer;
@@ -267,13 +354,29 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 
         scan_count++;
         float seconds = std::chrono::duration<float, std::ratio<1>>(std::chrono::steady_clock::now() - startTime).count();
-        QString qScanName = QString::fromStdWString(wScan->getName());
         updateProgress(scan_count, 100, scan_count * 100);
 
         if (deleted_point_count > 0)
             controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("%1 points deleted in scan %2 in %3 seconds.").arg(deleted_point_count).arg(qScanName).arg(seconds)));
         else
             controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Scan %1 not affected by outlier filter.").arg(qScanName)));
+
+        QString preAnalysisAction = preAnalysis.recommendedAction == SofPreAnalysisAction::SubdivisionRecommended
+            ? "SUBDIVISION_RECOMMENDED"
+            : "NO_SUBDIVISION";
+        controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(
+            QString("SOF pre-analysis %1: risk=%2, action=%3, occupiedCells=%4, testedPoints=%5, time=%6s, subdivisionShadow=%7 factor=%8 subBoxes=%9 halo=%10 fallbackSubBoxes=%11")
+                .arg(qScanName)
+                .arg(preAnalysis.riskScore, 0, 'f', 3)
+                .arg(preAnalysisAction)
+                .arg(preAnalysis.occupiedCells)
+                .arg(preAnalysis.testedPointsEstimate)
+                .arg(preAnalysisSeconds, 0, 'f', 3)
+                .arg(preAnalysis.subdivisionShadowEnabled ? "ON" : "OFF")
+                .arg(preAnalysis.subdivisionShadowFactor)
+                .arg(preAnalysis.subdivisionShadowSubBoxCount)
+                .arg(preAnalysis.subdivisionShadowHalo, 0, 'f', 3)
+                .arg(preAnalysis.subdivisionShadowFallbackSubBoxCount)));
 
         if (m_state != ContextState::running)
         {
@@ -283,6 +386,14 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
     }
 
     controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("Total points deleted: %1").arg(total_deleted_points)));
+    double averageRisk = scan_count > 0 ? preAnalysisRiskScoreSum / static_cast<double>(scan_count) : 0.0;
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF pre-analysis summary: LOW=%1 BORDERLINE=%2 HIGH=%3 avgRisk=%4 subdivisionShadowEnabled=%5 fallbackPlanned=%6")
+        .arg(preAnalysisLowCount)
+        .arg(preAnalysisBorderlineCount)
+        .arg(preAnalysisHighCount)
+        .arg(averageRisk, 0, 'f', 3)
+        .arg(subdivisionShadowEnabledCount)
+        .arg(subdivisionShadowFallbackCount)));
     controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 
     if (m_openFolderAfterExport && !wasAborted)

--- a/src/pointCloudEngine/EmbeddedScan.cpp
+++ b/src/pointCloudEngine/EmbeddedScan.cpp
@@ -554,6 +554,34 @@ namespace
         }
     };
 
+    double safeCv(double mean, double stddev)
+    {
+        constexpr double kEpsilon = 1e-9;
+        if (std::abs(mean) <= kEpsilon)
+            return 0.0;
+        return stddev / std::abs(mean);
+    }
+
+    double clamp01(double value)
+    {
+        return std::clamp(value, 0.0, 1.0);
+    }
+
+    const char* toRiskClassString(SofPreAnalysisRiskClass riskClass)
+    {
+        switch (riskClass)
+        {
+        case SofPreAnalysisRiskClass::Low:
+            return "LOW";
+        case SofPreAnalysisRiskClass::Borderline:
+            return "BORDERLINE";
+        case SofPreAnalysisRiskClass::High:
+            return "HIGH";
+        default:
+            return "UNKNOWN";
+        }
+    }
+
     std::shared_ptr<IClippingGeometry> cloneClippingGeometry(const std::shared_ptr<IClippingGeometry>& geometry)
     {
         if (!geometry)
@@ -1007,6 +1035,152 @@ bool EmbeddedScan::computeOutlierStats(const TransformationModule& src_transfo, 
     stats.count = running.count;
     stats.mean = running.mean;
     stats.stddev = running.stddev();
+
+    return true;
+}
+
+bool EmbeddedScan::computeOutlierPreAnalysis(const TransformationModule& src_transfo, const ClippingAssembly& clippingAssembly, int kNeighbors, int samplingPercent, double beta, SofPreAnalysisStats& preAnalysis, const ProgressCallback& progress)
+{
+    // Passe 1 (shadow mode) : on calcule des indicateurs robustes sans modifier la logique SOF existante.
+    ClippingAssembly localAssembly = deepCopyClippingAssembly(clippingAssembly);
+    localAssembly.clearMatrix();
+    glm::dmat4 src_transfo_mat = src_transfo.getTransformation();
+    localAssembly.addTransformation(src_transfo_mat);
+
+    std::vector<std::pair<uint32_t, bool>> cells;
+    getClippedCells_impl(m_uRootCell, localAssembly, cells);
+
+    const size_t neighborCount = std::max(1, kNeighbors);
+    const double samplingValue = std::clamp(static_cast<double>(samplingPercent), 1.0, 100.0);
+    const size_t sampleStep = std::max<size_t>(1, static_cast<size_t>(std::round(100.0 / samplingValue)));
+    const size_t totalCells = cells.size();
+
+    if (progress && totalCells > 0)
+        progress(0, totalCells);
+
+    RunningStats spacingStats;
+    RunningStats meanDistanceStats;
+    RunningStats zoneMeanDistanceStats;
+    RunningStats zoneSpacingStats;
+
+    uint64_t nonEmptyZones = 0;
+    uint64_t totalZones = 0;
+    uint64_t testedPointsEstimate = 0;
+    uint64_t occupiedCells = 0;
+
+    for (size_t cellIndex = 0; cellIndex < cells.size(); ++cellIndex)
+    {
+        const std::pair<uint32_t, bool>& cell = cells[cellIndex];
+        std::vector<PointXYZIRGB> points;
+        points.resize(tls_point_cloud_.getCellPointCount(cell.first));
+        if (!getCellPointsThreadSafe(cell.first, reinterpret_cast<tls::Point*>(points.data()), points.size()))
+        {
+            if (progress)
+                progress(cellIndex + 1, totalCells);
+            continue;
+        }
+
+        std::vector<PointXYZIRGB> visiblePoints;
+        if (cell.second)
+            clipIndividualPoints(points, visiblePoints, localAssembly);
+        else
+            visiblePoints.swap(points);
+
+        totalZones++;
+        if (visiblePoints.empty())
+        {
+            if (progress)
+                progress(cellIndex + 1, totalCells);
+            continue;
+        }
+
+        occupiedCells++;
+        nonEmptyZones++;
+        testedPointsEstimate += static_cast<uint64_t>(visiblePoints.size());
+
+        glm::dvec3 cellOrigin(m_vTreeCells[cell.first].m_position[0], m_vTreeCells[cell.first].m_position[1], m_vTreeCells[cell.first].m_position[2]);
+        double cellSize = m_vTreeCells[cell.first].m_size;
+        double avgSpacing = std::cbrt((cellSize * cellSize * cellSize) / std::max<size_t>(visiblePoints.size(), 1));
+        double voxelSize = std::max(cellSize / 128.0, avgSpacing * 2.0);
+        double maxRadius = std::clamp(beta * avgSpacing, cellSize / 8.0, cellSize);
+
+        spacingStats.add(avgSpacing);
+
+        std::vector<glm::dvec3> localPoints;
+        localPoints.reserve(visiblePoints.size());
+        for (const PointXYZIRGB& point : visiblePoints)
+            localPoints.emplace_back(point.x, point.y, point.z);
+
+        std::unordered_map<int64_t, std::vector<size_t>> grid;
+        grid.reserve(localPoints.size());
+        for (size_t i = 0; i < localPoints.size(); ++i)
+        {
+            GridIndex index = computeGridIndex(localPoints[i], cellOrigin, voxelSize);
+            grid[packGridIndex(index)].push_back(i);
+        }
+
+        RunningStats zoneMeanDistance;
+        for (size_t i = 0; i < localPoints.size(); i += sampleStep)
+        {
+            double meanDistance = 0.0;
+            if (computeMeanNeighborDistanceGrid(localPoints, grid, cellOrigin, voxelSize, i, neighborCount, maxRadius, meanDistance))
+            {
+                meanDistanceStats.add(meanDistance);
+                zoneMeanDistance.add(meanDistance);
+            }
+        }
+
+        if (zoneMeanDistance.count > 0)
+            zoneMeanDistanceStats.add(zoneMeanDistance.mean);
+        zoneSpacingStats.add(avgSpacing);
+
+        if (progress)
+            progress(cellIndex + 1, totalCells);
+    }
+
+    preAnalysis.occupiedCells = occupiedCells;
+    preAnalysis.testedPointsEstimate = testedPointsEstimate;
+    preAnalysis.spacingMean = spacingStats.mean;
+    preAnalysis.spacingStddev = spacingStats.stddev();
+    preAnalysis.spacingCv = safeCv(preAnalysis.spacingMean, preAnalysis.spacingStddev);
+    preAnalysis.meanDistanceMean = meanDistanceStats.mean;
+    preAnalysis.meanDistanceStddev = meanDistanceStats.stddev();
+    preAnalysis.meanDistanceCv = safeCv(preAnalysis.meanDistanceMean, preAnalysis.meanDistanceStddev);
+    preAnalysis.interZoneVarMeanDistance = zoneMeanDistanceStats.stddev() * zoneMeanDistanceStats.stddev();
+    preAnalysis.interZoneVarSpacing = zoneSpacingStats.stddev() * zoneSpacingStats.stddev();
+    preAnalysis.nonEmptyZoneRatio = totalZones == 0 ? 0.0 : static_cast<double>(nonEmptyZones) / static_cast<double>(totalZones);
+
+    const double sSpacing = clamp01((preAnalysis.spacingCv - 0.30) / 0.70);
+    const double sMeanDistance = clamp01((preAnalysis.meanDistanceCv - 0.30) / 0.70);
+    const double sInterZone = clamp01((std::sqrt(std::max(0.0, preAnalysis.interZoneVarMeanDistance)) - 0.02) / 0.08);
+    const double sSparse = clamp01((0.60 - preAnalysis.nonEmptyZoneRatio) / 0.60);
+    const double logPoints = std::log10(static_cast<double>(std::max<uint64_t>(preAnalysis.testedPointsEstimate, 1)));
+    const double sScale = clamp01((logPoints - 5.0) / 2.0);
+
+    preAnalysis.riskScore = 0.25 * sSpacing + 0.25 * sMeanDistance + 0.25 * sInterZone + 0.15 * sSparse + 0.10 * sScale;
+
+    if (preAnalysis.riskScore >= 0.60)
+        preAnalysis.riskClass = SofPreAnalysisRiskClass::High;
+    else if (preAnalysis.riskScore >= 0.45)
+        preAnalysis.riskClass = SofPreAnalysisRiskClass::Borderline;
+    else
+        preAnalysis.riskClass = SofPreAnalysisRiskClass::Low;
+
+    preAnalysis.recommendedAction = (preAnalysis.riskScore >= 0.60)
+        ? SofPreAnalysisAction::SubdivisionRecommended
+        : SofPreAnalysisAction::NoSubdivision;
+
+    Logger::log(LoggerMode::IOLog)
+        << "SOF_PRE_ANALYSIS"
+        << " occupiedCells=" << preAnalysis.occupiedCells
+        << " testedPointsEstimate=" << preAnalysis.testedPointsEstimate
+        << " spacingCv=" << preAnalysis.spacingCv
+        << " meanDistanceCv=" << preAnalysis.meanDistanceCv
+        << " interZoneVarMeanDistance=" << preAnalysis.interZoneVarMeanDistance
+        << " nonEmptyZoneRatio=" << preAnalysis.nonEmptyZoneRatio
+        << " riskScore=" << preAnalysis.riskScore
+        << " riskClass=" << toRiskClassString(preAnalysis.riskClass)
+        << Logger::endl;
 
     return true;
 }

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -636,6 +636,27 @@ bool TlScanOverseer::computeOutlierStats(tls::ScanGuid _scanGuid, const Transfor
     return scan->computeOutlierStats(_modelMat, _clippingAssembly, kNeighbors, samplingPercent, beta, stats, progress);
 }
 
+bool TlScanOverseer::computeOutlierPreAnalysis(tls::ScanGuid _scanGuid, const TransformationModule& _modelMat, const ClippingAssembly& _clippingAssembly, int kNeighbors, int samplingPercent, double beta, SofPreAnalysisStats& preAnalysis, const ProgressCallback& progress)
+{
+    EmbeddedScan* scan;
+    {
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+
+        auto it_scan = m_activeScans.find(_scanGuid);
+        if (it_scan == m_activeScans.end())
+        {
+            Logger::log(VKLog) << "Error: try to view a Scan not present, UUID = " << _scanGuid << Logger::endl;
+            return false;
+        }
+        else
+        {
+            scan = it_scan->second;
+        }
+    }
+
+    return scan->computeOutlierPreAnalysis(_modelMat, _clippingAssembly, kNeighbors, samplingPercent, beta, preAnalysis, progress);
+}
+
 bool TlScanOverseer::filterOutliersAndWrite(tls::ScanGuid _scanGuid, const TransformationModule& _modelMat, const ClippingAssembly& _clippingAssembly, int kNeighbors, const OutlierStats& stats, double nSigma, double beta, IScanFileWriter* _outScan, uint64_t& removedPoints, const ProgressCallback& progress)
 {
     EmbeddedScan* scan;


### PR DESCRIPTION
### Motivation
- Provide a fast pre-analysis step for the Statistical Outlier Filter (SOF) to detect scans/regions at risk of poor sampling and recommend subdivision before running the full SOF pass.
- Enable conservative "subdivision shadow" decisions to force local stats in high-risk cases while keeping a safe fallback to global statistics if the local sample is insufficient.
- Collect and expose metrics useful for logging, diagnostics and future adaptive filtering improvements.

### Description
- Introduced `SofPreAnalysisRiskClass`, `SofPreAnalysisAction` and `SofPreAnalysisStats` in `OutlierStats.h` to carry pre-analysis metrics and recommendations.
- Added `EmbeddedScan::computeOutlierPreAnalysis` declaration in `EmbeddedScan.h` and implemented it in `EmbeddedScan.cpp` to compute spacing/mean-distance statistics, inter-zone variance, non-empty zone ratio and a composite `riskScore` and classification; includes helpers `safeCv`, `clamp01` and `toRiskClassString` and logs the result.
- Added `TlScanOverseer::computeOutlierPreAnalysis` forwarding method in `TlScanOverseer.cpp` to call the scan implementation under the active-scan lock.
- Updated `ContextStatisticalOutlierFilter::launch` to call the pre-analysis for each scan, build a `SofSubdivisionShadowConfig` (conservative subdivision shadow decision), annotate `SofPreAnalysisStats` with planned subdivision parameters, force local stats for high-risk scans, and implement a safety fallback to global stats when the local sample count is too small; added summary logging and counters.
- Adjusted progress callbacks and log messages to include pre-analysis timing, risk, recommended action and subdivision planning details.

### Testing
- Project compiled successfully after the changes (`build` completed without errors).
- Existing automated unit/integration test suite was executed and completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcac6a909c832fa98e37750f791719)