### PR TITLE
Yan wip fix scan export import

### DIFF
--- a/include/pointCloudEngine/TlScanOverseer.h
+++ b/include/pointCloudEngine/TlScanOverseer.h
@@ -438,6 +438,7 @@ private:
     // Ensure a scan is available in m_activeScans.
     // The caller must hold m_activeMutex.
     bool ensureScanActive_locked(tls::ScanGuid scanGuid);
+    tls::ScanGuid resolveRuntimeGuid_locked(const tls::ScanGuid& fileGuid, const std::filesystem::path& scanPath);
     // Evict deletable active scans until size <= targetMax (excluding preserveGuid).
     void trimActiveScans_locked(size_t targetMax, tls::ScanGuid preserveGuid);
 
@@ -463,6 +464,11 @@ private:
     std::unordered_map<tls::ScanGuid, EmbeddedScan*> m_activeScans;
     // Persistent GUID->path knowledge, independent from currently active runtime scans.
     std::unordered_map<tls::ScanGuid, std::filesystem::path> m_scanPathByGuid;
+    // Hotfix (Pass 2.1):
+    // Keep a stable runtime GUID per absolute path to prevent different files that share
+    // the same TLS header GUID from being merged into a single runtime identity.
+    std::unordered_map<std::string, tls::ScanGuid> m_runtimeGuidByPath;
+    std::unordered_map<tls::ScanGuid, tls::ScanGuid> m_runtimeGuidToFileGuid;
     static thread_local std::vector<WorkingScanInfo> s_workingScansTransfo;
     GuidLookupStats m_guidLookupStats;
 

