### PR TITLE
Enable cylinder rotation gizmo on all axes

### DIFF
--- a/src/vulkan/MeshManager.cpp
+++ b/src/vulkan/MeshManager.cpp
@@ -39,7 +39,8 @@ const std::map<GenericMeshType, std::map<ManipulationMode, std::unordered_set<Se
     }},
     {GenericMeshType::Cylinder, {
         {ManipulationMode::Translation, { Selection::X, Selection::Y, Selection::Z }},
-        {ManipulationMode::Rotation, {}},
+        // Enable cylinder rotation gizmo on all three axes.
+        {ManipulationMode::Rotation, { Selection::X, Selection::Y, Selection::Z }},
         {ManipulationMode::Extrusion, { Selection::Z, Selection::_Z }},
         {ManipulationMode::Scale, { Selection::XY }}
     }},


### PR DESCRIPTION
### Motivation
- Allow the cylinder primitive to expose rotation manipulators on X, Y and Z axes so users can rotate cylinders with the same gizmo support as other primitives.

### Description
- Updated `src/vulkan/MeshManager.cpp` to set `ManipulationMode::Rotation` for `GenericMeshType::Cylinder` in `SimpleObjectManipulatorSelections` to `{ Selection::X, Selection::Y, Selection::Z }` and added an inline comment explaining the change.

### Testing
- No automated tests were run for this trivial mapping change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f7f77d28832f98230a24b355ca6b)