### PR TITLE
Add filter output mode and filtering clipping configuration to dialogs and GraphManager

### DIFF
--- a/include/gui/Dialog/DialogColorBalanceFilter.h
+++ b/include/gui/Dialog/DialogColorBalanceFilter.h
@@ -33,6 +33,7 @@ private:
     void applyPreset(BalancePreset preset);
     void syncUiFromValues();
     void updateAvailability(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable);
+    void updateOutputModeText();
 
     Ui::DialogColorBalanceFilter m_ui;
 
@@ -47,6 +48,7 @@ private:
     bool m_rgbAvailable = false;
     bool m_intensityAvailable = false;
     bool m_rgbAndIntensityAvailable = false;
+    int m_outputMode = 1;
     FileType m_outputFileType = FileType::TLS;
 
     QString m_openPath;

--- a/include/gui/Dialog/DialogStatisticalOutlierFilter.h
+++ b/include/gui/Dialog/DialogStatisticalOutlierFilter.h
@@ -31,6 +31,7 @@ private:
     void refreshUI();
     void applyPreset(OutlierPreset preset);
     void syncUiFromValues();
+    void updateOutputModeText();
 
     Ui::DialogStatisticalOutlierFilter m_ui;
     OutlierFilterMode m_mode = OutlierFilterMode::Separate;
@@ -40,6 +41,7 @@ private:
     int m_samplingPercent = 2;
     double m_beta = 4.0;
     FileType m_outputFileType = FileType::TLS;
+    int m_outputMode = 1;
     std::wstring m_outputFolder;
     QString m_openPath;
 };

--- a/include/gui/GuiData/GuiDataGeneralProject.h
+++ b/include/gui/GuiData/GuiDataGeneralProject.h
@@ -230,15 +230,18 @@ public:
 class GuiDataStatisticalOutlierFilterDialogDisplay : public IGuiData
 {
 public:
-    GuiDataStatisticalOutlierFilterDialogDisplay();
+    GuiDataStatisticalOutlierFilterDialogDisplay(int outputMode);
     ~GuiDataStatisticalOutlierFilterDialogDisplay();
     guiDType getType() override;
+
+public:
+    int m_outputMode;
 };
 
 class GuiDataColorBalanceFilterDialogDisplay : public IGuiData
 {
 public:
-    GuiDataColorBalanceFilterDialogDisplay(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable);
+    GuiDataColorBalanceFilterDialogDisplay(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable, int outputMode);
     ~GuiDataColorBalanceFilterDialogDisplay();
     guiDType getType() override;
 
@@ -246,6 +249,7 @@ public:
     bool m_rgbAvailable;
     bool m_intensityAvailable;
     bool m_rgbAndIntensityAvailable;
+    int m_outputMode;
 };
 
 class GuiDataGlobalColorPickerValue : public IGuiData

--- a/include/gui/texts/ExportTexts.hpp
+++ b/include/gui/texts/ExportTexts.hpp
@@ -39,6 +39,10 @@
 #define TEXT_EXPORT_GRID_TITLE_PROGESS QObject::tr("Export Point Cloud in gridded boxes")
 #define TEXT_EXPORT_DIALOG_NAME QObject::tr("Dialog export point cloud")
 #define TEXT_EXPORT_INVALID_DIRECTORY QObject::tr("The selected directory is not valid for exports (invalid path OR no write permission)")
+#define TEXT_EXPORT_OUTPUT_MODE_TITLE QObject::tr("Output mode")
+#define TEXT_EXPORT_OUTPUT_MODE_CASE1 QObject::tr("The filter will be applied to the active clipped areas. Only these areas will be exported.")
+#define TEXT_EXPORT_OUTPUT_MODE_CASE2 QObject::tr("The filter will be applied to the active full scans (no active clipping). Full filtered scans will be exported.")
+#define TEXT_EXPORT_OUTPUT_MODE_CASE3 QObject::tr("The filter will be applied to the selected but inactive clipped areas, while preserving the rest of the scans. Full scans containing filtered areas will be exported.")
 
 #define TEXT_EXPORT_FILTER_ALL QObject::tr("All")
 #define TEXT_EXPORT_FILTER_SELECTED QObject::tr("Selected")