--- a/src/controller/functionSystem/ContextExportPC.cpp
+++ b/src/controller/functionSystem/ContextExportPC.cpp
@@ -245,6 +245,9 @@ ContextType ContextExportPC::getType() const
 
 void ContextExportPC::copyTls(Controller& controller, CopyTask task)
 {
+    // GUID contract (Pass 2.2-B):
+    // This is a physical copy path, so GUID must remain unchanged on purpose.
+    // Only transformation is overwritten after copy.
     try
     {
         std::filesystem::copy(task.src_path, task.dst_path, std::filesystem::copy_options::overwrite_existing);
@@ -539,7 +542,11 @@ void ContextExportPC::prepareTasks(Controller& controller, std::vector<ContextEx
     {
         for (const tls::PointCloudInstance& pcInfo : pcInfos)
         {
-            // Filter out the tls that we can copy
+            // GUID contract (Pass 2.2-B):
+            // Keep pure TLS copy behavior unchanged by design:
+            // - same binary content lineage
+            // - same scan GUID
+            // This path is intentionally excluded from "new GUID on export" rules.
             if (m_parameters.outFileType == FileType::TLS &&
                 pcInfo.header.precision == m_parameters.encodingPrecision &&
                 clipping_assembly.empty())
@@ -574,7 +581,7 @@ void ContextExportPC::prepareTasks(Controller& controller, std::vector<ContextEx
 
                 task.header = pcInfo.header;
                 task.header.name = is_rcp ? task.scan_name : task.file_name;
-                // Pass 2.2-A:
+                // Pass 2.2-A / 2.2-B contract:
                 // Rewritten scan/PCO TLS exports must not keep source GUIDs.
                 // NOTE: pure copy path above intentionally preserves GUID by design.
                 task.header.guid = xg::newGuid();

--- a/src/controller/functionSystem/ContextExportPC.cpp
+++ b/src/controller/functionSystem/ContextExportPC.cpp
@@ -490,6 +490,10 @@ void ContextExportPC::prepareTasks(Controller& controller, std::vector<ContextEx
             }
 
             task.header.name = is_rcp ? task.scan_name : r_clipping->getComposedName();
+            // Pass 2.2-A:
+            // Clipping-based TLS exports must get a fresh scan GUID to avoid reusing
+            // source scan identities across exported files.
+            task.header.guid = xg::newGuid();
             task.header.precision = m_parameters.encodingPrecision;
             task.header.format = common_format;
 
@@ -517,6 +521,9 @@ void ContextExportPC::prepareTasks(Controller& controller, std::vector<ContextEx
         }
 
         task.header.name = is_rcp ? task.scan_name : m_parameters.fileName.wstring();
+        // Pass 2.2-A:
+        // Merged TLS exports are reconstructed outputs and therefore require a new GUID.
+        task.header.guid = xg::newGuid();
         task.header.precision = m_parameters.encodingPrecision;
         task.header.format = common_format;
 
@@ -567,6 +574,10 @@ void ContextExportPC::prepareTasks(Controller& controller, std::vector<ContextEx
 
                 task.header = pcInfo.header;
                 task.header.name = is_rcp ? task.scan_name : task.file_name;
+                // Pass 2.2-A:
+                // Rewritten scan/PCO TLS exports must not keep source GUIDs.
+                // NOTE: pure copy path above intentionally preserves GUID by design.
+                task.header.guid = xg::newGuid();
                 task.header.precision = m_parameters.encodingPrecision;
                 task.header.format = pcInfo.header.format;
 

--- a/src/controller/functionSystem/ContextExportPCGrid.cpp
+++ b/src/controller/functionSystem/ContextExportPCGrid.cpp
@@ -204,6 +204,9 @@ ContextState ContextExportPCGrid::process(Controller& controller)
 
             tls::ScanHeader dstScanHeader;
             dstScanHeader.name = stringStream.str();
+            // Pass 2.2-A:
+            // Grid TLS exports are rebuilt outputs and must use explicit fresh GUIDs.
+            dstScanHeader.guid = xg::newGuid();
             dstScanHeader.transfo = tls::Transformation{ {0, 0, 0, 1}, {boxe.getCenter().x, boxe.getCenter().y, boxe.getCenter().z} };
             // Initialize precision and point count
             dstScanHeader.precision = m_parameters.encodingPrecision;

--- a/src/controller/functionSystem/ContextExportPCGrid.cpp
+++ b/src/controller/functionSystem/ContextExportPCGrid.cpp
@@ -204,8 +204,9 @@ ContextState ContextExportPCGrid::process(Controller& controller)
 
             tls::ScanHeader dstScanHeader;
             dstScanHeader.name = stringStream.str();
-            // Pass 2.2-A:
-            // Grid TLS exports are rebuilt outputs and must use explicit fresh GUIDs.
+            // Pass 2.2-A / 2.2-B contract:
+            // Grid TLS exports are rebuilt outputs and must use explicit fresh GUIDs
+            // (never copied from input scan GUIDs).
             dstScanHeader.guid = xg::newGuid();
             dstScanHeader.transfo = tls::Transformation{ {0, 0, 0, 1}, {boxe.getCenter().x, boxe.getCenter().y, boxe.getCenter().z} };
             // Initialize precision and point count

--- a/src/models/graph/GraphManager.cpp
+++ b/src/models/graph/GraphManager.cpp
@@ -829,6 +829,17 @@ std::vector<tls::PointCloudInstance> GraphManager::getPointCloudInstances(const 
         result.push_back(tls::PointCloudInstance{ header, transfo, rPc->getClippable(), rPc->getPhase() });
     }
 
+    // Diagnostic trace:
+    // Summarize selected point-cloud instances to correlate tree visibility and runtime scan usage.
+    Logger::log(LoggerMode::IOLog)
+        << "GraphManager::getPointCloudInstances"
+        << " pano=" << pano
+        << " getScans=" << getScans
+        << " getPcos=" << getPcos
+        << " filterStatus=" << static_cast<int>(filterStatus)
+        << " resultCount=" << result.size()
+        << Logger::endl;
+
     return (result);
 }
 

--- a/src/models/graph/PointCloudNode.cpp
+++ b/src/models/graph/PointCloudNode.cpp
@@ -1,6 +1,9 @@
 #include "models/graph/PointCloudNode.h"
 #include "pointCloudEngine/PCE_core.h"
 #include "vulkan/VulkanManager.h"
+#include "utils/Logger.h"
+
+#define IOLog LoggerMode::IOLog
 
 PointCloudNode::PointCloudNode(const PointCloudNode& data)
     : AGraphNode(data)
@@ -52,6 +55,9 @@ std::wstring PointCloudNode::getComposedName() const
 
 void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool init_position, const tls::ScanGuid& scanGuid, bool reset_name)
 {
+    const tls::ScanGuid previousGuid = m_scanGuid;
+    const std::filesystem::path previousPath = backup_file_path_;
+
     if (scanGuid != tls::ScanGuid())
         m_scanGuid = scanGuid;
     else
@@ -66,6 +72,20 @@ void PointCloudNode::setTlsFilePath(const std::filesystem::path& scanPath, bool 
         setPosition(glm::dvec3(scanHeader.transfo.translation[0], scanHeader.transfo.translation[1], scanHeader.transfo.translation[2]));
         setRotation({ scanHeader.transfo.quaternion[3], scanHeader.transfo.quaternion[0], scanHeader.transfo.quaternion[1], scanHeader.transfo.quaternion[2] });
     }
+
+    // Diagnostic trace:
+    // Keep a concise import/runtime mapping to detect accidental GUID/path aliasing.
+    Logger::log(IOLog)
+        << "PointCloudNode::setTlsFilePath"
+        << " nodeName=\"" << m_name << "\""
+        << " nodeType=" << (is_object_ ? "PCO" : "Scan")
+        << " oldGuid=" << previousGuid
+        << " newGuid=" << m_scanGuid
+        << " oldPath=\"" << previousPath << "\""
+        << " newPath=\"" << scanPath << "\""
+        << " initPosition=" << init_position
+        << " resetName=" << reset_name
+        << Logger::endl;
 }
 
 std::filesystem::path PointCloudNode::getTlsFilePath() const

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -82,6 +82,8 @@ void TlScanOverseer::shutdown()
     }
     m_activeScans.clear();
     m_scanPathByGuid.clear();
+    m_runtimeGuidByPath.clear();
+    m_runtimeGuidToFileGuid.clear();
 }
 
 void TlScanOverseer::setWorkingScansTransfo(const std::vector<tls::PointCloudInstance>& workingTransfo)
@@ -178,6 +180,40 @@ void TlScanOverseer::trimActiveScans_locked(size_t targetMax, tls::ScanGuid pres
     }
 }
 
+tls::ScanGuid TlScanOverseer::resolveRuntimeGuid_locked(const tls::ScanGuid& fileGuid, const std::filesystem::path& scanPath)
+{
+    if (fileGuid == tls::ScanGuid() || scanPath.empty())
+        return fileGuid;
+
+    const std::string pathKey = scanPath.lexically_normal().string();
+    auto itKnownPath = m_runtimeGuidByPath.find(pathKey);
+    if (itKnownPath != m_runtimeGuidByPath.end())
+        return itKnownPath->second;
+
+    // Check whether the same file GUID is already tied to another path.
+    bool guidAlreadyBoundToOtherPath = false;
+    for (const auto& [knownGuid, knownPath] : m_scanPathByGuid)
+    {
+        if (knownGuid == fileGuid && knownPath != scanPath)
+        {
+            guidAlreadyBoundToOtherPath = true;
+            break;
+        }
+    }
+
+    tls::ScanGuid runtimeGuid = fileGuid;
+    if (guidAlreadyBoundToOtherPath)
+    {
+        runtimeGuid = xg::newGuid();
+        Logger::log(IOLog) << "resolveRuntimeGuid collision: fileGuid=" << fileGuid
+            << " path=\"" << scanPath << "\" runtimeGuid=" << runtimeGuid << Logger::endl;
+    }
+
+    m_runtimeGuidByPath.insert_or_assign(pathKey, runtimeGuid);
+    m_runtimeGuidToFileGuid.insert_or_assign(runtimeGuid, fileGuid);
+    return runtimeGuid;
+}
+
 void TlScanOverseer::registerScanPath(tls::ScanGuid scanGuid, const std::filesystem::path& scanPath)
 {
     if (scanGuid == tls::ScanGuid() || scanPath.empty())
@@ -229,10 +265,11 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     }
 
     std::lock_guard<std::mutex> lock(m_activeMutex);
-    auto it_scan = m_activeScans.find(newScan->getGuid());
+    const tls::ScanGuid runtimeGuid = resolveRuntimeGuid_locked(newScan->getGuid(), _filePath);
+    auto it_scan = m_activeScans.find(runtimeGuid);
     if (it_scan != m_activeScans.end())
     {
-        _scanGuid = it_scan->second->getGuid();
+        _scanGuid = runtimeGuid;
         if (it_scan->second->getPath() != _filePath)
         {
             // Diagnostic trace:
@@ -253,8 +290,8 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
         return true;
     }
 
-    m_activeScans.insert({ newScan->getGuid(), newScan });
-    _scanGuid = newScan->getGuid();
+    m_activeScans.insert({ runtimeGuid, newScan });
+    _scanGuid = runtimeGuid;
     Logger::log(IOLog) << "getScanGuid activated new scan guid=" << _scanGuid
         << " path=\"" << _filePath << "\" activeNow=" << m_activeScans.size()
         << Logger::endl;
@@ -305,9 +342,13 @@ bool TlScanOverseer::lookupScanGuid(const std::filesystem::path& filePath, tls::
         return false;
     }
 
-    // Pass 2.2.A:
-    // Persist GUID->path knowledge without forcing active runtime registration.
-    registerScanPath(scanGuid, filePath);
+    // Pass 2.1 hotfix:
+    // Normalize runtime identity so different files sharing the same header GUID do not alias.
+    {
+        std::lock_guard<std::mutex> lock(m_activeMutex);
+        scanGuid = resolveRuntimeGuid_locked(scanGuid, filePath);
+        m_scanPathByGuid.insert_or_assign(scanGuid, filePath);
+    }
     return true;
 }
 

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -142,8 +142,23 @@ bool TlScanOverseer::ensureScanActive_locked(tls::ScanGuid scanGuid)
     }
 
     EmbeddedScan* newScan = new EmbeddedScan(itPath->second);
-    if (newScan->getGuid() != scanGuid)
+    tls::ScanGuid expectedFileGuid = scanGuid;
+    auto itRuntimeToFile = m_runtimeGuidToFileGuid.find(scanGuid);
+    if (itRuntimeToFile != m_runtimeGuidToFileGuid.end())
     {
+        // Pass 2.1b hotfix:
+        // Runtime GUIDs may intentionally differ from TLS header GUIDs when collisions
+        // are detected across different files. Validate against the original file GUID.
+        expectedFileGuid = itRuntimeToFile->second;
+    }
+
+    if (newScan->getGuid() != expectedFileGuid)
+    {
+        Logger::log(IOLog) << "ensureScanActive_locked failed: runtimeGuid=" << scanGuid
+            << " expectedFileGuid=" << expectedFileGuid
+            << " actualFileGuid=" << newScan->getGuid()
+            << " path=\"" << itPath->second << "\""
+            << Logger::endl;
         delete newScan;
         return false;
     }

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -184,6 +184,15 @@ void TlScanOverseer::registerScanPath(tls::ScanGuid scanGuid, const std::filesys
         return;
 
     std::lock_guard<std::mutex> lock(m_activeMutex);
+    auto itExisting = m_scanPathByGuid.find(scanGuid);
+    if (itExisting != m_scanPathByGuid.end() && itExisting->second != scanPath)
+    {
+        // Diagnostic trace:
+        // A single GUID observed on multiple physical paths indicates possible aliasing.
+        Logger::log(IOLog) << "registerScanPath GUID path remap detected guid=" << scanGuid
+            << " oldPath=\"" << itExisting->second << "\" newPath=\"" << scanPath << "\""
+            << Logger::endl;
+    }
     m_scanPathByGuid.insert_or_assign(scanGuid, scanPath);
 }
 
@@ -224,6 +233,15 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
     if (it_scan != m_activeScans.end())
     {
         _scanGuid = it_scan->second->getGuid();
+        if (it_scan->second->getPath() != _filePath)
+        {
+            // Diagnostic trace:
+            // Runtime cache hit for the same GUID but different path.
+            Logger::log(IOLog) << "getScanGuid cache-hit GUID/path mismatch guid=" << _scanGuid
+                << " activePath=\"" << it_scan->second->getPath() << "\""
+                << " requestedPath=\"" << _filePath << "\""
+                << Logger::endl;
+        }
         // Keep path registry in sync even on cache hits.
         m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
         // No memory leak
@@ -237,6 +255,9 @@ bool TlScanOverseer::getScanGuid(std::filesystem::path _filePath, tls::ScanGuid&
 
     m_activeScans.insert({ newScan->getGuid(), newScan });
     _scanGuid = newScan->getGuid();
+    Logger::log(IOLog) << "getScanGuid activated new scan guid=" << _scanGuid
+        << " path=\"" << _filePath << "\" activeNow=" << m_activeScans.size()
+        << Logger::endl;
     m_scanPathByGuid.insert_or_assign(_scanGuid, _filePath);
     ++m_guidLookupStats.successCount;
     ++m_guidLookupStats.insertedActiveCount;


### PR DESCRIPTION
Issue description: clipped scans that were exported and then re-imported were causing duplicate GUID issues. This fix analysed the various export types and corrected the GUID to prevent duplicates. The only case where the GUID remains the same is when scans are copied (copyTLS).