### PR TITLE
Add Scantra auto-zoom lock option and control

### DIFF
--- a/include/controller/Controller.h
+++ b/include/controller/Controller.h
@@ -80,6 +80,7 @@ public:
 
     void startScantraInterface();
     void stopScantraInterface();
+    void setScantraAutoZoomLocked(bool lockZoom);
     void scantra_notify_project_created();
     void scantra_notify_project_opened();
 

--- a/include/controller/controls/ControlApplication.h
+++ b/include/controller/controls/ControlApplication.h
@@ -420,6 +420,16 @@ namespace control::application
     private:
         bool start_;
     };
+
+    class SetScantraAutoZoomLock : public AControl
+    {
+    public:
+        SetScantraAutoZoomLock(bool lockZoom);
+        void doFunction(Controller& controller) override;
+        ControlType getType() const override;
+    private:
+        bool lock_zoom_;
+    };
 }
 
 #endif // !CONTROLAPPLICATION_H_

--- a/include/controller/controls/IControl.h
+++ b/include/controller/controls/IControl.h
@@ -48,6 +48,7 @@ enum class ControlType
 	setNavigationParameters,
 	setPerspectiveZBounds,
 	setOrthoGridParams,
+	setScantraAutoZoomLock,
 	unlockScanManipulation,
 	setMultithreadedCalculation,
 	// setOrthoZBounds, // TODO

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -224,6 +224,11 @@ void Controller::stopScantraInterface()
     m_p->scantra_interface_.stopInterface();
 }
 
+void Controller::setScantraAutoZoomLocked(bool lockZoom)
+{
+    m_p->scantra_interface_.setLockAutoZoomExtent(lockZoom);
+}
+
 void Controller::scantra_notify_project_created()
 {
     const ProjectInfos& proj_infos = m_p->context.cgetProjectInfo();

--- a/src/controller/controls/ControlApplication.cpp
+++ b/src/controller/controls/ControlApplication.cpp
@@ -1051,4 +1051,24 @@ namespace control::application
         return ControlType::switchScantraConnexion;
     }
 
+    /*
+    ** SetScantraAutoZoomLock
+    */
+
+    SetScantraAutoZoomLock::SetScantraAutoZoomLock(bool lockZoom)
+        : lock_zoom_(lockZoom)
+    {
+    }
+
+    void SetScantraAutoZoomLock::doFunction(Controller& controller)
+    {
+        // This flag only applies to Scantra live adjustment updates.
+        controller.setScantraAutoZoomLocked(lock_zoom_);
+    }
+
+    ControlType SetScantraAutoZoomLock::getType() const
+    {
+        return ControlType::setScantraAutoZoomLock;
+    }
+
 }

--- a/src/gui/forms/toolbar_importScantra.ui
+++ b/src/gui/forms/toolbar_importScantra.ui
@@ -59,6 +59,16 @@ The names of the scans must be the same between Scantra and OpenScanTools</strin
      </property>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="lockScantraZoomExtentCheckBox">
+     <property name="toolTip">
+      <string>This checkbox allows you to lock the automatic extended zoom after making a block adjustment in Scantra.</string>
+     </property>
+     <property name="text">
+      <string>Lock auto-zoom out</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources>

--- a/src/gui/toolBars/ToolBarImportScantra.cpp
+++ b/src/gui/toolBars/ToolBarImportScantra.cpp
@@ -20,6 +20,11 @@ ToolBarImportScantra::ToolBarImportScantra(IDataDispatcher &dataDispatcher, QWid
 	m_openPath = QStandardPaths::locate(QStandardPaths::DocumentsLocation, QString(), QStandardPaths::LocateDirectory);
 
 	connect(m_ui.importScanTraButton, &QPushButton::clicked, this, &ToolBarImportScantra::slotImportScantra);
+	connect(m_ui.lockScantraZoomExtentCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+		// This option only controls the automatic zoom triggered by Scantra live adjustments.
+		m_dataDispatcher.sendControl(new control::application::SetScantraAutoZoomLock(checked));
+	});
+	m_ui.lockScantraZoomExtentCheckBox->setChecked(false);
 
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::projectLoaded);
 	m_dataDispatcher.registerObserverOnKey(this, guiDType::projectPath);

--- a/src/io/ScantraInterface.cpp
+++ b/src/io/ScantraInterface.cpp
@@ -152,6 +152,12 @@ int ScantraInterface::stopInterface()
     return 0;
 }
 
+void ScantraInterface::setLockAutoZoomExtent(bool lockZoom)
+{
+    // Keep default behavior unless explicitly locked by the Scantra toolbar checkbox.
+    lock_auto_zoom_extent_ = lockZoom;
+}
+
 void ScantraInterface::project_created(const std::filesystem::path& path, const std::wstring& name)
 {
     if (!data_)
@@ -601,7 +607,11 @@ void ScantraInterface::manageVisibility(int current_station, int total_station, 
             }
         }
         controller_.actualizeTreeView(tree_update);
-        controller_.getControlListener()->notifyUIControl(new control::viewport::AdjustZoomToScene(SafePtr<CameraNode>()));
+        if (!lock_auto_zoom_extent_)
+        {
+            // This zoom is specific to Scantra live block adjustment updates.
+            controller_.getControlListener()->notifyUIControl(new control::viewport::AdjustZoomToScene(SafePtr<CameraNode>()));
+        }
     }
 }
 

--- a/src/io/ScantraInterface.h
+++ b/src/io/ScantraInterface.h
@@ -29,6 +29,7 @@ public:
 
     int startInterface();
     int stopInterface();
+    void setLockAutoZoomExtent(bool lockZoom);
 
     void project_created(const std::filesystem::path& path, const std::wstring& name);
     void project_opened(const std::filesystem::path& path);
@@ -82,6 +83,7 @@ private:
 
     std::unordered_set<SafePtr<AGraphNode>> scan_selection_;
     GraphManager& graph_;
+    bool lock_auto_zoom_extent_ = false;
 };
 
 #endif


### PR DESCRIPTION
### Motivation
- Provide a way for users to prevent automatic scene zooming that occurs when Scantra sends live block adjustment updates. This avoids disruptive view changes while still allowing other Scantra functionality.

### Description
- Added a toolbar checkbox in `toolbar_importScantra.ui` and connected it in `ToolBarImportScantra.cpp` to send a new control when toggled.
- Introduced a new control class `control::application::SetScantraAutoZoomLock` and added `ControlType::setScantraAutoZoomLock` to the control enum in `IControl.h`.
- Exposed a `Controller` API `setScantraAutoZoomLocked(bool)` (declaration in `Controller.h` and implementation in `Controller.cpp`) which forwards the setting to `ScantraInterface` via `setLockAutoZoomExtent(bool)`.
- Added a `lock_auto_zoom_extent_` member and `setLockAutoZoomExtent` method in `ScantraInterface` and guarded the call to `AdjustZoomToScene` so automatic zooming is skipped when locked.

### Testing
- Project build was executed with `cmake --build` and completed successfully.
- The existing automated test suite was run with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045d2a0b9c832f8f102ee9e68d67ae)