### PR TITLE
SOF: add high-risk execution gate, adaptive aggressiveness, and experimental borderline mode

### DIFF
--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -121,6 +121,115 @@ namespace
         return result;
     }
 
+
+    struct Sof2CCalibration
+    {
+        // 2C-1: HIGH-only calibration constants (BORDERLINE remains unchanged/off).
+        uint32_t maxSubBoxes = 64;
+        double minEstimatedPointsPerSubBox = 3000.0;
+        double minDenseRatio = 0.08;
+        float preAnalysisTimeBudgetSeconds = 20.0f;
+
+        double heterogeneityActivationThreshold = 0.68;
+        double heterogeneityNormalizationSpan = 1.75;
+        double localDeltaMin = 0.12;
+        double localDeltaMax = 0.22;
+        double nSigmaFloor = 0.22;
+
+        // 2C-3: BORDERLINE remains OFF by default; optional experimental gate.
+        bool enableBorderlineExperimental = false;
+        double borderlineRiskScoreThreshold = 0.55;
+        double borderlineDeltaScale = 0.60;
+    };
+
+    struct SofHighRiskExecutionGuard
+    {
+        bool fallbackToParentScan = false;
+        bool fallbackDueToSparsePlanning = false;
+        bool fallbackDueToTimeBudget = false;
+        bool fallbackDueToRepeatedInstability = false;
+        double sparseSeverity = 0.0;
+    };
+
+    SofHighRiskExecutionGuard buildHighRiskExecutionGuard(const SofPreAnalysisStats& preAnalysis, float preAnalysisSeconds, const Sof2CCalibration& calibration)
+    {
+        SofHighRiskExecutionGuard guard;
+
+        // 2B.B-2: scan-level guardrails before full sub-box execution is enabled.
+        if (preAnalysis.subdivisionShadowSubBoxCount > calibration.maxSubBoxes)
+            guard.fallbackDueToSparsePlanning = true;
+
+        const bool lowEstimatedPoints = preAnalysis.subdivisionShadowEstimatedPointsPerSubBox < calibration.minEstimatedPointsPerSubBox;
+        const bool lowDenseRatio = preAnalysis.subdivisionShadowEstimatedDenseSubBoxRatio < calibration.minDenseRatio;
+        const double fallbackSubBoxRatio = preAnalysis.subdivisionShadowSubBoxCount > 0
+            ? static_cast<double>(preAnalysis.subdivisionShadowFallbackSubBoxCount) / static_cast<double>(preAnalysis.subdivisionShadowSubBoxCount)
+            : 0.0;
+
+        // 2C-2: avoid binary OR-only behavior; fallback only if sparse signals are materially combined.
+        guard.sparseSeverity = 0.0;
+        if (lowEstimatedPoints)
+            guard.sparseSeverity += 0.45;
+        if (lowDenseRatio)
+            guard.sparseSeverity += 0.35;
+        if (fallbackSubBoxRatio > 0.0)
+            guard.sparseSeverity += std::clamp(fallbackSubBoxRatio, 0.0, 1.0) * 0.40;
+
+        if ((lowEstimatedPoints && lowDenseRatio) || fallbackSubBoxRatio >= 0.50 || guard.sparseSeverity >= 0.75)
+            guard.fallbackDueToSparsePlanning = true;
+
+        if (preAnalysisSeconds > calibration.preAnalysisTimeBudgetSeconds)
+            guard.fallbackDueToTimeBudget = true;
+
+        guard.fallbackToParentScan =
+            guard.fallbackDueToSparsePlanning ||
+            guard.fallbackDueToTimeBudget ||
+            guard.fallbackDueToRepeatedInstability;
+
+        return guard;
+    }
+
+    struct SofHighRiskAggressiveness
+    {
+        bool active = false;
+        double delta = 0.0;
+        double heterogeneityScore = 0.0;
+    };
+
+    SofHighRiskAggressiveness buildHighRiskAggressiveness(const SofPreAnalysisStats& preAnalysis, bool enableHighRiskExecution, bool fallbackToParentScan, const Sof2CCalibration& calibration)
+    {
+        SofHighRiskAggressiveness result;
+        if (!enableHighRiskExecution || fallbackToParentScan)
+            return result;
+
+        // 2B.B-3: activate local aggressiveness only for heterogeneous HIGH scans.
+        const double heterogeneityScore = std::clamp(0.5 * preAnalysis.spacingCv + 0.5 * preAnalysis.meanDistanceCv, 0.0, 4.0);
+        const bool heterogeneous = heterogeneityScore >= calibration.heterogeneityActivationThreshold;
+        if (!heterogeneous)
+            return result;
+
+        result.active = true;
+        result.heterogeneityScore = heterogeneityScore;
+
+        // Bounded dynamic delta to avoid global over-hardening.
+        const double normalized = std::clamp((heterogeneityScore - calibration.heterogeneityActivationThreshold) / calibration.heterogeneityNormalizationSpan, 0.0, 1.0);
+        result.delta = std::clamp(calibration.localDeltaMin + normalized * (calibration.localDeltaMax - calibration.localDeltaMin), calibration.localDeltaMin, calibration.localDeltaMax);
+        return result;
+    }
+
+
+
+    bool isExperimentalBorderlineEnabled(const SofPreAnalysisStats& preAnalysis, const Sof2CCalibration& calibration)
+    {
+        // 2C-3 experimental policy: keep BORDERLINE off by default.
+        if (!calibration.enableBorderlineExperimental)
+            return false;
+
+        if (preAnalysis.riskClass != SofPreAnalysisRiskClass::Borderline)
+            return false;
+
+        return preAnalysis.riskScore >= calibration.borderlineRiskScoreThreshold;
+    }
+
     struct RunningStats
     {
         uint64_t count = 0;
@@ -286,14 +395,22 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         globalStats = runningStats.toStats();
     }
 
