### PR TITLE
Apply Scantra station pose as absolute transform and remove registration propagation logic

### DIFF
--- a/src/io/ScantraInterface.cpp
+++ b/src/io/ScantraInterface.cpp
@@ -474,33 +474,26 @@ void ScantraInterface::editStationAdjustment()
     glm::dquat station_rot(q0, qx, qy, qz);
 
     SafePtr<AGraphNode> scan = getScanOnName(station_id);
-    SafePtr<AGraphNode> datum = getScanOnName(datum_id);
-
     // Reset the geometric link. All computation are done in the global space.
     AGraphNode::addGeometricLink(graph_.getRoot(), scan);
-
-    if (datum == scan)
     {
         WritePtr<AGraphNode> wScan = scan.get();
         if (wScan)
         {
-            wScan->setPosition(station_pos); // should be (0, 0, 0)
-            wScan->setRotation(station_rot); // should be (1, 0, 0, 0)
+            // Apply Scantra pose directly in world coordinates.
+            // This mirrors the manual SCDB import logic and prevents propagating
+            // the datum scan tilt as a global axis for the whole campaign.
+            wScan->setPosition(station_pos);
+            wScan->setRotation(station_rot);
         }
     }
-    else
-    {
-        // Wait for registration
-        scans_registered_.push_back({
-            datum,
-            scan,
-            station_pos,
-            station_rot
-            });
-    }
 
-    if (current_entry == total_entry - 1)
-        applyRegistration();
+    // Keep datum lookup for diagnostics and future protocol checks.
+    SafePtr<AGraphNode> datum = getScanOnName(datum_id);
+    if (datum != scan)
+    {
+        log << "Info: datum differs from station. Pose applied as absolute transform to preserve global frame consistency.\n";
+    }
 
     // On recoit les stations une par une.
     // Il faut rendre invisible les stations que l’on ne recevra pas
@@ -559,42 +552,6 @@ SafePtr<AGraphNode> ScantraInterface::getScanOnName(std::wstring _name)
         return SafePtr<AGraphNode>();
 
     return *scan_uset.begin();
-}
-
-void ScantraInterface::applyRegistration()
-{
-    for (auto reg : scans_registered_)
-    {
-        if (reg.referential == reg.station)
-            continue;
-
-        glm::dvec3 ref_pos(0.0, 0.0, 0.0);
-        glm::dquat ref_rot(1.0, 0.0, 0.0, 0.0);
-        
-        // If the referential is null, then the ref coordinates are unchanged.
-        {
-            ReadPtr<AGraphNode> rDatum = reg.referential.cget();
-            if (rDatum)
-            {
-                ref_pos = rDatum->getCenter();
-                ref_rot = rDatum->getRotation();
-            }
-        }
-
-        {
-            WritePtr<AGraphNode> wScan = reg.station.get();
-            if (wScan)
-            {
-                wScan->setPosition(ref_pos);
-                wScan->setRotation(ref_rot);
-
-                wScan->addLocalTranslation(reg.position);
-                wScan->addPreRotation(reg.rotation);
-            }
-        }
-    }
-
-    scans_registered_.clear();
 }
 
 void ScantraInterface::manageVisibility(int current_station, int total_station, SafePtr<AGraphNode> scan)

--- a/src/io/ScantraInterface.h
+++ b/src/io/ScantraInterface.h
@@ -59,7 +59,6 @@ private:
     void openProject();
 
     SafePtr<AGraphNode> getScanOnName(std::wstring _name);
-    void applyRegistration();
     void manageVisibility(int current_idx, int total_station, SafePtr<AGraphNode> scan);
     void changeGraphicSettings();
     void deactivateIntersectionBox();
@@ -81,16 +80,6 @@ private:
     Controller& controller_;
     IDataDispatcher& data_dispatcher_;
 
-    struct Registration
-    {
-        SafePtr<AGraphNode> referential;
-        SafePtr<AGraphNode> station;
-        glm::dvec3 position;
-        glm::dquat rotation;
-    };
-
-    std::vector<Registration> referentials_;
-    std::vector<Registration> scans_registered_;
     std::unordered_set<SafePtr<AGraphNode>> scan_selection_;
     GraphManager& graph_;
 };


### PR DESCRIPTION
### Motivation

- Prevent the datum scan tilt from being propagated as a global axis by applying incoming Scantra station poses directly in world coordinates.  
- Simplify the Scantra import flow by removing the prior two-step registration/accumulation mechanism that mutated scan frames relative to a referential.  
- Keep datum lookup for diagnostics and future checks while removing unused registration state.

### Description

- Change `ScantraInterface::editStationAdjustment` to apply the received station pose as an absolute transform with `setPosition` and `setRotation` instead of accumulating a relative transform.  
- Remove the deferred registration flow by deleting `applyRegistration`, the `Registration` struct, and the `scans_registered_`/`referentials_` member variables and their usages.  
- Retain a `getScanOnName` lookup of the datum only for diagnostics and add an informational log when the datum differs from the station.  
- Remove the call to `applyRegistration()` and the code that queued registrations at the end of station processing, keeping visibility management and graphic updates unchanged.

### Testing

- Project was rebuilt after the change using the normal build system and the build completed successfully.  
- The repository's automated unit test suite was executed and completed with all tests passing.  
- No automated integration regressions were detected by the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044989ad70832f90cea51beacdaa50)