### PR TITLE
Refresh all root nodes when updated objects are invalid in ProjectTreePanel

### DIFF
--- a/src/gui/widgets/ProjectTreePanel.cpp
+++ b/src/gui/widgets/ProjectTreePanel.cpp
@@ -122,6 +122,18 @@ void ProjectTreePanel::actualizeNodes(IGuiData* data)
             }
         }
 
+        // If all nodes from the update payload are already invalid (e.g. just deleted),
+        // no TreeType can be extracted from model objects. In that case we force a broad
+        // refresh of all root nodes to keep the tree view in sync without manual collapse/expand.
+        if (nodesToUpdate.empty() && !actualizeNodes->m_objects.empty())
+        {
+            for (const auto& rootNodeByType : m_rootNodes)
+            {
+                for (TreeNode* treenode : rootNodeByType.second)
+                    nodesToUpdate.insert(treenode);
+            }
+        }
+
 
         for (TreeNode* node : nodesToUpdate)
             updateNode(node);


### PR DESCRIPTION
### Motivation
- Ensure the tree view stays in sync when all objects in an update payload are already invalid or deleted and no `TreeType` can be derived from the model objects.

### Description
- In `ProjectTreePanel::actualizeNodes` add a fallback that when `nodesToUpdate` is empty but `actualizeNodes->m_objects` is non-empty, all root nodes in `m_rootNodes` are inserted into `nodesToUpdate` to force a broad refresh of the tree.

### Testing
- Ran the project's unit test suite; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c001762c832fa91d51f1535b6d1c)