+    const Sof2CCalibration sof2CCalibration;
+
     uint64_t scan_count = 0;
     uint64_t total_deleted_points = 0;
     uint64_t preAnalysisLowCount = 0;
     uint64_t preAnalysisBorderlineCount = 0;
     uint64_t preAnalysisHighCount = 0;
+    uint64_t preAnalysisBorderlineExperimentalEligibleCount = 0;
     uint64_t subdivisionShadowEnabledCount = 0;
     uint64_t subdivisionShadowFallbackCount = 0;
     double preAnalysisRiskScoreSum = 0.0;
+    uint64_t highRiskInstabilityFallbackCount = 0;
+    uint64_t highRiskAggressivenessActiveCount = 0;
+    double highRiskAggressivenessDeltaSum = 0.0;
+    double highRiskAdaptiveDeltaScale = 1.0;
+    uint64_t highRiskAdaptiveBackoffTriggerCount = 0;
     auto updateProgress = [&](uint64_t scansDone, int percent, uint64_t progressValue)
     {
         QString state = QString("%1 - %2%")
@@ -358,6 +475,16 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         preAnalysis.subdivisionShadowEstimatedPointsPerSubBox = spatialDiag.estimatedPointsPerSubBox;
         preAnalysis.subdivisionShadowEstimatedDenseSubBoxRatio = spatialDiag.estimatedDenseSubBoxRatio;
         const float preAnalysisSeconds = preAnalysisRun.durationSeconds;
+        SofHighRiskExecutionGuard highRiskGuard = buildHighRiskExecutionGuard(preAnalysis, preAnalysisSeconds, sof2CCalibration);
+        SofHighRiskAggressiveness highRiskAggressiveness = buildHighRiskAggressiveness(
+            preAnalysis,
+            preAnalysis.riskClass == SofPreAnalysisRiskClass::High,
+            highRiskGuard.fallbackToParentScan,
+            sof2CCalibration);
+        const bool borderlineExperimentalEnabled = isExperimentalBorderlineEnabled(preAnalysis, sof2CCalibration);
+        if (borderlineExperimentalEnabled)
+            ++preAnalysisBorderlineExperimentalEligibleCount;
+
         preAnalysisRiskScoreSum += preAnalysis.riskScore;
         if (preAnalysis.subdivisionShadowEnabled)
         {
@@ -392,6 +519,8 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
 
         OutlierStats statsToUse = globalStats;
         const bool forceLocalStatsForHighRisk = preAnalysis.subdivisionShadowEnabled;
+        const bool enableHighRiskSubdivisionExecution = preAnalysis.riskClass == SofPreAnalysisRiskClass::High;
+        const bool enableBorderlineExperimentalExecution = borderlineExperimentalEnabled;
         if (!m_globalFiltering || forceLocalStatsForHighRisk)
         {
             auto statsProgress = makeProgressCallback(scan_count, 0, 50);
@@ -411,8 +540,35 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
             }
         }
 
+        // 2B.B-1 execution gate (HIGH only): keep the classic pipeline for LOW/BORDERLINE.
+        // NOTE: full spatial subdivision (core/work halo ownership) is introduced incrementally in next passes.
+        double effectiveNSigma = m_nSigma;
+        if (enableHighRiskSubdivisionExecution && !highRiskGuard.fallbackToParentScan)
+        {
+            // 2B.B-3: apply bounded local aggressiveness only on heterogeneous HIGH-risk scans.
+            if (highRiskAggressiveness.active)
+            {
+                const double adaptedDelta = highRiskAggressiveness.delta * highRiskAdaptiveDeltaScale;
+                effectiveNSigma = std::max(sof2CCalibration.nSigmaFloor, m_nSigma - adaptedDelta);
+                ++highRiskAggressivenessActiveCount;
+                highRiskAggressivenessDeltaSum += highRiskAggressiveness.delta;
+            }
+        }
+        else if (enableHighRiskSubdivisionExecution && highRiskGuard.fallbackToParentScan)
+        {
+            ++highRiskInstabilityFallbackCount;
+        }
+
+        if (enableBorderlineExperimentalExecution)
+        {
+            // 2C-3 experimental branch: lighter-than-HIGH local hardening for near-HIGH borderline scans.
+            const double highLikeDelta = std::clamp(highRiskAggressiveness.delta, sof2CCalibration.localDeltaMin, sof2CCalibration.localDeltaMax);
+            const double borderlineDelta = highLikeDelta * sof2CCalibration.borderlineDeltaScale;
+            effectiveNSigma = std::max(sof2CCalibration.nSigmaFloor, m_nSigma - borderlineDelta);
+        }
+
         auto filterProgress = makeProgressCallback(scan_count, (m_globalFiltering && !forceLocalStatsForHighRisk) ? 0 : 50, (m_globalFiltering && !forceLocalStatsForHighRisk) ? 100 : 50);
-        bool res = TlScanOverseer::getInstance().filterOutliersAndWrite(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, statsToUse, m_nSigma, m_beta, scan_writer, deleted_point_count, filterProgress);
+        bool res = TlScanOverseer::getInstance().filterOutliersAndWrite(old_guid, (TransformationModule)*&wScan, *clippingToUse, m_kNeighbors, statsToUse, effectiveNSigma, m_beta, scan_writer, deleted_point_count, filterProgress);
         res &= scan_writer->finalizePointCloud();
         delete scan_writer;
 
@@ -448,6 +604,45 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
                 .arg(preAnalysis.subdivisionShadowEstimatedPointsPerSubBox, 0, 'f', 1)
                 .arg(preAnalysis.subdivisionShadowEstimatedDenseSubBoxRatio, 0, 'f', 3)));
 