--- a/include/models/graph/GraphManager.h
+++ b/include/models/graph/GraphManager.h
@@ -34,6 +34,19 @@ typedef void (GraphManager::* GraphManagerMethod)(IGuiData*, bool);
 class GraphManager : public IPanel
 {
 public:
+    enum class FilterOutputMode
+    {
+        ActiveClippingOnly,
+        FullScansNoClipping,
+        FullScansSelectedInactiveClipping
+    };
+
+    struct FilterClippingConfiguration
+    {
+        FilterOutputMode mode = FilterOutputMode::FullScansNoClipping;
+        std::unordered_set<SafePtr<AClippingNode>> clippings;
+    };
+
 	GraphManager(IDataDispatcher& dataDispatcher);
 	~GraphManager();
 
@@ -82,6 +95,7 @@ public:
 	std::unordered_set<SafePtr<AClippingNode>> getClippingObjects(bool filterActive, bool filterSelected) const;
 	std::unordered_set<SafePtr<AClippingNode>> getRampObjects(bool filterActive, bool filterSelected) const;
 	std::unordered_set<SafePtr<AClippingNode>> getActivatedOrSelectedClippingObjects() const;
+    FilterClippingConfiguration getFilterClippingConfiguration() const;
 
 	std::unordered_set<SafePtr<BoxNode>> getGrids() const;
 	std::unordered_set<SafePtr<TagNode>> getTagsWithTemplate(SafePtr<sma::TagTemplate> tagTemplate) const;

--- a/src/controller/functionSystem/ContextColorBalanceFilter.cpp
+++ b/src/controller/functionSystem/ContextColorBalanceFilter.cpp
@@ -110,7 +110,8 @@ ContextState ContextColorBalanceFilter::start(Controller& controller)
             rgbAndIntensityAvailable = true;
     }
 
-    controller.updateInfo(new GuiDataColorBalanceFilterDialogDisplay(rgbAvailable, intensityAvailable, rgbAndIntensityAvailable));
+    GraphManager::FilterClippingConfiguration clippingConfig = graphManager.getFilterClippingConfiguration();
+    controller.updateInfo(new GuiDataColorBalanceFilterDialogDisplay(rgbAvailable, intensityAvailable, rgbAndIntensityAvailable, (int)clippingConfig.mode));
     return (m_state = ContextState::waiting_for_input);
 }
 
@@ -184,9 +185,9 @@ ContextState ContextColorBalanceFilter::launch(Controller& controller)
     controller.updateInfo(new GuiDataProcessingSplashScreenStart(totalProgressSteps, TEXT_EXPORT_COLOR_BALANCE_TITLE_PROGRESS, TEXT_SPLASH_SCREEN_SCAN_PROCESSING.arg(0).arg(totalScans)));
 
     ClippingAssembly clippingAssembly;
-    std::unordered_set<SafePtr<AClippingNode>> clippings = graphManager.getActivatedOrSelectedClippingObjects();
-    if (!clippings.empty())
-        graphManager.getClippingAssembly(clippingAssembly, clippings);
+    GraphManager::FilterClippingConfiguration clippingConfig = graphManager.getFilterClippingConfiguration();
+    if (!clippingConfig.clippings.empty())
+        graphManager.getClippingAssembly(clippingAssembly, clippingConfig.clippings);
     const bool useTempClippedScans = m_globalBalancing && !clippingAssembly.empty();
     std::filesystem::path tempFolder;
     if (useTempClippedScans)

--- a/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
+++ b/src/controller/functionSystem/ContextStatisticalOutlierFilter.cpp
@@ -97,7 +97,8 @@ ContextState ContextStatisticalOutlierFilter::start(Controller& controller)
         return (m_state = ContextState::abort);
     }
 
-    controller.updateInfo(new GuiDataStatisticalOutlierFilterDialogDisplay());
+    GraphManager::FilterClippingConfiguration clippingConfig = graphManager.getFilterClippingConfiguration();
+    controller.updateInfo(new GuiDataStatisticalOutlierFilterDialogDisplay((int)clippingConfig.mode));
 
     return (m_state = ContextState::waiting_for_input);
 }
@@ -159,7 +160,9 @@ ContextState ContextStatisticalOutlierFilter::launch(Controller& controller)
     controller.updateInfo(new GuiDataProcessingSplashScreenStart(totalProgressSteps, TEXT_EXPORT_STAT_OUTLIER_TITLE_PROGESS, TEXT_SPLASH_SCREEN_SCAN_PROCESSING.arg(0).arg(totalScans)));
 
     ClippingAssembly clippingAssembly;
-    graphManager.getClippingAssembly(clippingAssembly, true, false);
+    GraphManager::FilterClippingConfiguration clippingConfig = graphManager.getFilterClippingConfiguration();
+    if (!clippingConfig.clippings.empty())
+        graphManager.getClippingAssembly(clippingAssembly, clippingConfig.clippings);
 
     OutlierStats globalStats;
     bool wasAborted = false;

--- a/src/gui/Dialog/DialogColorBalanceFilter.cpp
+++ b/src/gui/Dialog/DialogColorBalanceFilter.cpp
@@ -181,6 +181,7 @@ void DialogColorBalanceFilter::informData(IGuiData* data)
     {
         auto dialogData = static_cast<GuiDataColorBalanceFilterDialogDisplay*>(data);
         updateAvailability(dialogData->m_rgbAvailable, dialogData->m_intensityAvailable, dialogData->m_rgbAndIntensityAvailable);
+        m_outputMode = dialogData->m_outputMode;
         refreshUI();
     }
     break;
