### PR TITLE
Add optional PIPE_METRICS logging for cylinder fitting and pipe detection

### DIFF
--- a/src/controller/functionSystem/ContextFitCylinder.cpp
+++ b/src/controller/functionSystem/ContextFitCylinder.cpp
@@ -12,6 +12,23 @@
 #include "models/graph/GraphManager.h"
 
 #include <glm/gtx/quaternion.hpp>
+#include <cstdlib>
+#include <algorithm>
+#include <string>
+
+namespace
+{
+	// Temporary metrics switch for pass 1 instrumentation.
+	bool isPipeMetricsEnabled()
+	{
+		const char* envValue = std::getenv("OPENSCANTOOLS_PIPE_METRICS");
+		if (!envValue)
+			return false;
+		std::string value(envValue);
+		std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+		return value == "1" || value == "true" || value == "on" || value == "yes";
+	}
+}
 
 ContextFitCylinder::ContextFitCylinder(const ContextId& id)
     : ARayTracingContext(id)
@@ -62,6 +79,7 @@ ContextState ContextFitCylinder::launch(Controller& controller)
 	std::chrono::steady_clock::time_point tp_0 = std::chrono::steady_clock::now();
 	controller.updateInfo(new GuiDataTmpMessage(TEXT_LUCAS_SEARCH_ONGOING, 0));
 	bool success = false;
+	const bool metricsEnabled = isPipeMetricsEnabled();
 
 	GraphManager& graphManager = controller.getGraphManager();
 
@@ -140,6 +158,12 @@ ContextState ContextFitCylinder::launch(Controller& controller)
 
 	if (!abortPipeErrorText.isEmpty())
 	{
+		if (metricsEnabled)
+		{
+			Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] ContextFitCylinder fail extendMode=" << static_cast<int>(m_options.extendMode)
+				<< " noisy=" << m_options.noisy << " optimized=" << m_options.optimized
+				<< " reason=" << abortPipeErrorText.toStdString().c_str() << Logger::endl;
+		}
 		if (m_state == ContextState::running)
 		{
 			resetClickUsages(controller);
@@ -147,6 +171,12 @@ ContextState ContextFitCylinder::launch(Controller& controller)
 		}
 		else
 			return m_state == ContextState::done ? ARayTracingContext::validate(controller) : ((m_state == ContextState::abort) ? ARayTracingContext::abort(controller) : m_state);
+	}
+	else if (metricsEnabled)
+	{
+		Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] ContextFitCylinder success extendMode=" << static_cast<int>(m_options.extendMode)
+			<< " noisy=" << m_options.noisy << " optimized=" << m_options.optimized
+			<< " radius=" << cylinderRadius << Logger::endl;
 	}
 
 	controller.updateInfo(new GuiDataTmpMessage(QString(TEXT_CYLINDER_FOUND).arg(2 * cylinderRadius, cylinderCenter.x, cylinderCenter.y, cylinderCenter.z)));

--- a/src/controller/functionSystem/ContextPipeDetectionConnexion.cpp
+++ b/src/controller/functionSystem/ContextPipeDetectionConnexion.cpp
@@ -19,6 +19,23 @@
 #include "models/graph/GraphManager.h"
 
 #include <glm/gtx/quaternion.hpp>
+#include <cstdlib>
+#include <algorithm>
+#include <string>
+
+namespace
+{
+	// Temporary metrics switch for pass 1 instrumentation.
+	bool isPipeMetricsEnabled()
+	{
+		const char* envValue = std::getenv("OPENSCANTOOLS_PIPE_METRICS");
+		if (!envValue)
+			return false;
+		std::string value(envValue);
+		std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+		return value == "1" || value == "true" || value == "on" || value == "yes";
+	}
+}
 
 ContextPipeDetectionConnexion::ContextPipeDetectionConnexion(const ContextId& id)
 	: ARayTracingContext(id)
@@ -101,6 +118,7 @@ ContextState ContextPipeDetectionConnexion::launch(Controller& controller)
 		m_state = ContextState::running;
 		controller.updateInfo(new GuiDataTmpMessage(TEXT_LUCAS_SEARCH_ONGOING, 0));
 		bool success = false;
+		const bool metricsEnabled = isPipeMetricsEnabled();
 		ClippingAssembly clippingAssembly;
 		GraphManager& graphManager = controller.getGraphManager();
 
@@ -165,6 +183,12 @@ ContextState ContextPipeDetectionConnexion::launch(Controller& controller)
 
 		if (!abortPipeErrorText.isEmpty())
 		{
+			if (metricsEnabled)
+			{
+				Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] ContextPipeDetectionConnexion fail extendMode=" << static_cast<int>(m_options.extendMode)
+					<< " noisy=" << m_options.noisy << " optimized=" << m_options.optimized
+					<< " reason=" << abortPipeErrorText.toStdString().c_str() << Logger::endl;
+			}
 			if (m_state == ContextState::running)
 			{
 				resetClickUsages(controller);
@@ -172,6 +196,12 @@ ContextState ContextPipeDetectionConnexion::launch(Controller& controller)
 			}
 			else
 				return m_state == ContextState::done ? ARayTracingContext::validate(controller) : ((m_state == ContextState::abort) ? ARayTracingContext::abort(controller) : m_state);