+        if (enableHighRiskSubdivisionExecution)
+        {
+            controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(
+                QString("SOF high-risk execution gate for scan %1 (effectiveNSigma=%2, fallbackParent=%3, sparsePlan=%4, timeBudget=%5, localAggressive=%6, delta=%7, heterogeneity=%8)")
+                    .arg(qScanName)
+                    .arg(effectiveNSigma, 0, 'f', 3)
+                    .arg(highRiskGuard.fallbackToParentScan ? "YES" : "NO")
+                    .arg(highRiskGuard.fallbackDueToSparsePlanning ? "YES" : "NO")
+                    .arg(highRiskGuard.fallbackDueToTimeBudget ? "YES" : "NO")
+                    .arg(highRiskAggressiveness.active ? "YES" : "NO")
+                    .arg(highRiskAggressiveness.delta, 0, 'f', 3)
+                    .arg(highRiskAggressiveness.heterogeneityScore, 0, 'f', 3)));
+            controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(
+                QString("SOF high-risk diagnostics for scan %1 (adaptiveDeltaScale=%2, sparseSeverity=%3)")
+                    .arg(qScanName)
+                    .arg(highRiskAdaptiveDeltaScale, 0, 'f', 3)
+                    .arg(highRiskGuard.sparseSeverity, 0, 'f', 3)));
+        }
+
+
+        if (enableHighRiskSubdivisionExecution)
+        {
+            // 2C-2: adaptive safe-backoff if fallback happened and removal is still weak.
+            const double removalRatio = initial_point_count > 0
+                ? static_cast<double>(deleted_point_count) / static_cast<double>(initial_point_count)
+                : 0.0;
+            if (highRiskGuard.fallbackToParentScan && removalRatio < 0.004)
+            {
+                // 2C short pass 1: faster backoff to protect sparse/remote zones from over-removal.
+                highRiskAdaptiveDeltaScale = std::clamp(highRiskAdaptiveDeltaScale - 0.15, 0.55, 1.00);
+                ++highRiskAdaptiveBackoffTriggerCount;
+            }
+            else if (!highRiskGuard.fallbackToParentScan && removalRatio > 0.015)
+            {
+                // Recovery is intentionally slower than backoff to keep conservative behavior sticky.
+                highRiskAdaptiveDeltaScale = std::clamp(highRiskAdaptiveDeltaScale + 0.03, 0.55, 1.00);
+            }
+        }
+
         if (m_state != ContextState::running)
         {
             wasAborted = true;
@@ -464,6 +659,25 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
         .arg(averageRisk, 0, 'f', 3)
         .arg(subdivisionShadowEnabledCount)
         .arg(subdivisionShadowFallbackCount)));
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF high-risk parent fallback count: %1").arg(highRiskInstabilityFallbackCount)));
+    const double avgHighRiskDelta = highRiskAggressivenessActiveCount > 0 ? highRiskAggressivenessDeltaSum / static_cast<double>(highRiskAggressivenessActiveCount) : 0.0;
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF 2C calibration: minPtsPerSubBox=%1 minDenseRatio=%2 heterogeneityThreshold=%3 deltaRange=[%4,%5]")
+        .arg(sof2CCalibration.minEstimatedPointsPerSubBox, 0, 'f', 0)
+        .arg(sof2CCalibration.minDenseRatio, 0, 'f', 3)
+        .arg(sof2CCalibration.heterogeneityActivationThreshold, 0, 'f', 3)
+        .arg(sof2CCalibration.localDeltaMin, 0, 'f', 3)
+        .arg(sof2CCalibration.localDeltaMax, 0, 'f', 3)));
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF borderline experimental mode: enabled=%1 eligibleScans=%2 threshold=%3 deltaScale=%4")
+        .arg(sof2CCalibration.enableBorderlineExperimental ? "YES" : "NO")
+        .arg(preAnalysisBorderlineExperimentalEligibleCount)
+        .arg(sof2CCalibration.borderlineRiskScoreThreshold, 0, 'f', 3)
+        .arg(sof2CCalibration.borderlineDeltaScale, 0, 'f', 3)));
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF high-risk adaptive backoff: scale=%1 triggers=%2")
+        .arg(highRiskAdaptiveDeltaScale, 0, 'f', 3)
+        .arg(highRiskAdaptiveBackoffTriggerCount)));
+    controller.updateInfo(new GuiDataProcessingSplashScreenLogUpdate(QString("SOF high-risk local aggressiveness: active=%1 avgDelta=%2")
+        .arg(highRiskAggressivenessActiveCount)
+        .arg(avgHighRiskDelta, 0, 'f', 3)));
     controller.updateInfo(new GuiDataProcessingSplashScreenEnd(TEXT_SPLASH_SCREEN_DONE));
 
     if (m_openFolderAfterExport && !wasAborted)


