### PR TITLE
Prevent runtime GUID aliasing for TLS files and add diagnostics

### DIFF
--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -438,6 +438,7 @@ private:
     // Ensure a scan is available in m_activeScans.
     // The caller must hold m_activeMutex.
     bool ensureScanActive_locked(tls::ScanGuid scanGuid);
+    tls::ScanGuid resolveRuntimeGuid_locked(const tls::ScanGuid& fileGuid, const std::filesystem::path& scanPath);
     // Evict deletable active scans until size <= targetMax (excluding preserveGuid).
     void trimActiveScans_locked(size_t targetMax, tls::ScanGuid preserveGuid);
 
@@ -463,6 +464,11 @@ private:
     std::unordered_map<tls::ScanGuid, EmbeddedScan*> m_activeScans;
     // Persistent GUID->path knowledge, independent from currently active runtime scans.
     std::unordered_map<tls::ScanGuid, std::filesystem::path> m_scanPathByGuid;
+    // Hotfix (Pass 2.1):
+    // Keep a stable runtime GUID per absolute path to prevent different files that share
+    // the same TLS header GUID from being merged into a single runtime identity.
+    std::unordered_map<std::string, tls::ScanGuid> m_runtimeGuidByPath;
+    std::unordered_map<tls::ScanGuid, tls::ScanGuid> m_runtimeGuidToFileGuid;
     static thread_local std::vector<WorkingScanInfo> s_workingScansTransfo;
     GuidLookupStats m_guidLookupStats;
 

--- a/src/models/graph/GraphManager.cpp
+++ b/src/models/graph/GraphManager.cpp
@@ -829,6 +829,17 @@ std::vector<tls::PointCloudInstance> GraphManager::getPointCloudInstances(const 
         result.push_back(tls::PointCloudInstance{ header, transfo, rPc->getClippable(), rPc->getPhase() });
     }
 
+    // Diagnostic trace:
+    // Summarize selected point-cloud instances to correlate tree visibility and runtime scan usage.
+    Logger::log(LoggerMode::IOLog)
+        << "GraphManager::getPointCloudInstances"
+        << " pano=" << pano
+        << " getScans=" << getScans
+        << " getPcos=" << getPcos
+        << " filterStatus=" << static_cast<int>(filterStatus)
+        << " resultCount=" << result.size()
+        << Logger::endl;
+
     return (result);
 }
 

--- a/src/models/graph/PointCloudNode.cpp
+++ b/src/models/graph/PointCloudNode.cpp
@@ -1,6 +1,9 @@
 #include "models/graph/PointCloudNode.h"
 #include "pointCloudEngine/PCE_core.h"
 #include "vulkan/VulkanManager.h"
+#include "utils/Logger.h"
+
+#define IOLog LoggerMode::IOLog
 
 PointCloudNode::PointCloudNode(const PointCloudNode& data)
     : AGraphNode(data)
@@ -52,6 +55,9 @@ std::wstring PointCloudNode::getComposedName() const
 
 void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool init_position, const tls::ScanGuid& scanGuid, bool reset_name)
 {
+    const tls::ScanGuid previousGuid = m_scanGuid;
+    const std::filesystem::path previousPath = backup_file_path_;
+
     if (scanGuid != tls::ScanGuid())
         m_scanGuid = scanGuid;
     else
@@ -66,6 +72,20 @@ void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool 
         setPosition(glm::dvec3(scanHeader.transfo.translation[0], scanHeader.transfo.translation[1], scanHeader.transfo.translation[2]));
         setRotation({ scanHeader.transfo.quaternion[3], scanHeader.transfo.quaternion[0], scanHeader.transfo.quaternion[1], scanHeader.transfo.quaternion[2] });
     }
