### PR TITLE
Add high-risk execution gate and bounded local aggressiveness to SOF pipeline

### DIFF
--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -121,6 +121,76 @@ namespace
         return result;
     }
 
+
+    struct SofHighRiskExecutionGuard
+    {
+        bool fallbackToParentScan = false;
+        bool fallbackDueToSparsePlanning = false;
+        bool fallbackDueToTimeBudget = false;
+        bool fallbackDueToRepeatedInstability = false;
+    };
+
+    SofHighRiskExecutionGuard buildHighRiskExecutionGuard(const SofPreAnalysisStats& preAnalysis, float preAnalysisSeconds)
+    {
+        SofHighRiskExecutionGuard guard;
+
+        // 2B.B-2: scan-level guardrails before full sub-box execution is enabled.
+        const uint32_t maxSubBoxes = 64;
+        const double minEstimatedPointsPerSubBox = 5000.0;
+        const double minDenseRatio = 0.10;
+        const float preAnalysisTimeBudgetSeconds = 20.0f;
+
+        if (preAnalysis.subdivisionShadowSubBoxCount > maxSubBoxes)
+            guard.fallbackDueToSparsePlanning = true;
+
+        if (preAnalysis.subdivisionShadowEstimatedPointsPerSubBox < minEstimatedPointsPerSubBox ||
+            preAnalysis.subdivisionShadowEstimatedDenseSubBoxRatio < minDenseRatio ||
+            preAnalysis.subdivisionShadowFallbackSubBoxCount > 0)
+        {
+            guard.fallbackDueToSparsePlanning = true;
+        }
+
+        if (preAnalysisSeconds > preAnalysisTimeBudgetSeconds)
+            guard.fallbackDueToTimeBudget = true;
+
+        guard.fallbackToParentScan =
+            guard.fallbackDueToSparsePlanning ||
+            guard.fallbackDueToTimeBudget ||
+            guard.fallbackDueToRepeatedInstability;
+
+        return guard;
+    }
+
+    struct SofHighRiskAggressiveness
+    {
+        bool active = false;
+        double delta = 0.0;
+        double heterogeneityScore = 0.0;
+    };
+
+    SofHighRiskAggressiveness buildHighRiskAggressiveness(const SofPreAnalysisStats& preAnalysis, bool enableHighRiskExecution, bool fallbackToParentScan)
+    {
+        SofHighRiskAggressiveness result;
+        if (!enableHighRiskExecution || fallbackToParentScan)
+            return result;
+
+        // 2B.B-3: activate local aggressiveness only for heterogeneous HIGH scans.
+        const double heterogeneityScore = std::clamp(0.5 * preAnalysis.spacingCv + 0.5 * preAnalysis.meanDistanceCv, 0.0, 4.0);
+        const bool heterogeneous = heterogeneityScore >= 0.65;
+        if (!heterogeneous)
+            return result;
+
+        result.active = true;
+        result.heterogeneityScore = heterogeneityScore;
+
+        // Bounded dynamic delta to avoid global over-hardening.
+        const double minDelta = 0.10;
+        const double maxDelta = 0.25;
+        const double normalized = std::clamp((heterogeneityScore - 0.65) / 1.50, 0.0, 1.0);
+        result.delta = std::clamp(minDelta + normalized * (maxDelta - minDelta), minDelta, maxDelta);
+        return result;
+    }
+
     struct RunningStats
     {
         uint64_t count = 0;
@@ -294,6 +364,9 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
     uint64_t subdivisionShadowEnabledCount = 0;
     uint64_t subdivisionShadowFallbackCount = 0;
     double preAnalysisRiskScoreSum = 0.0;
+    uint64_t highRiskInstabilityFallbackCount = 0;
+    uint64_t highRiskAggressivenessActiveCount = 0;
+    double highRiskAggressivenessDeltaSum = 0.0;
     auto updateProgress = [&](uint64_t scansDone, int percent, uint64_t progressValue)
     {
         QString state = QString("%1 - %2%")
@@ -358,6 +431,11 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         preAnalysis.subdivisionShadowEstimatedPointsPerSubBox = spatialDiag.estimatedPointsPerSubBox;
         preAnalysis.subdivisionShadowEstimatedDenseSubBoxRatio = spatialDiag.estimatedDenseSubBoxRatio;
         const float preAnalysisSeconds = preAnalysisRun.durationSeconds;
+        SofHighRiskExecutionGuard highRiskGuard = buildHighRiskExecutionGuard(preAnalysis, preAnalysisSeconds);
+        SofHighRiskAggressiveness highRiskAggressiveness = buildHighRiskAggressiveness(
+            preAnalysis,
+            preAnalysis.riskClass == SofPreAnalysisRiskClass::High,
+            highRiskGuard.fallbackToParentScan);
         preAnalysisRiskScoreSum += preAnalysis.riskScore;
         if (preAnalysis.subdivisionShadowEnabled)
         {
@@ -392,6 +470,7 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 
         OutlierStats statsToUse = globalStats;
         const bool forceLocalStatsForHighRisk = preAnalysis.subdivisionShadowEnabled;
+        const bool enableHighRiskSubdivisionExecution = preAnalysis.riskClass == SofPreAnalysisRiskClass::High;
         if (!m_globalFiltering || forceLocalStatsForHighRisk)
         {
             auto statsProgress = makeProgressCallback(scan_count, 0, 50);
@@ -411,8 +490,26 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
             }
         }
 
+        // 2B.B-1 execution gate (HIGH only): keep the classic pipeline for LOW/BORDERLINE.
+        // NOTE: full spatial subdivision (core/work halo ownership) is introduced incrementally in next passes.
+        double effectiveNSigma = m_nSigma;
+        if (enableHighRiskSubdivisionExecution && !highRiskGuard.fallbackToParentScan)
+        {
+            // 2B.B-3: apply bounded local aggressiveness only on heterogeneous HIGH-risk scans.
+            if (highRiskAggressiveness.active)
+            {
+                effectiveNSigma = std::max(0.1, m_nSigma - highRiskAggressiveness.delta);
+                ++highRiskAggressivenessActiveCount;
+                highRiskAggressivenessDeltaSum += highRiskAggressiveness.delta;
+            }
+        }
+        else if (enableHighRiskSubdivisionExecution && highRiskGuard.fallbackToParentScan)
+        {
+            ++highRiskInstabilityFallbackCount;
+        }
+
         auto filterProgress = makeProgressCallback(scan_count, (m_globalFiltering && !forceLocalStatsForHighRisk) ? 0 : 50, (m_globalFiltering && !forceLocalStatsForHighRisk) ? 100 : 50);
-        bool res = TlScanOverseer::getInstance().filterOutliersAndWrite(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, statsToUse, m_nSigma, m_beta, scan_writer, deleted_point_count, filterProgress);
+        bool res = TlScanOverseer::getInstance().filterOutliersAndWrite(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, statsToUse, effectiveNSigma, m_beta, scan_writer, deleted_point_count, filterProgress);
         res &= scan_writer->finalizePointCloud();
         delete scan_writer;
 
@@ -448,6 +545,20 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
                 .arg(preAnalysis.subdivisionShadowEstimatedPointsPerSubBox, 0, 'f', 1)
                 .arg(preAnalysis.subdivisionShadowEstimatedDenseSubBoxRatio, 0, 'f', 3)));
 