+		}
+		else if (metricsEnabled)
+		{
+			Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] ContextPipeDetectionConnexion success extendMode=" << static_cast<int>(m_options.extendMode)
+				<< " noisy=" << m_options.noisy << " optimized=" << m_options.optimized
+				<< " radius=" << cylinderRadius << Logger::endl;
 		}
 
 		SafePtr<StandardList> currentStandard = controller.getContext().getCurrentStandard(StandardType::Pipe);

--- a/src/pointCloudEngine/TlScanOverseer.cpp
+++ b/src/pointCloudEngine/TlScanOverseer.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <algorithm>
 #include <queue>
+#include <cstdlib>
 #include <glm/gtx/quaternion.hpp>
 using namespace std::chrono;
 
@@ -25,6 +26,24 @@ constexpr size_t kMaxActiveScanBudget = 1536;
 #else
 constexpr size_t kMaxActiveScanBudget = 768;
 #endif
+
+bool isPipeMetricsEnabled()
+{
+    const char* envValue = std::getenv("OPENSCANTOOLS_PIPE_METRICS");
+    if (!envValue)
+        return false;
+    std::string value(envValue);
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value == "1" || value == "true" || value == "on" || value == "yes";
+}
+
+size_t countBucketPoints(const std::vector<std::vector<glm::dvec3>>& buckets)
+{
+    size_t total = 0;
+    for (const auto& bucket : buckets)
+        total += bucket.size();
+    return total;
+}
 }
 
 TlScanOverseer::TlScanOverseer()
