### PR TITLE
Apply registration using referential translation only and use normalized station rotation

### DIFF
--- a/src/io/ScantraInterface.cpp
+++ b/src/io/ScantraInterface.cpp
@@ -569,15 +569,13 @@ void ScantraInterface::applyRegistration()
             continue;
 
         glm::dvec3 ref_pos(0.0, 0.0, 0.0);
-        glm::dquat ref_rot(1.0, 0.0, 0.0, 0.0);
         
-        // If the referential is null, then the ref coordinates are unchanged.
+        // If the referential is null, then the reference translation is unchanged.
         {
             ReadPtr<AGraphNode> rDatum = reg.referential.cget();
             if (rDatum)
             {
                 ref_pos = rDatum->getCenter();
-                ref_rot = rDatum->getRotation();
             }
         }
 
@@ -585,11 +583,11 @@ void ScantraInterface::applyRegistration()
             WritePtr<AGraphNode> wScan = reg.station.get();
             if (wScan)
             {
-                wScan->setPosition(ref_pos);
-                wScan->setRotation(ref_rot);
-
-                wScan->addLocalTranslation(reg.position);
-                wScan->addPreRotation(reg.rotation);
+                // Translation remains anchored to the referential position.
+                // The station orientation comes from the adjustment result and must not inherit
+                // the referential tilt, otherwise non-reference stations are over-rotated.
+                wScan->setPosition(ref_pos + reg.position);
+                wScan->setRotation(glm::normalize(reg.rotation));
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent stations from inheriting the referential tilt which caused over-rotation of non-reference stations during registration.
- Ensure the station translation remains anchored to the referential position while the station orientation comes solely from the registration result.

### Description
- Remove use of the referential rotation and stop composing the station rotation from the referential; only the station rotation from the registration (`reg.rotation`) is applied.
- Compute the station position as `ref_pos + reg.position` so the translation is anchored to the referential center.
- Apply the normalized registration rotation with `setRotation(glm::normalize(reg.rotation))` and update related comments to clarify intent.

### Testing
- Built the project using `cmake`/`make` successfully without compile errors.
- Ran the existing automated unit test suite with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034e5fbcd8832f8fe0a987f2d9ee78)