### PR TITLE
Add diagnostic logging for point-cloud GUID/path and scan overseer events

### DIFF
--- a/src/models/graph/GraphManager.cpp
+++ b/src/models/graph/GraphManager.cpp
@@ -829,6 +829,17 @@ std::vector<tls::PointCloudInstance> GraphManager::getPointCloudInstances(const 
         result.push_back(tls::PointCloudInstance{ header, transfo, rPc->getClippable(), rPc->getPhase() });
     }
 
+    // Diagnostic trace:
+    // Summarize selected point-cloud instances to correlate tree visibility and runtime scan usage.
+    Logger::log(LoggerMode::IOLog)
+        << "GraphManager::getPointCloudInstances"
+        << " pano=" << pano
+        << " getScans=" << getScans
+        << " getPcos=" << getPcos
+        << " filterStatus=" << static_cast<int>(filterStatus)
+        << " resultCount=" << result.size()
+        << Logger::endl;
+
     return (result);
 }
 

--- a/src/models/graph/PointCloudNode.cpp
+++ b/src/models/graph/PointCloudNode.cpp
@@ -1,6 +1,9 @@
 #include "models/graph/PointCloudNode.h"
 #include "pointCloudEngine/PCE_core.h"
 #include "vulkan/VulkanManager.h"
+#include "utils/Logger.h"
+
+#define IOLog LoggerMode::IOLog
 
 PointCloudNode::PointCloudNode(const PointCloudNode& data)
     : AGraphNode(data)
@@ -52,6 +55,9 @@ std::wstring PointCloudNode::getComposedName() const
 
 void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool init_position, const tls::ScanGuid& scanGuid, bool reset_name)
 {
+    const tls::ScanGuid previousGuid = m_scanGuid;
+    const std::filesystem::path previousPath = backup_file_path_;
+
     if (scanGuid != tls::ScanGuid())
         m_scanGuid = scanGuid;
     else
@@ -66,6 +72,20 @@ void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool 
         setPosition(glm::dvec3(scanHeader.transfo.translation[0], scanHeader.transfo.translation[1], scanHeader.transfo.translation[2]));
         setRotation({ scanHeader.transfo.quaternion[3], scanHeader.transfo.quaternion[0], scanHeader.transfo.quaternion[1], scanHeader.transfo.quaternion[2] });
     }
+
+    // Diagnostic trace:
+    // Keep a concise import/runtime mapping to detect accidental GUID/path aliasing.
+    Logger::log(IOLog)
+        << "PointCloudNode::setTlsFilePath"
+        << " nodeName=\"" << m_name << "\""
+        << " nodeType=" << (is_object_ ? "PCO" : "Scan")
+        << " oldGuid=" << previousGuid
+        << " newGuid=" << m_scanGuid
+        << " oldPath=\"" << previousPath << "\""
+        << " newPath=\"" << scanPath << "\""
+        << " initPosition=" << init_position
+        << " resetName=" << reset_name
+        << Logger::endl;
 }
 
 std::filesystem::path PointCloudNode::getTlsFilePath() const

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -184,6 +184,15 @@ void TlScanOverseer::registerScanPath(tls::ScanGuid scanGuid, const std::filesys
         return;
 
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    auto itExisting = m_scanPathByGuid.find(scanGuid);
+    if (itExisting != m_scanPathByGuid.end() && itExisting->second != scanPath)
+    {
+        // Diagnostic trace:
+        // A single GUID observed on multiple physical paths indicates possible aliasing.
+        Logger::log(IOLog) << "registerScanPath GUID path remap detected guid=" << scanGuid
+            << " oldPath=\"" << itExisting->second << "\" newPath=\"" << scanPath << "\""
+            << Logger::endl;
+    }
     m_scanPathByGuid.insert_or_assign(scanGuid, scanPath);
 }
 
@@ -224,6 +233,15 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     if (it_scan != m_activeScans.end())
     {
         _scanGuid = it_scan->second->getGuid();
+        if (it_scan->second->getPath() != _filePath)
+        {
+            // Diagnostic trace:
+            // Runtime cache hit for the same GUID but different path.
+            Logger::log(IOLog) << "getScanGuid cache-hit GUID/path mismatch guid=" << _scanGuid
+                << " activePath=\"" << it_scan->second->getPath() << "\""
+                << " requestedPath=\"" << _filePath << "\""
+                << Logger::endl;
+        }
         // Keep path registry in sync even on cache hits.
         m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
         // No memory leak
@@ -237,6 +255,9 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
 
     m_activeScans.insert({ newScan->getGuid(), newScan });
     _scanGuid = newScan->getGuid();
+    Logger::log(IOLog) << "getScanGuid activated new scan guid=" << _scanGuid
+        << " path=\"" << _filePath << "\" activeNow=" << m_activeScans.size()
+        << Logger::endl;
     m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
     ++m_guidLookupStats.successCount;
     ++m_guidLookupStats.insertedActiveCount;


### PR DESCRIPTION
### Motivation
- Add lightweight diagnostic traces to help correlate scene tree visibility and runtime scan usage for debugging point-cloud selection and loading issues.
- Detect and record cases of GUID/path aliasing and cache hits where the same GUID is observed on different file paths to surface potential data consistency problems.

### Description
- Added a diagnostic log in `GraphManager::getPointCloudInstances` to emit parameters and the returned instance count for correlation between tree state and runtime scans.
- Added logging to `PointCloudNode::setTlsFilePath` (and included `utils/Logger.h`), capturing previous and new GUID/path and options to detect accidental remaps during import/load.
- Extended `TlScanOverseer` with logs in `registerScanPath` to report GUID->path remaps and in `getScanGuid` to report cache-hit GUID/path mismatches and when a new scan is activated, while keeping the path registry synchronized.
- Kept behavior unchanged aside from adding `Logger` calls and a small `IOLog` define in `PointCloudNode` for consistent logging mode.

### Testing
- Project built successfully after the changes using the normal build system.
- Existing automated tests were executed with `ctest` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3854f730832f99d7139f58513e50)