@@ -226,6 +227,7 @@ void DialogColorBalanceFilter::cancelBalancing()
 void DialogColorBalanceFilter::translateUI()
 {
     setWindowTitle(TEXT_EXPORT_TITLE_COLOR_BALANCE);
+    m_ui.groupBox_outputMode->setTitle(TEXT_EXPORT_OUTPUT_MODE_TITLE);
 }
 
 void DialogColorBalanceFilter::refreshUI()
@@ -279,6 +281,7 @@ void DialogColorBalanceFilter::syncUiFromValues()
         m_ui.comboBox_file_format->setCurrentIndex(formatIndex);
 
     m_ui.checkBox_balanceIntensityRGB->setEnabled(m_rgbAndIntensityAvailable);
+    updateOutputModeText();
 }
 
 void DialogColorBalanceFilter::updateAvailability(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable)
@@ -290,5 +293,22 @@ void DialogColorBalanceFilter::updateAvailability(bool rgbAvailable, bool intens
     if (!m_rgbAndIntensityAvailable)
     {
         m_applyOnIntensityAndRgb = false;
+    }
+}
+
+void DialogColorBalanceFilter::updateOutputModeText()
+{
+    switch (m_outputMode)
+    {
+    case 0:
+        m_ui.label_outputMode->setText(TEXT_EXPORT_OUTPUT_MODE_CASE1);
+        break;
+    case 2:
+        m_ui.label_outputMode->setText(TEXT_EXPORT_OUTPUT_MODE_CASE3);
+        break;
+    case 1:
+    default:
+        m_ui.label_outputMode->setText(TEXT_EXPORT_OUTPUT_MODE_CASE2);
+        break;
     }
 }

--- a/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
+++ b/src/gui/Dialog/DialogStatisticalOutlierFilter.cpp
@@ -127,7 +127,11 @@ void DialogStatisticalOutlierFilter::informData(IGuiData* data)
     switch (data->getType())
     {
     case guiDType::statisticalOutlierFilterDialogDisplay:
+    {
+        auto dialogData = static_cast<GuiDataStatisticalOutlierFilterDialogDisplay*>(data);
+        m_outputMode = dialogData->m_outputMode;
         refreshUI();
+    }
         break;
     case guiDType::projectPath:
     {
@@ -170,6 +174,7 @@ void DialogStatisticalOutlierFilter::cancelFiltering()
 void DialogStatisticalOutlierFilter::translateUI()
 {
     setWindowTitle(TEXT_EXPORT_TITLE_STAT_OUTLIER);
+    m_ui.groupBox_outputMode->setTitle(TEXT_EXPORT_OUTPUT_MODE_TITLE);
 }
 
 void DialogStatisticalOutlierFilter::refreshUI()
@@ -228,4 +233,22 @@ void DialogStatisticalOutlierFilter::syncUiFromValues()
     int formatIndex = m_ui.comboBox_file_format->findData(QVariant(static_cast<int>(m_outputFileType)));
     if (formatIndex >= 0)
         m_ui.comboBox_file_format->setCurrentIndex(formatIndex);
+    updateOutputModeText();
+}
+
+void DialogStatisticalOutlierFilter::updateOutputModeText()
+{
+    switch (m_outputMode)
+    {
+    case 0:
+        m_ui.label_outputMode->setText(TEXT_EXPORT_OUTPUT_MODE_CASE1);
+        break;
+    case 2:
+        m_ui.label_outputMode->setText(TEXT_EXPORT_OUTPUT_MODE_CASE3);
+        break;
+    case 1:
+    default:
+        m_ui.label_outputMode->setText(TEXT_EXPORT_OUTPUT_MODE_CASE2);
+        break;
+    }
 }

--- a/src/gui/GuiData/GuiDataGeneralProject.cpp
+++ b/src/gui/GuiData/GuiDataGeneralProject.cpp
@@ -300,7 +300,8 @@ guiDType GuiDataDeletePointsDialogDisplay::getType()
     return (guiDType::deletePointsDialogDisplay);
 }
 
-GuiDataStatisticalOutlierFilterDialogDisplay::GuiDataStatisticalOutlierFilterDialogDisplay()
+GuiDataStatisticalOutlierFilterDialogDisplay::GuiDataStatisticalOutlierFilterDialogDisplay(int outputMode)
+    : m_outputMode(outputMode)
 {
 }
 
@@ -313,10 +314,11 @@ guiDType GuiDataStatisticalOutlierFilterDialogDisplay::getType()
     return guiDType::statisticalOutlierFilterDialogDisplay;
 }
 