+
+    // Diagnostic trace:
+    // Keep a concise import/runtime mapping to detect accidental GUID/path aliasing.
+    Logger::log(IOLog)
+        << "PointCloudNode::setTlsFilePath"
+        << " nodeName=\"" << m_name << "\""
+        << " nodeType=" << (is_object_ ? "PCO" : "Scan")
+        << " oldGuid=" << previousGuid
+        << " newGuid=" << m_scanGuid
+        << " oldPath=\"" << previousPath << "\""
+        << " newPath=\"" << scanPath << "\""
+        << " initPosition=" << init_position
+        << " resetName=" << reset_name
+        << Logger::endl;
 }
 
 std::filesystem::path PointCloudNode::getTlsFilePath() const

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -82,6 +82,8 @@ void TlScanOverseer::shutdown()
     }
     m_activeScans.clear();
     m_scanPathByGuid.clear();
+    m_runtimeGuidByPath.clear();
+    m_runtimeGuidToFileGuid.clear();
 }
 
 void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingTransfo)
@@ -140,8 +142,23 @@ bool TlScanOverseer::ensureScanActive_locked(tls::ScanGuid scanGuid)
     }
 
     EmbeddedScan* newScan = new EmbeddedScan(itPath->second);
-    if (newScan->getGuid() != scanGuid)
+    tls::ScanGuid expectedFileGuid = scanGuid;
+    auto itRuntimeToFile = m_runtimeGuidToFileGuid.find(scanGuid);
+    if (itRuntimeToFile != m_runtimeGuidToFileGuid.end())
     {
+        // Pass 2.1b hotfix:
+        // Runtime GUIDs may intentionally differ from TLS header GUIDs when collisions
+        // are detected across different files. Validate against the original file GUID.
+        expectedFileGuid = itRuntimeToFile->second;
+    }
+
+    if (newScan->getGuid() != expectedFileGuid)
+    {
+        Logger::log(IOLog) << "ensureScanActive_locked failed: runtimeGuid=" << scanGuid
+            << " expectedFileGuid=" << expectedFileGuid
+            << " actualFileGuid=" << newScan->getGuid()
+            << " path=\"" << itPath->second << "\""
+            << Logger::endl;
         delete newScan;
         return false;
     }
@@ -178,12 +195,55 @@ void TlScanOverseer::trimActiveScans_locked(size_t targetMax, tls::ScanGuid pres
     }
 }
 
+tls::ScanGuid TlScanOverseer::resolveRuntimeGuid_locked(const tls::ScanGuid& fileGuid, const std::filesystem::path& scanPath)
+{
+    if (fileGuid == tls::ScanGuid() || scanPath.empty())
+        return fileGuid;
+
+    const std::string pathKey = scanPath.lexically_normal().string();
+    auto itKnownPath = m_runtimeGuidByPath.find(pathKey);
+    if (itKnownPath != m_runtimeGuidByPath.end())
+        return itKnownPath->second;
+
+    // Check whether the same file GUID is already tied to another path.
+    bool guidAlreadyBoundToOtherPath = false;
+    for (const auto& [knownGuid, knownPath] : m_scanPathByGuid)
+    {
+        if (knownGuid == fileGuid && knownPath != scanPath)
+        {
+            guidAlreadyBoundToOtherPath = true;
+            break;
+        }
+    }
+
+    tls::ScanGuid runtimeGuid = fileGuid;
+    if (guidAlreadyBoundToOtherPath)
+    {
+        runtimeGuid = xg::newGuid();
+        Logger::log(IOLog) << "resolveRuntimeGuid collision: fileGuid=" << fileGuid
+            << " path=\"" << scanPath << "\" runtimeGuid=" << runtimeGuid << Logger::endl;
+    }
+
+    m_runtimeGuidByPath.insert_or_assign(pathKey, runtimeGuid);
+    m_runtimeGuidToFileGuid.insert_or_assign(runtimeGuid, fileGuid);
+    return runtimeGuid;
+}
+
 void TlScanOverseer::registerScanPath(tls::ScanGuid scanGuid, const std::filesystem::path& scanPath)
 {
     if (scanGuid == tls::ScanGuid() || scanPath.empty())
         return;
 
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    auto itExisting = m_scanPathByGuid.find(scanGuid);
+    if (itExisting != m_scanPathByGuid.end() && itExisting->second != scanPath)
+    {
+        // Diagnostic trace:
+        // A single GUID observed on multiple physical paths indicates possible aliasing.
+        Logger::log(IOLog) << "registerScanPath GUID path remap detected guid=" << scanGuid
+            << " oldPath=\"" << itExisting->second << "\" newPath=\"" << scanPath << "\""
+            << Logger::endl;
+    }
     m_scanPathByGuid.insert_or_assign(scanGuid, scanPath);
 }
 