### PR DESCRIPTION
### Motivation
- Improve robustness of the Statistical Outlier Filter (SOF) when processing HIGH-risk scans by preventing overly aggressive spatial subdivision on sparse/unstable data. 
- Provide a bounded, locally-adaptive hardening mechanism for heterogeneous HIGH scans while keeping BORDERLINE mode off by default and offering an experimental lighter branch. 
- Add diagnostics and adaptive backoff to track and reduce over-removal when fallback to parent scan occurs.

### Description
- Introduce `Sof2CCalibration`, `SofHighRiskExecutionGuard`, `SofHighRiskAggressiveness` and helper builders (`buildHighRiskExecutionGuard`, `buildHighRiskAggressiveness`, `isExperimentalBorderlineEnabled`) to encapsulate calibration, guardrail logic and local aggressiveness computation. 
- Compute a `highRiskGuard` and `highRiskAggressiveness` during pre-analysis and derive an `effectiveNSigma` used for local filtering instead of the global `m_nSigma` when applicable. 
- Add an experimental `borderline` execution branch that can apply lighter-than-HIGH hardening when enabled in calibration. 
- Implement adaptive safe-backoff (`highRiskAdaptiveDeltaScale`) to reduce local delta when fallback to parent scan yields very low removal, plus counters and logging for diagnostics (`highRiskInstabilityFallbackCount`, `highRiskAggressivenessActiveCount`, etc.). 
- Replace the direct call using `m_nSigma` with `effectiveNSigma` in `filterOutliersAndWrite` and add multiple informative `controller.updateInfo` log messages reporting per-scan and summary high-risk diagnostics.

### Testing
- Project was built successfully using the standard build system (`cmake` / build target) and compilation errors were resolved. 
- Automated unit test suite (`ctest`) was executed and returned no failures. 
- An automated SOF integration smoke test against a representative sample dataset was run and verified that filtering completes and the new diagnostic logs are produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf640412c832fb3112ea278b26bdc)