-GuiDataColorBalanceFilterDialogDisplay::GuiDataColorBalanceFilterDialogDisplay(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable)
+GuiDataColorBalanceFilterDialogDisplay::GuiDataColorBalanceFilterDialogDisplay(bool rgbAvailable, bool intensityAvailable, bool rgbAndIntensityAvailable, int outputMode)
     : m_rgbAvailable(rgbAvailable)
     , m_intensityAvailable(intensityAvailable)
     , m_rgbAndIntensityAvailable(rgbAndIntensityAvailable)
+    , m_outputMode(outputMode)
 {
 }
 

--- a/src/gui/forms/DialogColorBalanceFilter.ui
+++ b/src/gui/forms/DialogColorBalanceFilter.ui
@@ -261,6 +261,25 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_outputMode">
+     <property name="title">
+      <string>Output mode</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_outputMode">
+      <item>
+       <widget class="QLabel" name="label_outputMode">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_buttons">
      <item>
       <spacer name="horizontalSpacer">

--- a/src/gui/forms/DialogStatisticalOutlierFilter.ui
+++ b/src/gui/forms/DialogStatisticalOutlierFilter.ui
@@ -234,6 +234,25 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_outputMode">
+     <property name="title">
+      <string>Output mode</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_outputMode">
+      <item>
+       <widget class="QLabel" name="label_outputMode">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_buttons">
      <item>
       <spacer name="horizontalSpacer">

--- a/src/models/graph/GraphManager.cpp
+++ b/src/models/graph/GraphManager.cpp
@@ -587,6 +587,38 @@ std::unordered_set<SafePtr<AClippingNode>> GraphManager::getActivatedOrSelectedC
         {return (clip->isClippingActive() || clip->isSelected()); });
 }
 
+GraphManager::FilterClippingConfiguration GraphManager::getFilterClippingConfiguration() const
+{
+    FilterClippingConfiguration config;
+
+    std::unordered_set<SafePtr<AClippingNode>> activeClippings = getClippingObjects(true, false);
+    if (!activeClippings.empty())
+    {
+        // Active clipping always has priority over selected inactive clipping.
+        config.mode = FilterOutputMode::ActiveClippingOnly;
+        config.clippings = std::move(activeClippings);
+        return config;
+    }
+
+    std::unordered_set<SafePtr<AClippingNode>> selectedClippings = getClippingObjects(false, true);
+    for (const SafePtr<AClippingNode>& clip : selectedClippings)
+    {
+        ReadPtr<AClippingNode> rClip = clip.cget();
+        if (rClip && !rClip->isClippingActive())
+            config.clippings.insert(clip);
+    }
+
+    if (!config.clippings.empty())
+    {
+        config.mode = FilterOutputMode::FullScansSelectedInactiveClipping;
+    }
+    else
+    {
+        config.mode = FilterOutputMode::FullScansNoClipping;
+    }
+    return config;
+}
+
 std::unordered_set<SafePtr<BoxNode>> GraphManager::getGrids() const
 {
     return getNodesOnFilter<BoxNode>(


### PR DESCRIPTION
### Motivation
- Provide users with clear output-mode information for filtering operations and ensure filtering respects active/selected clippings when exporting or applying filters.
- Centralize clipping selection logic for filters so contexts can consistently obtain which clippings to use and which output mode to display.

### Description
- Introduced `GraphManager::FilterOutputMode` enum and `FilterClippingConfiguration` struct, and implemented `GraphManager::getFilterClippingConfiguration()` that prioritizes active clippings, then selected-but-inactive clippings, otherwise full-scan mode.
- Updated contexts to query `getFilterClippingConfiguration()` and pass the `mode` and `clippings` into existing workflows for `ColorBalance` and `StatisticalOutlier` filters, replacing previous ad-hoc clipping selection.
- Extended GUI data classes `GuiDataStatisticalOutlierFilterDialogDisplay` and `GuiDataColorBalanceFilterDialogDisplay` to carry an `m_outputMode` integer, and propagated this through `GuiData` construction.
- Updated dialogs `DialogColorBalanceFilter` and `DialogStatisticalOutlierFilter` to show a new `groupBox_outputMode` with `label_outputMode`, to store `m_outputMode`, and to update the displayed explanatory text via `updateOutputModeText()` using new text constants.
- Added new translation strings in `ExportTexts.hpp` for the output mode title and three explanatory cases.
- Updated UI `.ui` forms to include the output mode `QGroupBox` and `QLabel`.

### Testing
- Built the project locally (`cmake` / build) to ensure the code compiles and the new symbols are resolved, and the build succeeded.
- Ran the project's automated test suite (`ctest` / existing unit tests) and observed all tests passing with no regressions reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b392bd6c832f932a13de88966c7d)