### PR TITLE
Fix tree refresh after undo-delete and handle invalid nodes when actualizing tree

### DIFF
--- a/src/controller/controls/ControlSpecial.cpp
+++ b/src/controller/controls/ControlSpecial.cpp
@@ -117,7 +117,8 @@ namespace control::special
 		SaveLoadSystem::LoadFileObjects(controller, fileObjectsToReload, "", false);
 
         controller.changeSelection({});
-		controller.actualizeTreeView(m_elemsDeleted);
+		// Refresh restored nodes in tree after undoing deletion.
+		controller.actualizeTreeView(toActualize);
 
 
 		CONTROLLOG << "control::special::DeleteElement undo" << LOGENDL;

--- a/src/gui/widgets/ProjectTreePanel.cpp
+++ b/src/gui/widgets/ProjectTreePanel.cpp
@@ -113,12 +113,27 @@ void ProjectTreePanel::actualizeNodes(IGuiData* data)
                     treetypes.insert(treetype);
         }
 
-        for (TreeType treetype : treetypes)
+        // If deleted/invalid nodes cannot be read anymore, we can no longer infer
+        // their tree types from the payload. In that case, fall back to refreshing
+        // all roots to keep the tree view consistent without user collapse/expand.
+        if (treetypes.empty())
         {
-            if (m_rootNodes.find(treetype) != m_rootNodes.end())
+            for (const auto& [rootType, rootNodes] : m_rootNodes)
             {
-                for (TreeNode* treenode : m_rootNodes[treetype])
+                (void)rootType; // explicit unused name for readability
+                for (TreeNode* treenode : rootNodes)
                     nodesToUpdate.insert(treenode);
+            }
+        }
+        else
+        {
+            for (TreeType treetype : treetypes)
+            {
+                if (m_rootNodes.find(treetype) != m_rootNodes.end())
+                {
+                    for (TreeNode* treenode : m_rootNodes[treetype])
+                        nodesToUpdate.insert(treenode);
+                }
             }
         }
 


### PR DESCRIPTION
### Motivation
- Ensure restored nodes are correctly refreshed in the project tree after undoing a deletion by passing the actualized set instead of a cleared container.
- Prevent the tree view from becoming inconsistent when payload nodes are deleted or invalid and their tree types cannot be inferred.

### Description
- In `DeleteElement::undo()` change the `actualizeTreeView` call to pass `toActualize` so restored nodes are refreshed instead of the cleared `m_elemsDeleted`.
- In `ProjectTreePanel::actualizeNodes()` add a fallback that refreshes all root nodes when `treetypes` is empty, with the original selective-refresh behavior preserved when types are available.
- Add clarifying comments and a small unused-variable cast for readability in the root-iteration code path.

### Testing
- Built the project after the changes with the usual build system and the build completed successfully.
- Ran the unit test suite including tree update and undo-delete related tests and all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cafc5630832fa582f9b1a9109413)