@@ -1053,6 +1072,8 @@ bool TlScanOverseer::nearestNeighbor(const glm::dvec3& globalPoint, glm::dvec3& 
 
 bool TlScanOverseer::fitCylinder(const glm::dvec3& globalSeedPoint, const double& radius, const double& threshold, double& cylinderRadius, glm::dvec3& cylinderDirection, glm::dvec3& cylinderCenter, const FitCylinderMode& mode, const ClippingAssembly& clippingAssembly)
 {
+    const bool metricsEnabled = isPipeMetricsEnabled();
+    auto t0 = std::chrono::steady_clock::now();
     std::vector<std::vector<glm::dvec3>> neighborList, secondList;
     std::vector<glm::dvec3> temp;
     glm::dvec3 cCenter, cDirection;
@@ -1086,10 +1107,28 @@ bool TlScanOverseer::fitCylinder(const glm::dvec3& globalSeedPoint, const double
         secondList.push_back(temp);
     }
     findNeighborsBuckets(globalSeedPoint, searchRadius, neighborList, numberOfBuckets, clippingAssembly);
+    if (metricsEnabled)
+    {
+        Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinder start mode=" << static_cast<int>(mode)
+            << " threshold=" << threshold << " inputRadius=" << radius << " searchRadius=" << searchRadius
+            << " buckets=" << numberOfBuckets << " neighbors=" << countBucketPoints(neighborList) << Logger::endl;
+    }
     if (!OctreeRayTracing::beginCylinderFit(neighborList, threshold, cylinderRadius, cylinderDirection, cylinderCenter, 10000))
+    {
+        if (metricsEnabled)
+        {
+            auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+            Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinder result=fail elapsedMs=" << elapsedMs << Logger::endl;
+        }
         return false;
+    }
     if (!doubleCheck)
     {
+        if (metricsEnabled)
+        {
+            auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+            Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinder result=success radius=" << cylinderRadius << " elapsedMs=" << elapsedMs << Logger::endl;
+        }
         return true;
         if (numberOfBuckets > 2)
         {
@@ -1116,7 +1155,13 @@ bool TlScanOverseer::fitCylinder(const glm::dvec3& globalSeedPoint, const double
     vecCCenter.push_back(cylinderCenter);
     vecCDirection.push_back(cylinderDirection);
     vecCRadius.push_back(cylinderRadius);
-    return (isCylinderCloseToPreviousCylinders(vecCCenter, vecCDirection, vecCRadius, cCenter, cDirection, cRadius));
+    const bool success = isCylinderCloseToPreviousCylinders(vecCCenter, vecCDirection, vecCRadius, cCenter, cDirection, cRadius);
+    if (metricsEnabled)
+    {
+        auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+        Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinder doubleCheck result=" << (success ? "success" : "fail") << " elapsedMs=" << elapsedMs << Logger::endl;
+    }
+    return success;
 }
 
 //for testing
@@ -1190,6 +1235,8 @@ bool TlScanOverseer::fitCylinderTest(const glm::dvec3& globalSeedPoint, const do
 
 bool TlScanOverseer::fitCylinderMultipleSeeds(const std::vector<glm::dvec3>& globalSeedPoint, const double& radius, const double& threshold, double& cylinderRadius, glm::dvec3& cylinderDirection, glm::dvec3& cylinderCenter, const FitCylinderMode& mode, const ClippingAssembly& clippingAssembly)
 {
+    const bool metricsEnabled = isPipeMetricsEnabled();
+    auto t0 = std::chrono::steady_clock::now();
     if ((int)globalSeedPoint.size() != 2)
         return false;
     std::vector<std::vector<glm::dvec3>> neighborList, secondList;
@@ -1228,11 +1275,29 @@ bool TlScanOverseer::fitCylinderMultipleSeeds(const std::vector<glm::dvec3>& glo
         //findNeighborsBuckets(globalSeedPoint[i], searchRadius, neighborList, numberOfBuckets, clippingAssembly);
     findNeighborsBucketsDirected(globalSeedPoint[0], globalSeedPoint[1], searchRadius, neighborList, numberOfBuckets, clippingAssembly);
     findNeighborsBucketsDirected(globalSeedPoint[1], globalSeedPoint[0], searchRadius, neighborList, numberOfBuckets, clippingAssembly);
+    if (metricsEnabled)
+    {
+        Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinderMultipleSeeds start mode=" << static_cast<int>(mode)
+            << " threshold=" << threshold << " inputRadius=" << radius << " searchRadius=" << searchRadius
+            << " buckets=" << numberOfBuckets << " neighbors=" << countBucketPoints(neighborList) << Logger::endl;
+    }
 
     if (!OctreeRayTracing::beginCylinderFit(neighborList, threshold, cylinderRadius, cylinderDirection, cylinderCenter, 10000))
+    {
+        if (metricsEnabled)
+        {
+            auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+            Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinderMultipleSeeds result=fail elapsedMs=" << elapsedMs << Logger::endl;
+        }
         return false;
+    }
     if (!doubleCheck)
     {
+        if (metricsEnabled)
+        {
+            auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+            Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinderMultipleSeeds result=success radius=" << cylinderRadius << " elapsedMs=" << elapsedMs << Logger::endl;
+        }
         return true;
         /*if (numberOfBuckets > 2)
         {
@@ -1259,7 +1324,13 @@ bool TlScanOverseer::fitCylinderMultipleSeeds(const std::vector<glm::dvec3>& glo
     vecCCenter.push_back(cylinderCenter);
     vecCDirection.push_back(cylinderDirection);
     vecCRadius.push_back(cylinderRadius);
-    return (isCylinderCloseToPreviousCylinders(vecCCenter, vecCDirection, vecCRadius, cCenter, cDirection, cRadius));
+    const bool success = isCylinderCloseToPreviousCylinders(vecCCenter, vecCDirection, vecCRadius, cCenter, cDirection, cRadius);
+    if (metricsEnabled)
+    {
+        auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+        Logger::log(LoggerMode::DataLog) << "[PIPE_METRICS] fitCylinderMultipleSeeds doubleCheck result=" << (success ? "success" : "fail") << " elapsedMs=" << elapsedMs << Logger::endl;
+    }
+    return success;
 }
 
 /*bool TlScanOverseer::fitBigCylinder2(const glm::dvec3& seedPoint1, const glm::dvec3& seedPoint2, const double& radius, const double& threshold, double& cylinderRadius, glm::dvec3& cylinderDirection, glm::dvec3& cylinderCenter, const ClippingAssembly& clippingAssembly)


### PR DESCRIPTION
### Motivation

- Add lightweight, opt-in instrumentation to capture runtime metrics and outcomes for pipe/cylinder fitting to aid debugging and performance analysis.

### Description

- Introduce an environment-controlled switch `OPENSCANTOOLS_PIPE_METRICS` (checked by `isPipeMetricsEnabled`) and include it in relevant source files to enable/disable metrics logging at runtime.
- Emit structured `[PIPE_METRICS]` log lines from `TlScanOverseer::fitCylinder` and `TlScanOverseer::fitCylinderMultipleSeeds` reporting mode, thresholds, search radii, neighbor counts, elapsed milliseconds and success/failure and final radius when available, and add `countBucketPoints` helper to report neighbor totals.
- Emit corresponding `[PIPE_METRICS]` success/failure logs in `ContextFitCylinder` and `ContextPipeDetectionConnexion` with selected option flags and detected radius or failure reason.
- Add required headers (`<cstdlib>`, `<algorithm>`, `<string>`), small refactors for timing measurement and neighbor counting, and keep the instrumentation behind the environment switch so normal behavior is unchanged when disabled.

### Testing

- Built the project locally and verified the application starts with no changes when `OPENSCANTOOLS_PIPE_METRICS` is unset. 
- Exercised the cylinder fitting code paths and observed `[PIPE_METRICS]` logs when `OPENSCANTOOLS_PIPE_METRICS` is enabled, confirming logging triggers on both success and failure paths. 
- Ran the existing automated unit/test suite and continuous integration checks, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c62e965ac832f88fcc344c7e17eb5)