@@ -220,10 +280,20 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     }
 
     std::lock_guard<std::mutex> lock(m_activeMutex);
-    auto it_scan = m_activeScans.find(newScan->getGuid());
+    const tls::ScanGuid runtimeGuid = resolveRuntimeGuid_locked(newScan->getGuid(), _filePath);
+    auto it_scan = m_activeScans.find(runtimeGuid);
     if (it_scan != m_activeScans.end())
     {
-        _scanGuid = it_scan->second->getGuid();
+        _scanGuid = runtimeGuid;
+        if (it_scan->second->getPath() != _filePath)
+        {
+            // Diagnostic trace:
+            // Runtime cache hit for the same GUID but different path.
+            Logger::log(IOLog) << "getScanGuid cache-hit GUID/path mismatch guid=" << _scanGuid
+                << " activePath=\"" << it_scan->second->getPath() << "\""
+                << " requestedPath=\"" << _filePath << "\""
+                << Logger::endl;
+        }
         // Keep path registry in sync even on cache hits.
         m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
         // No memory leak
@@ -235,8 +305,11 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
         return true;
     }
 
-    m_activeScans.insert({ newScan->getGuid(), newScan });
-    _scanGuid = newScan->getGuid();
+    m_activeScans.insert({ runtimeGuid, newScan });
+    _scanGuid = runtimeGuid;
+    Logger::log(IOLog) << "getScanGuid activated new scan guid=" << _scanGuid
+        << " path=\"" << _filePath << "\" activeNow=" << m_activeScans.size()
+        << Logger::endl;
     m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
     ++m_guidLookupStats.successCount;
     ++m_guidLookupStats.insertedActiveCount;
@@ -284,9 +357,13 @@ bool TlScanOverseer::lookupScanGuid(const std::filesystem::path& filePath, tls::
         return false;
     }
 
-    // Pass 2.2.A:
-    // Persist GUID->path knowledge without forcing active runtime registration.
-    registerScanPath(scanGuid, filePath);
+    // Pass 2.1 hotfix:
+    // Normalize runtime identity so different files sharing the same header GUID do not alias.
+    {
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        scanGuid = resolveRuntimeGuid_locked(scanGuid, filePath);
+        m_scanPathByGuid.insert_or_assign(scanGuid, filePath);
+    }
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent different physical TLS files that share the same header GUID from being merged into a single runtime identity by introducing a stable per-path runtime GUID mapping and related diagnostics.
- Improve observability of GUID/path resolution and cache behavior to help diagnose import and visibility issues when many scans are opened.

### Description
- Added runtime GUID maps `m_runtimeGuidByPath` and `m_runtimeGuidToFileGuid` to `TlScanOverseer` and cleared them on `shutdown` to maintain a stable runtime identity per absolute path.
- Introduced `resolveRuntimeGuid_locked` to normalize/translate a file header GUID into a runtime GUID, generating a new runtime GUID on collisions and registering the path->runtime mapping.
- Updated `getScanGuid` and `ensureScanActive_locked` to use the resolved runtime GUID and to log informative diagnostic messages on cache hits, path mismatches, activations, and GUID/path remaps.
- Added logging traces in `PointCloudNode::setTlsFilePath` and `GraphManager::getPointCloudInstances` to record import/runtime mapping and selected point-cloud instance summaries.
- Preserved old behavior where `backup_file_path_` is used as a fallback in `PointCloudNode::getTlsFilePath` when runtime activation is deferred.

### Testing
- Built the project and exercised point-cloud import and lookup flows to validate that `resolveRuntimeGuid_locked` produces distinct runtime GUIDs for distinct file paths and that registrations/log messages occur as expected, with no crashes observed.
- Ran the existing automated test suite and continuous build checks; all tests and checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3854f730832f99d7139f58513e50)