### PR TITLE
Wait for frame completion between HD tiles to limit Vulkan/VMA memory usage

### DIFF
--- a/src/pointCloudEngine/RenderingEngine.cpp
+++ b/src/pointCloudEngine/RenderingEngine.cpp
@@ -635,6 +635,12 @@ void RenderingEngine::updateHD()
                     imgWriter.writeTile(tileBuffer.data(), tileWidth, tileHeight, tileOffsetW, tileOffsetH);
                 }
 
+                // Keep HD tile generation memory-bounded: wait for the tile work to finish,
+                // then advance the frame so Vulkan/VMA deferred resources can be reclaimed
+                // before the next tile starts.
+                vkm.waitIdle();
+                vkm.startNextFrame();
+
                 // Copy du rendu dans l'image de destination
                 if (m_showProgressBar)
                     m_dataDispatcher.updateInformation(new GuiDataProcessingSplashScreenProgressBarUpdate(TEXT_SCREENSHOT_PROCESSING.arg(count).arg(tileCountX * tileCountY), count));


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth during HD tile generation by allowing Vulkan/VMA deferred resources to be reclaimed between tiles.

### Description
- Add `vkm.waitIdle()` and `vkm.startNextFrame()` in `RenderingEngine::updateHD()` (`src/pointCloudEngine/RenderingEngine.cpp`) to synchronize and advance frames before starting the next tile.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3145a07fe4832fa7470ce9f02e9d98)