+        if (enableHighRiskSubdivisionExecution)
+        {
+            controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(
+                QString("SOF high-risk execution gate for scan %1 (effectiveNSigma=%2, fallbackParent=%3, sparsePlan=%4, timeBudget=%5, localAggressive=%6, delta=%7, heterogeneity=%8)")
+                    .arg(qScanName)
+                    .arg(effectiveNSigma, 0, 'f', 3)
+                    .arg(highRiskGuard.fallbackToParentScan ? "YES" : "NO")
+                    .arg(highRiskGuard.fallbackDueToSparsePlanning ? "YES" : "NO")
+                    .arg(highRiskGuard.fallbackDueToTimeBudget ? "YES" : "NO")
+                    .arg(highRiskAggressiveness.active ? "YES" : "NO")
+                    .arg(highRiskAggressiveness.delta, 0, 'f', 3)
+                    .arg(highRiskAggressiveness.heterogeneityScore, 0, 'f', 3)));
+        }
+
         if (m_state != ContextState::running)
         {
             wasAborted = true;
@@ -464,6 +575,11 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         .arg(averageRisk, 0, 'f', 3)
         .arg(subdivisionShadowEnabledCount)
         .arg(subdivisionShadowFallbackCount)));
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF high-risk parent fallback count: %1").arg(highRiskInstabilityFallbackCount)));
+    const double avgHighRiskDelta = highRiskAggressivenessActiveCount > 0 ? highRiskAggressivenessDeltaSum / static_cast<double>(highRiskAggressivenessActiveCount) : 0.0;
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF high-risk local aggressiveness: active=%1 avgDelta=%2")
+        .arg(highRiskAggressivenessActiveCount)
+        .arg(avgHighRiskDelta, 0, 'f', 3)));
     controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 
     if (m_openFolderAfterExport && !wasAborted)


### PR DESCRIPTION
### Motivation
- Introduce safer, scan-level guardrails and controlled local aggressiveness when handling HIGH-risk scans detected by the SOF pre-analysis to avoid instability and excessive computation during subdivision execution.
- Provide telemetry counters and log messages to observe fallback conditions and applied local aggressiveness for high-risk cases.

### Description
- Add `SofHighRiskExecutionGuard` and `SofHighRiskAggressiveness` types and helper builders `buildHighRiskExecutionGuard` and `buildHighRiskAggressiveness` to evaluate pre-analysis results and decide fallbacks and bounded aggressiveness based on metrics such as subdivisions, estimated points per sub-box, heterogeneity score, and pre-analysis time budget.
- Integrate guard and aggressiveness into `ContextStatisticalOutlierFilter::launch` by computing `highRiskGuard` and `highRiskAggressiveness`, deriving an `effectiveNSigma`, and passing `effectiveNSigma` to `filterOutliersAndWrite` instead of the original `m_nSigma` when appropriate.
- Add counters `highRiskInstabilityFallbackCount`, `highRiskAggressivenessActiveCount`, and `highRiskAggressivenessDeltaSum` and emit detailed runtime logs about the high-risk execution gate and applied aggressiveness.
- Preserve existing fallback to global statistics for insufficient local samples and keep the LOW/BORDERLINE pipeline unchanged while enabling the new logic only for HIGH-risk scans.

### Testing
- Built the project (`cmake` / build) to ensure the code compiles successfully in the modified translation unit. 
- Executed the automated test suite using `ctest` and observed all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf640412c832fb3112ea278b26bdc)